### PR TITLE
test: make CPU suite independent of local CUDA state

### DIFF
--- a/.github/scripts/run_cpu_tests.sh
+++ b/.github/scripts/run_cpu_tests.sh
@@ -28,16 +28,21 @@
 # test is guarded by pytest.skip / importorskip / skipif(not cuda_ok).  Run
 # per-file on a machine with no GPU, no nvcc, no vLLM and no artifacts, each
 # file is all-pass-or-skip.  A marker layer on top would duplicate that logic
-# across the 16 test files (15 of which run here) for no added signal, so it
+# across the test modules for no added signal, so it
 # was not added -- see docs/RELEASING.md.
 set -uo pipefail
 
 TESTS="${1:?usage: run_cpu_tests.sh <tests-dir>}"
 
-# The only file that cannot run outside the private monorepo: it imports
-# `prismaquant.nvfp4_cb_formats` at module scope, which is a hard collection
-# ERROR (not a skip) anywhere `prismaquant` is not importable.
-EXCLUDE=("test_cb_kernels.py")
+# Every optional monorepo/GPU dependency is guarded with importorskip/skip, so
+# every test module can be collected in the released-package environment.
+EXCLUDE=()
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "python interpreter not found: $PYTHON_BIN" >&2
+  exit 2
+fi
 
 if [ ! -d "$TESTS" ]; then
   echo "no such tests dir: $TESTS" >&2
@@ -62,7 +67,7 @@ for f in "$TESTS"/test_*.py; do
     fi
   done
   echo "::group::$base"
-  python -m pytest "$f" -q --no-header -rs -p no:cacheprovider
+  "$PYTHON_BIN" -m pytest "$f" -q --no-header -rs -p no:cacheprovider
   rc=$?
   echo "::endgroup::"
   # 0 = passed (or everything skipped), 5 = no tests collected.

--- a/tests/test_cb_kernels.py
+++ b/tests/test_cb_kernels.py
@@ -43,6 +43,9 @@ codec = pytest.importorskip(
 kernels = pytest.importorskip("gridbook.kernels")
 cb_decode_linear = kernels.cb_decode_linear
 
+if not torch.cuda.is_available():
+    pytest.skip("CUDA device unavailable", allow_module_level=True)
+
 SERVE = Path("/home/rob/dq-runs/nvfp4-cb-phase0/serve")
 ARTIFACTS = ["fp8cb_k44", "nvfp4cb_k16"]
 # One single-role Linear per common role (single codebook -> row offset 0).

--- a/tests/test_cuda_gemv.py
+++ b/tests/test_cuda_gemv.py
@@ -28,6 +28,9 @@ codec = pytest.importorskip(
 kernels = pytest.importorskip("gridbook.kernels")
 from gridbook.cuda_ext import get_ext  # noqa: E402
 
+if not torch.cuda.is_available():
+    pytest.skip("CUDA device unavailable", allow_module_level=True)
+
 ext = get_ext()
 if ext is None:
     pytest.skip("CUDA extension unavailable (no nvcc?)",

--- a/tests/test_fused_prefill.py
+++ b/tests/test_fused_prefill.py
@@ -27,6 +27,9 @@ import torch
 codec = pytest.importorskip("gridbook.codec")
 from gridbook.cuda_ext import _find_cutlass_include, csrc_dir, get_ext  # noqa: E402
 
+if not torch.cuda.is_available():
+    pytest.skip("CUDA device unavailable", allow_module_level=True)
+
 gemv_ext = get_ext()
 if gemv_ext is None:
     pytest.skip("CUDA extension unavailable (no nvcc?)", allow_module_level=True)

--- a/tests/test_persistent_prefill.py
+++ b/tests/test_persistent_prefill.py
@@ -23,6 +23,9 @@ import torch
 codec = pytest.importorskip("gridbook.codec")
 from gridbook.cuda_ext import csrc_dir, get_ext  # noqa: E402
 
+if not torch.cuda.is_available():
+    pytest.skip("CUDA device unavailable", allow_module_level=True)
+
 gemv_ext = get_ext()
 if gemv_ext is None:
     pytest.skip("CUDA extension unavailable (no nvcc?)", allow_module_level=True)

--- a/tests/test_transient_fp8.py
+++ b/tests/test_transient_fp8.py
@@ -91,6 +91,8 @@ def _subtables(scheme, codebooks):
 def _prep(qname):
     """Load a single-role FP8_CB layer and derive every tensor the transient
     path consumes. Returns a dict."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device required for artifact-backed expansion")
     tensors, codebooks, q2s = _load()
     if qname not in q2s:
         pytest.skip(f"{qname} not a CB target in {ART}")


### PR DESCRIPTION
This review follow-up fixes baseline test-harness failures discovered while validating the supplied contributor bundles.

Changes:
- use python3 by default instead of assuming a python alias
- collect test_cb_kernels normally now that its private dependency is guarded
- skip CUDA-extension modules before JIT loading when no CUDA device is usable
- skip artifact-backed expansion cleanly on CPU-only Torch

Validation:
- true CPU Torch host: full isolated suite passes
- CUDA-built Torch with no GPU mounted: full isolated suite passes
- 20 test modules are now collected; optional CUDA, vLLM, PrismaQuant, and artifact checks report explicit skips

This PR contains no contributor-bundle code and is intended to land first so later PR checks distinguish real regressions from environment leakage.