### PR TITLE
config: align ignore matching with compressed-tensors

### DIFF
--- a/gridbook/config.py
+++ b/gridbook/config.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from typing import Any
 
 import torch
@@ -33,7 +32,6 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
 )
-
 try:
     from vllm.model_executor.layers.fused_moe import RoutedExperts
 except Exception:  # pragma: no cover - older vLLM
@@ -261,53 +259,25 @@ class PrismaQuantConfig(QuantizationConfig):
         return self._codebooks
 
     # -- per-prefix scheme resolution (handles vLLM fused qkv/gate_up) -------
-    @staticmethod
-    def _ignore_entry_matches(entry: str, name: str) -> bool:
-        """Does one ``ignore`` entry match module *name*, on SEGMENT boundaries?
-
-        Semantics are deliberately those of compressed-tensors' own matcher
-        (``vllm…quantization.compressed_tensors.utils._is_equal_or_regex_match``),
-        because ``_build_ct_config`` hands the very same ``ignore`` list to a
-        real ``CompressedTensorsConfig`` — two different readings of one list
-        in one process is how dispatch becomes incoherent.
-
-          * ``re:<pattern>``  ->  ``re.match(pattern, name)``  (as upstream:
-            ``re.match``, NOT ``fullmatch`` — upstream anchors at the start
-            only, and diverging here would re-open the same asymmetry)
-          * otherwise         ->  exact equality,
-
-        widened by exactly one case that CT does not have but the old substring
-        test did, and that artifacts may already depend on: an entry naming a
-        PARENT module (``…layers.0.mlp``) also ignores its children
-        (``…layers.0.mlp.down_proj``). Keeping it makes this change purely
-        subtractive; dropping it would *additionally* un-ignore every module
-        whose parent is listed, which is a far larger behaviour change than the
-        bug warrants. It is a dotted-SEGMENT prefix — never a raw character
-        prefix.
-
-        WHY THIS EXISTS.  The predicate used to be ``entry in name`` — an
-        unanchored substring — and it is why a HunYuan-V3-shaped artifact could
-        not serve at all. Exporters collapse ``.mlp.router.gate`` to
-        ``.mlp.gate`` (and ``_alias_collapsed_shared_prefixes`` above collapses
-        ``.mlp.shared_mlp.X`` to ``.mlp.X``), so the ignored BF16 router entry
-        ``model.layers.N.mlp.gate`` is a raw substring of the *quantized*
-        ``model.layers.N.mlp.gate_proj`` / ``…mlp.gate_up_proj``. The whole
-        shared-expert stack was therefore forced to ``UnquantizedLinearMethod``
-        and its NVFP4 tensors had nowhere to land (``KeyError:
-        'layers.1.mlp.shared_mlp.down_proj.input_global_scale'``).
-
-        Note for reviewers: for non-``re:`` entries this predicate is a strict
-        SUBSET of the old substring test, so it can only ever *un*-ignore a
-        module, never newly ignore one.
-        """
-        if entry.startswith("re:"):
-            return re.match(entry[3:], name) is not None
-        return name == entry or name.startswith(entry + ".")
-
     def _is_ignored(self, prefix: str) -> bool:
-        return any(self._ignore_entry_matches(ig, base)
-                   for base in _candidate_bases(prefix)
-                   for ig in self.ignore)
+        """Read ``ignore`` exactly as delegated compressed-tensors does.
+
+        In particular, fused modules are checked through their unfused shard
+        names and regexes use compressed-tensors' ``regex`` engine.  Keeping a
+        local near-copy caused the same list to mean different things on the CB
+        and stock sides of one mixed artifact.
+        """
+        # Lazy so codec/config tests that provide the repository's minimal
+        # vLLM stubs can still import this module without having to recreate
+        # compressed-tensors' entire package tree. Production always has the
+        # helper because compressed-tensors is a supported vLLM dependency.
+        from vllm.model_executor.layers.quantization.compressed_tensors.utils import (  # noqa: E501
+            should_ignore_layer,
+        )
+        fused = dict(_FUSED_FALLBACK)
+        fused.update(getattr(self, "packed_modules_mapping", {}) or {})
+        return any(should_ignore_layer(base, self.ignore, fused)
+                   for base in _candidate_bases(prefix))
 
     def shard_target_keys(self, prefix: str, *,
                           unfused_fallback: bool = False) -> list[str]:
@@ -464,7 +434,15 @@ class PrismaQuantConfig(QuantizationConfig):
         # so an un-remapped key silently falls through to unquantized and the
         # cb_qweight load then fails ("no parameter named …cb_qweight"). Mirror
         # exactly what the delegated stock-CT config does for its own targets.
-        self.ignore = hf_to_vllm_mapper.apply_list(self.ignore)
+        # vLLM's compressed-tensors mapper deliberately leaves regex entries
+        # untouched: a name mapper cannot safely rewrite regex syntax.  Mirror
+        # that rule before handing the same list to our own ignore check.
+        regex_ignores = [name for name in self.ignore
+                         if name.startswith("re:")]
+        literal_ignores = [name for name in self.ignore
+                           if not name.startswith("re:")]
+        self.ignore = (hf_to_vllm_mapper.apply_list(literal_ignores)
+                       + regex_ignores)
         self.target_scheme = hf_to_vllm_mapper.apply_dict(self.target_scheme)
         self._cb_targets = set(
             hf_to_vllm_mapper.apply_list(sorted(self._cb_targets)))

--- a/gridbook/config.py
+++ b/gridbook/config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from typing import Any
 
 import torch
@@ -260,8 +261,52 @@ class PrismaQuantConfig(QuantizationConfig):
         return self._codebooks
 
     # -- per-prefix scheme resolution (handles vLLM fused qkv/gate_up) -------
+    @staticmethod
+    def _ignore_entry_matches(entry: str, name: str) -> bool:
+        """Does one ``ignore`` entry match module *name*, on SEGMENT boundaries?
+
+        Semantics are deliberately those of compressed-tensors' own matcher
+        (``vllm…quantization.compressed_tensors.utils._is_equal_or_regex_match``),
+        because ``_build_ct_config`` hands the very same ``ignore`` list to a
+        real ``CompressedTensorsConfig`` — two different readings of one list
+        in one process is how dispatch becomes incoherent.
+
+          * ``re:<pattern>``  ->  ``re.match(pattern, name)``  (as upstream:
+            ``re.match``, NOT ``fullmatch`` — upstream anchors at the start
+            only, and diverging here would re-open the same asymmetry)
+          * otherwise         ->  exact equality,
+
+        widened by exactly one case that CT does not have but the old substring
+        test did, and that artifacts may already depend on: an entry naming a
+        PARENT module (``…layers.0.mlp``) also ignores its children
+        (``…layers.0.mlp.down_proj``). Keeping it makes this change purely
+        subtractive; dropping it would *additionally* un-ignore every module
+        whose parent is listed, which is a far larger behaviour change than the
+        bug warrants. It is a dotted-SEGMENT prefix — never a raw character
+        prefix.
+
+        WHY THIS EXISTS.  The predicate used to be ``entry in name`` — an
+        unanchored substring — and it is why a HunYuan-V3-shaped artifact could
+        not serve at all. Exporters collapse ``.mlp.router.gate`` to
+        ``.mlp.gate`` (and ``_alias_collapsed_shared_prefixes`` above collapses
+        ``.mlp.shared_mlp.X`` to ``.mlp.X``), so the ignored BF16 router entry
+        ``model.layers.N.mlp.gate`` is a raw substring of the *quantized*
+        ``model.layers.N.mlp.gate_proj`` / ``…mlp.gate_up_proj``. The whole
+        shared-expert stack was therefore forced to ``UnquantizedLinearMethod``
+        and its NVFP4 tensors had nowhere to land (``KeyError:
+        'layers.1.mlp.shared_mlp.down_proj.input_global_scale'``).
+
+        Note for reviewers: for non-``re:`` entries this predicate is a strict
+        SUBSET of the old substring test, so it can only ever *un*-ignore a
+        module, never newly ignore one.
+        """
+        if entry.startswith("re:"):
+            return re.match(entry[3:], name) is not None
+        return name == entry or name.startswith(entry + ".")
+
     def _is_ignored(self, prefix: str) -> bool:
-        return any(ig in base for base in _candidate_bases(prefix)
+        return any(self._ignore_entry_matches(ig, base)
+                   for base in _candidate_bases(prefix)
                    for ig in self.ignore)
 
     def shard_target_keys(self, prefix: str, *,
@@ -335,7 +380,7 @@ class PrismaQuantConfig(QuantizationConfig):
 
         if isinstance(layer, LinearBase):
             # 1) CB target (has a "scheme") — ours (precise, fused-aware; ahead
-            #    of the substring ignore test).
+            #    of the ignore test).
             scheme = self._scheme_for_prefix(prefix)
             if os.environ.get("PRISMAQUANT_DEBUG_PREFIXES") == "1":
                 import sys
@@ -413,7 +458,9 @@ class PrismaQuantConfig(QuantizationConfig):
         # applied. For hybrid/VLM checkpoints that means the module-nesting
         # prefix (e.g. Qwen3-VL: ``model.language_model.`` -> ``language_model.
         # model.``) must be applied to the CB target keys too: _scheme_for_prefix
-        # matches serve-time prefixes EXACTLY (unlike the substring ignore test),
+        # matches serve-time prefixes EXACTLY (the ignore test additionally
+        # accepts a parent-module entry and ``re:`` patterns — see
+        # ``_ignore_entry_matches`` — but neither path is a substring search),
         # so an un-remapped key silently falls through to unquantized and the
         # cb_qweight load then fails ("no parameter named …cb_qweight"). Mirror
         # exactly what the delegated stock-CT config does for its own targets.

--- a/tests/test_target_namespace_compat.py
+++ b/tests/test_target_namespace_compat.py
@@ -375,3 +375,116 @@ def test_mixed_fused_formats_still_raise():
     cfg.target_scheme["language_model." + _GDN_BASE + "in_proj_z"] = other
     with pytest.raises(ValueError, match="mixed CB decode"):
         cfg._scheme_for_prefix(_GDN_SERVE)
+
+
+# ---------------------------------------------------------------------------
+# ``ignore`` matches on dotted-SEGMENT boundaries, not raw substrings.
+#
+# ``_is_ignored`` used to be ``any(ig in base for base in
+# _candidate_bases(prefix) for ig in self.ignore)`` — an unanchored substring
+# test. Exporters collapse ``.mlp.router.gate`` to ``.mlp.gate``, so the ignored
+# BF16 router entry ``model.layers.N.mlp.gate`` was a raw substring of the
+# QUANTIZED ``…mlp.gate_proj`` / ``…mlp.gate_up_proj``: the shared-expert stack
+# was forced to ``UnquantizedLinearMethod``, its NVFP4 tensors had nowhere to
+# land, and the load died with ``KeyError:
+# 'layers.1.mlp.shared_mlp.down_proj.input_global_scale'``.
+#
+# The same list is handed to a real ``CompressedTensorsConfig`` by
+# ``_build_ct_config``, whose matcher is exact/``re:`` — so the readings must
+# agree. These tests pin both the fix and the safety property (for non-``re:``
+# entries the new predicate is a strict subset of the old one).
+# ---------------------------------------------------------------------------
+
+_ROUTER_NS = ["model.layers.1.",
+              "language_model.model.layers.1.",
+              "model.language_model.layers.1."]
+
+
+def _ignore_config(ignore):
+    """A resolved config whose only interesting content is *ignore*."""
+    cfg = PrismaQuantConfig.from_config({
+        "quant_method": "prismaquant", "format": "nvfp4_cb",
+        "codebook_file": "cb_codebooks.pqcb",
+        "config_groups": {"cb": {"format": "FP8_CB_K44",
+                                 "targets": ["model.layers.0.mlp.down_proj"],
+                                 "scheme": dict(_SCHEME)}},
+        "ignore": list(ignore),
+    })
+    cfg._ensure_resolved()
+    return cfg
+
+
+@pytest.mark.parametrize("pre", _ROUTER_NS)
+def test_collapsed_router_does_not_ignore_the_gate_projections(pre):
+    """The regression itself: an ignored ``…mlp.gate`` must not swallow
+    ``…mlp.gate_proj`` / ``…mlp.gate_up_proj`` in ANY namespace vintage."""
+    cfg = _ignore_config(["model.layers.1.mlp.gate"])
+    assert cfg._is_ignored(pre + "mlp.gate")            # the router: still BF16
+    assert not cfg._is_ignored(pre + "mlp.gate_proj")
+    assert not cfg._is_ignored(pre + "mlp.gate_up_proj")
+
+
+def test_parent_module_entry_ignores_its_children():
+    """A parent-module entry still covers the whole subtree. That is the one
+    widening over plain ``==`` — kept so the change stays purely subtractive —
+    and it is a dotted-SEGMENT prefix, not a character prefix."""
+    cfg = _ignore_config(["model.layers.0.mlp"])
+    assert cfg._is_ignored("model.layers.0.mlp")
+    assert cfg._is_ignored("model.layers.0.mlp.down_proj")
+    assert cfg._is_ignored("model.layers.0.mlp.shared_mlp.up_proj")
+    # ...and stops at the segment boundary: layer 0 does not cover layer 01.
+    assert not cfg._is_ignored("model.layers.01.mlp.down_proj")
+    assert not cfg._is_ignored("model.layers.0.mlp_extra.down_proj")
+
+
+def test_exact_entry_matches_only_itself():
+    cfg = _ignore_config(["lm_head"])
+    assert cfg._is_ignored("lm_head")
+    assert not cfg._is_ignored("lm_head_proj")
+    # An entry matches the module it names and that module's descendants — not
+    # a same-suffix module elsewhere in the tree. (``lm_head`` reaches
+    # ``_is_ignored`` only if the head is a LinearBase; the
+    # VocabParallelEmbedding arm of get_quant_method never consults it.)
+    assert not cfg._is_ignored("model.lm_head")
+
+
+def test_regex_entry_uses_re_match_like_compressed_tensors():
+    """``re:`` delegates to ``re.match`` — start-anchored, NOT ``fullmatch`` —
+    because the delegated ``CompressedTensorsConfig`` reads the identical list
+    with ``re.match``. A ``fullmatch`` here would make one list mean two
+    different things in one process."""
+    cfg = _ignore_config([r"re:model\.layers\.\d+\.mlp\.gate$"])
+    assert cfg._is_ignored("model.layers.7.mlp.gate")
+    assert not cfg._is_ignored("model.layers.7.mlp.gate_proj")
+    # start-anchored, so a mid-string match does not count...
+    assert not cfg._is_ignored("prefix.model.layers.7.mlp.gate")
+    # ...but an unanchored tail does (this is re.match, not fullmatch).
+    assert _ignore_config([r"re:model\.layers\.0"])._is_ignored(
+        "model.layers.0.mlp.down_proj")
+
+
+def test_regex_entry_survives_the_vllm_mapper():
+    """``apply_vllm_mapper`` rewrites ignore entries; a ``re:`` entry that the
+    mapper leaves alone must still be honoured against the mapped prefix."""
+    cfg = _mapped_config([_GDN_BASE + r for r in _GDN_ROLES],
+                         ignore=("re:.*\\.mlp\\.gate$",))
+    assert cfg._is_ignored("language_model.model.layers.9.mlp.gate")
+    assert not cfg._is_ignored("language_model.model.layers.9.mlp.gate_proj")
+
+
+_SUBSET_ENTRIES = ["model.layers.1.mlp.gate", "model.layers.1.mlp", "lm_head",
+                   "mlp.down_proj", "model.layers.1"]
+_SUBSET_NAMES = ["model.layers.1.mlp.gate", "model.layers.1.mlp.gate_proj",
+                 "model.layers.1.mlp.gate_up_proj", "model.layers.1.mlp",
+                 "model.layers.1.mlp.shared_mlp.down_proj", "lm_head",
+                 "model.layers.11.mlp.gate", "language_model.model.layers.1"]
+
+
+@pytest.mark.parametrize("entry", _SUBSET_ENTRIES)
+@pytest.mark.parametrize("name", _SUBSET_NAMES)
+def test_non_regex_match_is_a_subset_of_the_old_substring_test(entry, name):
+    """Safety property: the new predicate can only ever *un*-ignore a module,
+    never newly ignore one. (Asserted, not argued.)"""
+    new = PrismaQuantConfig._ignore_entry_matches(entry, name)
+    old = entry in name
+    assert not (new and not old), (entry, name)

--- a/tests/test_target_namespace_compat.py
+++ b/tests/test_target_namespace_compat.py
@@ -64,6 +64,36 @@ if "vllm" not in sys.modules:
 
         bc.QuantizationConfig = QuantizationConfig
         bc.QuantizeMethodBase = object
+        ctu = _mod(
+            "vllm.model_executor.layers.quantization.compressed_tensors.utils")
+
+        def _stub_should_ignore(layer_name, ignore=(), fused_mapping=None):
+            try:
+                import regex as regex_engine
+            except ImportError:
+                # ``regex`` arrives with a real vLLM installation, but it is
+                # intentionally not a Gridbook dependency.  Keep the CPU-only
+                # test shim usable in the wheel's minimal dependency set.
+                import re as regex_engine
+
+            def _matches(name):
+                return any(
+                    regex_engine.match(entry[3:], name) is not None
+                    if entry.startswith("re:") else entry == name
+                    for entry in ignore)
+
+            fused_mapping = fused_mapping or {}
+            leaf = layer_name.rsplit(".", 1)[-1]
+            if leaf in fused_mapping and layer_name not in ignore:
+                stem = layer_name[:-len(leaf)]
+                verdicts = [_matches(stem + shard)
+                            for shard in fused_mapping[leaf]]
+                if len(set(verdicts)) != 1:
+                    raise ValueError("Found a different quantization schemes")
+                return verdicts[0]
+            return _matches(layer_name)
+
+        ctu.should_ignore_layer = _stub_should_ignore
         vpe = _mod("vllm.model_executor.layers.vocab_parallel_embedding")
         vpe.UnquantizedEmbeddingMethod = type("UEM", (), {})
         vpe.VocabParallelEmbedding = type("VPE", (), {})
@@ -378,7 +408,7 @@ def test_mixed_fused_formats_still_raise():
 
 
 # ---------------------------------------------------------------------------
-# ``ignore`` matches on dotted-SEGMENT boundaries, not raw substrings.
+# ``ignore`` follows compressed-tensors exact/regex semantics, not substrings.
 #
 # ``_is_ignored`` used to be ``any(ig in base for base in
 # _candidate_bases(prefix) for ig in self.ignore)`` — an unanchored substring
@@ -424,15 +454,12 @@ def test_collapsed_router_does_not_ignore_the_gate_projections(pre):
     assert not cfg._is_ignored(pre + "mlp.gate_up_proj")
 
 
-def test_parent_module_entry_ignores_its_children():
-    """A parent-module entry still covers the whole subtree. That is the one
-    widening over plain ``==`` — kept so the change stays purely subtractive —
-    and it is a dotted-SEGMENT prefix, not a character prefix."""
+def test_literal_entry_is_exact_like_compressed_tensors():
+    """A literal entry names one module; parents are not implicit globs."""
     cfg = _ignore_config(["model.layers.0.mlp"])
     assert cfg._is_ignored("model.layers.0.mlp")
-    assert cfg._is_ignored("model.layers.0.mlp.down_proj")
-    assert cfg._is_ignored("model.layers.0.mlp.shared_mlp.up_proj")
-    # ...and stops at the segment boundary: layer 0 does not cover layer 01.
+    assert not cfg._is_ignored("model.layers.0.mlp.down_proj")
+    assert not cfg._is_ignored("model.layers.0.mlp.shared_mlp.up_proj")
     assert not cfg._is_ignored("model.layers.01.mlp.down_proj")
     assert not cfg._is_ignored("model.layers.0.mlp_extra.down_proj")
 
@@ -463,6 +490,29 @@ def test_regex_entry_uses_re_match_like_compressed_tensors():
         "model.layers.0.mlp.down_proj")
 
 
+def test_regex_entry_uses_compressed_tensors_regex_engine():
+    """``regex`` supports Unicode properties that stdlib ``re`` rejects."""
+    pytest.importorskip("regex", reason="installed with the real vLLM stack")
+    cfg = _ignore_config([r"re:model\.\p{L}+$"])
+    assert cfg._is_ignored("model.layers")
+
+
+def test_fused_regex_is_evaluated_on_unfused_shards():
+    # A regex naming only the fused spelling does not ignore its checkpoint
+    # shards.  This is compressed-tensors' fused contract.
+    cfg = _ignore_config([r"re:.*gate_up_proj$"])
+    assert not cfg._is_ignored("model.layers.0.mlp.gate_up_proj")
+
+    both = _ignore_config([
+        r"re:.*gate_proj$", r"re:.*up_proj$",
+    ])
+    assert both._is_ignored("model.layers.0.mlp.gate_up_proj")
+
+    mixed = _ignore_config([r"re:.*gate_proj$"])
+    with pytest.raises(ValueError, match="different quantization schemes"):
+        mixed._is_ignored("model.layers.0.mlp.gate_up_proj")
+
+
 def test_regex_entry_survives_the_vllm_mapper():
     """``apply_vllm_mapper`` rewrites ignore entries; a ``re:`` entry that the
     mapper leaves alone must still be honoured against the mapped prefix."""
@@ -470,6 +520,52 @@ def test_regex_entry_survives_the_vllm_mapper():
                          ignore=("re:.*\\.mlp\\.gate$",))
     assert cfg._is_ignored("language_model.model.layers.9.mlp.gate")
     assert not cfg._is_ignored("language_model.model.layers.9.mlp.gate_proj")
+
+
+def test_mapper_is_never_asked_to_rewrite_regex_syntax():
+    cfg = _ignore_config([r"re:.*\.mlp\.gate$", "model.layers.0.mlp.foo"])
+
+    class _LiteralOnlyMapper:
+        def apply_list(self, names):
+            assert all(not name.startswith("re:") for name in names)
+            return ["mapped." + name for name in names]
+
+        def apply_dict(self, values):
+            return values
+
+    cfg.apply_vllm_mapper(_LiteralOnlyMapper())
+    assert r"re:.*\.mlp\.gate$" in cfg.ignore
+    assert "mapped.model.layers.0.mlp.foo" in cfg.ignore
+
+
+def test_get_quant_method_delegates_gate_projection_not_router(monkeypatch):
+    """Exercise the public dispatch order, not only the private predicate."""
+    import gridbook.config as config_mod
+
+    class _Linear:
+        pass
+
+    class _CBMethod:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_linear_module = types.ModuleType("gridbook.linear")
+    fake_linear_module.PrismaQuantCBLinearMethod = _CBMethod
+    monkeypatch.setitem(sys.modules, "gridbook.linear", fake_linear_module)
+    monkeypatch.setattr(config_mod, "LinearBase", _Linear)
+
+    delegated = object()
+    ct = types.SimpleNamespace(
+        packed_modules_mapping=None,
+        get_quant_method=lambda layer, prefix: delegated,
+    )
+    cfg = _ignore_config(["model.layers.1.mlp.gate"])
+    cfg.ct_config = ct
+
+    router = cfg.get_quant_method(_Linear(), "model.layers.1.mlp.gate")
+    assert isinstance(router, config_mod.UnquantizedLinearMethod)
+    assert cfg.get_quant_method(
+        _Linear(), "model.layers.1.mlp.gate_proj") is delegated
 
 
 _SUBSET_ENTRIES = ["model.layers.1.mlp.gate", "model.layers.1.mlp", "lm_head",
@@ -485,6 +581,7 @@ _SUBSET_NAMES = ["model.layers.1.mlp.gate", "model.layers.1.mlp.gate_proj",
 def test_non_regex_match_is_a_subset_of_the_old_substring_test(entry, name):
     """Safety property: the new predicate can only ever *un*-ignore a module,
     never newly ignore one. (Asserted, not argued.)"""
-    new = PrismaQuantConfig._ignore_entry_matches(entry, name)
+    cfg = _ignore_config([entry])
+    new = cfg._is_ignored(name)
     old = entry in name
     assert not (new and not old), (entry, name)


### PR DESCRIPTION
Bundle 01 from the supplied Gridbook PR archive, reviewed and corrected against current master and vLLM 0.24.

Outcome:
- fixes the router gate versus gate_proj substring collision
- delegates literal and regex matching to the official compressed-tensors helper
- handles fused modules through their unfused shard names
- preserves regex entries when applying the vLLM name mapper
- adds public dispatch, fused-regex, Unicode-regex, mapper, and failure-mode coverage

Review correction:
The submitted implementation used a different regex engine, widened parent matches, and could disagree with compressed-tensors on fused modules. The follow-up commit removes those semantic differences.

Validation:
- 81 focused resolver tests pass on the CPU host
- 81 focused tests pass with real vLLM 0.24 in the serving container
- 30 weight-residency tests pass after making the compressed-tensors helper import lazy
- full host suite is green apart from the separately tracked baseline harness failures fixed by PR #2

Attribution:
Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.