### PR TITLE
loader: support legacy fused native-NVFP4 expert stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,13 @@ separate research pipeline that *produces* gridbook artifacts —
 - The plugin **does not patch vLLM core**. It does install a thin `load_weights`
   wrapper on specific *model classes* (HunYuan-V3, Laguna, Qwen3.5-MoE and their
   MTP drafters) whose loaders map MoE experts at the top level and would
-  otherwise not recognise stacked codebook expert tensors. That wrap is inert for
-  non-CB checkpoints. Nothing in `vllm/` is modified.
+  otherwise not recognise stacked codebook expert tensors. It also has a
+  compatibility-only path for externally authored fused native-NVFP4 expert
+  stacks, restricted to vLLM's compressed-tensors method with `TP=EP=1`, no
+  padding, exact dtypes/shapes, and a complete eight-tensor stack. PrismaQuant's
+  current native exporter uses per-expert tensors and its mixed streaming
+  exporter rejects stock expert stacks, so this is not a producer capability.
+  Nothing in `vllm/` is modified.
 - This repository **serves** the format; it does not yet **produce** artifacts.
   A reference encoder is a roadmap item — until then, artifacts come from the
   authors' pipeline, and the [spec](docs/SPEC.md) is published so an encoder can

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -70,8 +70,12 @@ but several times slower and not a serving target.
 - **No vLLM-core files are patched.** The plugin does wrap `load_weights` on
   specific *model classes* (HunYuan-V3 + its MTP drafter, Laguna, Qwen3.5-MoE +
   its MTP) whose loaders map MoE experts at the top level and would otherwise not
-  recognise stacked codebook expert tensors. The wrap is inert for non-CB
-  checkpoints.
+  recognise stacked codebook expert tensors. A compatibility-only interception
+  also recognises externally authored fused native-NVFP4 expert stacks, but only
+  for `CompressedTensorsW4A4Nvfp4MoEMethod` at `TP=EP=1`, without padding, with
+  exact dtypes/shapes and all eight stack tensors. Current PrismaQuant native
+  exports are per-expert, and its mixed streaming exporter rejects stock expert
+  stacks; the interception does not add that producer capability.
 
 ## CUDA kernel set (decode-GEMV + prefill)
 

--- a/gridbook/moe_toplevel_loader.py
+++ b/gridbook/moe_toplevel_loader.py
@@ -36,14 +36,19 @@ the original loader. One line per arch registers it
 (``install_toplevel_cb_expert_loader(SomeForCausalLM)``); DSv4 and any other
 top-level-expert-mapping MoE arch reuse it as-is.
 
-The same KeyError hits FUSED **native-NVFP4** expert stacks
-(``…experts.gate_up_proj.weight_packed`` and friends), which a heterogeneous
-artifact carries for the layers left on stock compressed-tensors instead of CB:
-they too are one 3D tensor per role, and vLLM's ``expert_params_mapping`` too
-matches only per-expert names. Those land on the params that
-``CompressedTensorsW4A4Nvfp4MoEMethod.create_weights`` registers
-(``w13_weight_packed``/``w2_weight_packed`` + the global-scale stacks) — see
-``_CB_EXPERT_SUFFIX_TO_LEAF`` below for the shape/order proof.
+The same KeyError can hit a legacy or externally-authored FUSED
+**native-NVFP4** expert stack (``…experts.gate_up_proj.weight_packed`` and
+friends): vLLM's top-level ``expert_params_mapping`` matches per-expert names,
+not one tensor holding every expert. The compatibility path below accepts that
+layout only when it can prove that the target was registered by
+``CompressedTensorsW4A4Nvfp4MoEMethod``, TP=EP=1, no dimension was padded, all
+eight tensors are present, and every shape and dtype is exact.
+
+This is deliberately not advertised as a PrismaQuant producer path. The
+current native compressed-tensors exporter splits non-BF16 packed experts into
+per-expert tensors, while the mixed streaming CB exporter rejects stock expert
+stacks. The interception exists for compatible external/legacy artifacts; it
+does not make a currently unsupported producer layout supported by itself.
 
 **Shared-expert (``shared_mlp``) CB tensors — the second interception.** HunYuan
 V3 passes ``shared_experts=self.shared_mlp`` into ``FusedMoE``; the shared MLP is
@@ -121,15 +126,10 @@ def installed_module_paths() -> set[str]:
 # names (e.g. ``…mlp.shared_mlp.gate_proj.cb_qweight``,
 # ``…layers.0.mlp.down_proj.cb_qweight``), which must go to the ORIGINAL loader.
 #
-# NATIVE-NVFP4 FUSED STACKS (the ``weight_packed`` block below).
-# A heterogeneous artifact leaves some layers on stock compressed-tensors NVFP4
-# rather than CB. Those layers are written in the SAME fused 3D stacked layout
-# as our CB experts, and vLLM's ``CompressedTensorsW4A4Nvfp4MoEMethod.
-# create_weights`` registers params that match them EXACTLY (vLLM
-# ``model_executor/layers/quantization/compressed_tensors/
-# compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py``:82/95/109/125/
-# 136/145/156/165). Shapes below are that method's own, for E experts, hidden
-# ``H``, per-partition intermediate ``I``, group size ``g``:
+# NATIVE-NVFP4 FUSED STACKS (compatibility-only).
+# vLLM's ``CompressedTensorsW4A4Nvfp4MoEMethod.create_weights`` registers the
+# following whole-stack params for E experts, hidden H, intermediate I and
+# group size g:
 #
 #   checkpoint suffix                          shape          dtype   -> param
 #   .experts.gate_up_proj.weight_packed        (E, 2I, H//2)  u8       w13_weight_packed
@@ -141,45 +141,163 @@ def installed_module_paths() -> set[str]:
 #   .experts.gate_up_proj.input_global_scale   (E, 2)         f32      w13_input_global_scale
 #   .experts.down_proj.input_global_scale      (E,)           f32      w2_input_global_scale
 #
-# Row/shard ORDER is gate-first, and that is what stock vLLM expects, so a
-# whole-stack ``copy_`` reproduces byte-for-byte what the per-expert
-# weight_loader would have built — no de-fusing and no re-fusing. Read out of
-# vLLM ``model_executor/layers/fused_moe/routed_experts.py``: ``_load_w13``
-# (:436) narrows ``w1``/gate_proj to rows ``[0:I]`` and ``w3``/up_proj to
-# ``[I:2I]``, and ``_load_per_tensor_weight_scale`` (:278) uses
-# ``idx = 0 if shard_id == "w1" else 1`` — i.e. ``[:, 0] = gate, [:, 1] = up``
-# for the two ``(E, 2)`` global-scale stacks.
+# The external layout must be gate-first: rows [0:I] and scale column 0 are
+# gate/w1, rows [I:2I] and column 1 are up/w3. This is the convention vLLM's
+# per-expert ``RoutedExperts.weight_loader`` builds. We intentionally do not
+# call that loader here: its public inputs are one expert + one shard, while
+# this checkpoint tensor is already fused. Decomposing and feeding it back
+# through that API would duplicate vLLM's TP/EP/padding policy in this shim.
+# Exact raw copy is the smaller contract, so it is allowed only after the
+# metadata checks in ``_validate_native_nvfp4_target`` prove TP=EP=1 and no
+# padding. A shape match alone is not evidence of gate/up order.
 #
-# Why these need an entry at all: ``FusedMoE.make_expert_params_mapping``
-# (routed_experts.py:906) emits weight names of the form
-# ``experts.{expert_id}.{proj}.`` only, so a FUSED stack matches nothing there
-# and falls through to the arch loader's final ``params_dict[name]`` ->
-# ``KeyError``. ``resolve_cb_expert_param`` below is purely table-driven, so
-# extending this table IS the whole fix, and it is generic: any fused
-# native-NVFP4 MoE export benefits; nothing here is arch-specific.
-#
-# The ``weight_scale`` pair is shared by both lanes: CB fp8 rungs and native
-# NVFP4 both land on ``w13_weight_scale`` / ``w2_weight_scale``, and the
-# resolver keys on the param that actually exists, so one entry serves both.
-_CB_EXPERT_SUFFIX_TO_LEAF: dict[str, str] = {
-    ".experts.gate_up_proj.cb_qweight": "w13_cb_qweight",
-    ".experts.down_proj.cb_qweight": "w2_cb_qweight",
-    ".experts.gate_up_proj.weight_scale": "w13_weight_scale",
-    ".experts.down_proj.weight_scale": "w2_weight_scale",
-    # -- native NVFP4 fused stacks (stock compressed-tensors MoE method) --
+# The current PrismaQuant native exporter writes per-expert tensors and the
+# mixed streaming exporter rejects stock expert stacks. These suffixes are for
+# compatible legacy/external artifacts, not a promise that PrismaQuant emits
+# this layout today.
+_NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF: dict[str, str] = {
     ".experts.gate_up_proj.weight_packed": "w13_weight_packed",
     ".experts.down_proj.weight_packed": "w2_weight_packed",
+    ".experts.gate_up_proj.weight_scale": "w13_weight_scale",
+    ".experts.down_proj.weight_scale": "w2_weight_scale",
     ".experts.gate_up_proj.weight_global_scale": "w13_weight_global_scale",
     ".experts.down_proj.weight_global_scale": "w2_weight_global_scale",
     ".experts.gate_up_proj.input_global_scale": "w13_input_global_scale",
     ".experts.down_proj.input_global_scale": "w2_input_global_scale",
 }
 
+_CB_EXPERT_SUFFIX_TO_LEAF: dict[str, str] = {
+    ".experts.gate_up_proj.cb_qweight": "w13_cb_qweight",
+    ".experts.down_proj.cb_qweight": "w2_cb_qweight",
+    ".experts.gate_up_proj.weight_scale": "w13_weight_scale",
+    ".experts.down_proj.weight_scale": "w2_weight_scale",
+    **_NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF,
+}
+
+_NATIVE_NVFP4_METHOD = "CompressedTensorsW4A4Nvfp4MoEMethod"
+
+
+def _native_nvfp4_suffix(name: str, param) -> str | None:
+    """The native fused suffix represented by *(name, param)*, if any.
+
+    ``weight_scale`` is shared with FP8-CB stacks. Native NVFP4 scales are 3-D
+    ``(E, out, groups)`` while FP8-CB scales are 2-D ``(E, out)``, so the
+    registered target disambiguates that pair without importing vLLM.
+    """
+    for suffix in _NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF:
+        if not name.endswith(suffix):
+            continue
+        if suffix.endswith(".weight_scale") and param.ndim != 3:
+            return None
+        return suffix
+    return None
+
+
+def _native_nvfp4_owner(param):
+    """Owner of vLLM's bound per-expert ``weight_loader``, or ``None``."""
+    loader = getattr(param, "weight_loader", None)
+    return getattr(loader, "__self__", None)
+
+
+def _validate_native_nvfp4_target(name: str, mapped: str, param, weight) -> None:
+    """Fail closed unless raw whole-stack copy is provably safe.
+
+    The registered ``weight_loader`` is deliberately not invoked. It accepts a
+    per-expert, per-shard input and applies rank slicing/padding; the incoming
+    tensor is already a fused whole stack. Direct copy avoids reimplementing
+    that policy, but only for the one-rank, unpadded, exact-layout case.
+    """
+    if tuple(param.shape) != tuple(weight.shape):
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}' -> '{mapped}': "
+            f"checkpoint shape {tuple(weight.shape)} != param shape "
+            f"{tuple(param.shape)}; whole-stack loading requires an exact "
+            "unsharded, unpadded shape")
+    if param.dtype != weight.dtype:
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}' -> '{mapped}': "
+            f"checkpoint dtype {weight.dtype} != param dtype {param.dtype}; "
+            "packed/scaling tensors are never cast implicitly")
+    if not weight.is_contiguous():
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': checkpoint "
+            "tensor is non-contiguous; the whole-stack byte-layout contract "
+            "requires contiguous tensors")
+
+    owner = _native_nvfp4_owner(param)
+    moe_config = getattr(owner, "moe_config", None)
+    parallel = getattr(moe_config, "moe_parallel_config", None)
+    quant_method = getattr(owner, "quant_method", None)
+    if owner is None or moe_config is None or parallel is None or \
+            quant_method is None:
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': target "
+            "parameter has no inspectable vLLM MoE weight-loader metadata; "
+            "refusing an unverified raw whole-stack copy")
+    method_name = quant_method.__class__.__name__
+    if method_name != _NATIVE_NVFP4_METHOD:
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': target method "
+            f"is {method_name}, expected {_NATIVE_NVFP4_METHOD}")
+
+    tp_size = getattr(parallel, "tp_size", None)
+    ep_size = getattr(parallel, "ep_size", None)
+    if tp_size != 1 or ep_size != 1 or bool(getattr(parallel, "use_ep", False)):
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': whole-stack "
+            f"compatibility loading supports TP=EP=1 only (got TP={tp_size}, "
+            f"EP={ep_size}, use_ep={getattr(parallel, 'use_ep', None)})")
+    if bool(getattr(parallel, "enable_eplb", False)):
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': EPLB may "
+            "remap/redundantly materialize experts and is unsupported by raw "
+            "whole-stack copy")
+
+    hidden = getattr(owner, "hidden_size", getattr(moe_config, "hidden_dim", None))
+    hidden_unpadded = getattr(moe_config, "hidden_dim_unpadded", None)
+    inter = getattr(owner, "intermediate_size_per_partition", getattr(
+        moe_config, "intermediate_size_per_partition", None))
+    inter_unpadded = getattr(
+        moe_config, "intermediate_size_per_partition_unpadded", None)
+    if None in (hidden, hidden_unpadded, inter, inter_unpadded):
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': vLLM did not "
+            "expose padded/unpadded dimensions; refusing raw whole-stack copy")
+    if int(hidden) != int(hidden_unpadded) or int(inter) != int(inter_unpadded):
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': padded MoE "
+            "dimensions are unsupported (hidden "
+            f"{hidden_unpadded}->{hidden}, intermediate "
+            f"{inter_unpadded}->{inter})")
+
+    counts = (
+        getattr(moe_config, "num_experts", None),
+        getattr(moe_config, "num_local_experts", None),
+        getattr(moe_config, "num_logical_experts", None),
+    )
+    if any(v is None for v in counts) or len({int(v) for v in counts}) != 1 or \
+            int(param.shape[0]) != int(counts[0]):
+        raise ValueError(
+            f"prismaquant fused native-NVFP4 expert '{name}': global/local/"
+            "logical/parameter expert counts must be identical, got "
+            f"config={counts}, param={param.shape[0]}")
+
+
+def _validate_complete_native_nvfp4_stacks(
+        seen: dict[str, set[str]]) -> None:
+    expected = set(_NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF)
+    for prefix, suffixes in seen.items():
+        missing = sorted(expected - suffixes)
+        if missing:
+            raise ValueError(
+                f"prismaquant fused native-NVFP4 expert stack '{prefix}' is "
+                f"incomplete; missing checkpoint tensor suffixes {missing}")
+
 
 def resolve_cb_expert_param(name: str,
                             param_names) -> str | None:
-    """Resolve a stacked-CB expert checkpoint tensor name to the registered
-    FusedMoE param name, by matching against the model's ACTUAL parameter names.
+    """Resolve a stacked CB/compatible-native checkpoint tensor name to its
+    registered FusedMoE param, using the model's ACTUAL parameter names.
 
     The checkpoint writes ``…mlp.experts.<proj>.cb_qweight`` (flat), but vLLM
     may nest the routed FusedMoE one level deeper — HunYuan V3's SharedFusedMoE
@@ -206,7 +324,7 @@ def resolve_cb_expert_param(name: str,
             return matches[0]
         if len(matches) > 1:
             raise ValueError(
-                f"prismaquant CB expert '{name}': ambiguous target params "
+                f"prismaquant fused expert '{name}': ambiguous target params "
                 f"{matches} — layer structure differs from the "
                 "one-FusedMoE-per-layer assumption")
         return None                                        # missing on rank
@@ -604,6 +722,7 @@ def install_toplevel_cb_expert_loader(model_cls: type) -> None:
         rename = _compose_renames(_hf_mapper_rename(self),
                                   _spec_layer_rename(self))
         loaded: set[str] = set()
+        native_nvfp4_seen: dict[str, set[str]] = {}
         # Shared-expert CB tensors (…shared_mlp.*.cb_qweight / .weight_scale):
         # vLLM built bf16 Linears for these (no cb_qweight param). Buffer them
         # (~0.58 GB total — held owned CPU tensors; safetensors yields copies),
@@ -628,18 +747,29 @@ def install_toplevel_cb_expert_loader(model_cls: type) -> None:
                 mapped = resolve_cb_expert_param(res_name, param_names)
                 if mapped is not None:
                     param = params_dict[mapped]
-                    if tuple(param.shape) != tuple(w.shape):
+                    native_suffix = _native_nvfp4_suffix(res_name, param)
+                    if native_suffix is not None:
+                        _validate_native_nvfp4_target(
+                            name, mapped, param, w)
+                        native_prefix = (
+                            res_name[:-len(native_suffix)] + ".experts")
+                        suffixes = native_nvfp4_seen.setdefault(
+                            native_prefix, set())
+                        if native_suffix in suffixes:
+                            raise ValueError(
+                                f"prismaquant fused native-NVFP4 expert stack "
+                                f"'{native_prefix}' contains duplicate tensor "
+                                f"suffix {native_suffix}")
+                        suffixes.add(native_suffix)
+                    elif tuple(param.shape) != tuple(w.shape):
                         raise ValueError(
-                            f"prismaquant fused expert '{name}' -> "
+                            f"prismaquant CB expert '{name}' -> "
                             f"'{mapped}': checkpoint shape {tuple(w.shape)} "
-                            f"!= param shape {tuple(param.shape)} — fused "
-                            "whole-stack contract violated. This is the "
-                            "INTENDED failure when the param is TP/EP-sharded "
-                            "(the param holds this rank's slice, so a "
-                            "whole-stack copy_ would silently place the wrong "
-                            "rows), or when gate/up are ordered differently "
-                            "from vLLM's gate-first w13 convention.")
-                    param.data.copy_(w.to(param.dtype))
+                            f"!= param shape {tuple(param.shape)} — stacked "
+                            "expert contract violated (the target may be "
+                            "sharded or padded)")
+                    param.data.copy_(w if native_suffix is not None
+                                     else w.to(param.dtype))
                     # fill path 2 of 2 (top-level): stamp the sentinel that
                     # process_weights_after_loading checks (cb_fill_guard).
                     mark_filled(param)
@@ -664,6 +794,7 @@ def install_toplevel_cb_expert_loader(model_cls: type) -> None:
         # return None (HYV3MTP's drafter loader) — tolerate both; our own
         # `loaded` set still reports the tensors WE placed.
         ret = orig_load_weights(self, _passthrough())
+        _validate_complete_native_nvfp4_stacks(native_nvfp4_seen)
         if ret:
             loaded |= set(ret)
         if shared_cb_buf:

--- a/gridbook/moe_toplevel_loader.py
+++ b/gridbook/moe_toplevel_loader.py
@@ -36,6 +36,15 @@ the original loader. One line per arch registers it
 (``install_toplevel_cb_expert_loader(SomeForCausalLM)``); DSv4 and any other
 top-level-expert-mapping MoE arch reuse it as-is.
 
+The same KeyError hits FUSED **native-NVFP4** expert stacks
+(``…experts.gate_up_proj.weight_packed`` and friends), which a heterogeneous
+artifact carries for the layers left on stock compressed-tensors instead of CB:
+they too are one 3D tensor per role, and vLLM's ``expert_params_mapping`` too
+matches only per-expert names. Those land on the params that
+``CompressedTensorsW4A4Nvfp4MoEMethod.create_weights`` registers
+(``w13_weight_packed``/``w2_weight_packed`` + the global-scale stacks) — see
+``_CB_EXPERT_SUFFIX_TO_LEAF`` below for the shape/order proof.
+
 **Shared-expert (``shared_mlp``) CB tensors — the second interception.** HunYuan
 V3 passes ``shared_experts=self.shared_mlp`` into ``FusedMoE``; the shared MLP is
 an ordinary ``HYV3FeedForward`` (fused ``gate_up_proj`` + ``down_proj`` Linears).
@@ -111,11 +120,59 @@ def installed_module_paths() -> set[str]:
 # and dense MLP projections that share the ``gate_up_proj`` / ``down_proj`` leaf
 # names (e.g. ``…mlp.shared_mlp.gate_proj.cb_qweight``,
 # ``…layers.0.mlp.down_proj.cb_qweight``), which must go to the ORIGINAL loader.
+#
+# NATIVE-NVFP4 FUSED STACKS (the ``weight_packed`` block below).
+# A heterogeneous artifact leaves some layers on stock compressed-tensors NVFP4
+# rather than CB. Those layers are written in the SAME fused 3D stacked layout
+# as our CB experts, and vLLM's ``CompressedTensorsW4A4Nvfp4MoEMethod.
+# create_weights`` registers params that match them EXACTLY (vLLM
+# ``model_executor/layers/quantization/compressed_tensors/
+# compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py``:82/95/109/125/
+# 136/145/156/165). Shapes below are that method's own, for E experts, hidden
+# ``H``, per-partition intermediate ``I``, group size ``g``:
+#
+#   checkpoint suffix                          shape          dtype   -> param
+#   .experts.gate_up_proj.weight_packed        (E, 2I, H//2)  u8       w13_weight_packed
+#   .experts.down_proj.weight_packed           (E, H,  I//2)  u8       w2_weight_packed
+#   .experts.gate_up_proj.weight_scale         (E, 2I, H//g)  f8e4m3   w13_weight_scale
+#   .experts.down_proj.weight_scale            (E, H,  I//g)  f8e4m3   w2_weight_scale
+#   .experts.gate_up_proj.weight_global_scale  (E, 2)         f32      w13_weight_global_scale
+#   .experts.down_proj.weight_global_scale     (E,)           f32      w2_weight_global_scale
+#   .experts.gate_up_proj.input_global_scale   (E, 2)         f32      w13_input_global_scale
+#   .experts.down_proj.input_global_scale      (E,)           f32      w2_input_global_scale
+#
+# Row/shard ORDER is gate-first, and that is what stock vLLM expects, so a
+# whole-stack ``copy_`` reproduces byte-for-byte what the per-expert
+# weight_loader would have built — no de-fusing and no re-fusing. Read out of
+# vLLM ``model_executor/layers/fused_moe/routed_experts.py``: ``_load_w13``
+# (:436) narrows ``w1``/gate_proj to rows ``[0:I]`` and ``w3``/up_proj to
+# ``[I:2I]``, and ``_load_per_tensor_weight_scale`` (:278) uses
+# ``idx = 0 if shard_id == "w1" else 1`` — i.e. ``[:, 0] = gate, [:, 1] = up``
+# for the two ``(E, 2)`` global-scale stacks.
+#
+# Why these need an entry at all: ``FusedMoE.make_expert_params_mapping``
+# (routed_experts.py:906) emits weight names of the form
+# ``experts.{expert_id}.{proj}.`` only, so a FUSED stack matches nothing there
+# and falls through to the arch loader's final ``params_dict[name]`` ->
+# ``KeyError``. ``resolve_cb_expert_param`` below is purely table-driven, so
+# extending this table IS the whole fix, and it is generic: any fused
+# native-NVFP4 MoE export benefits; nothing here is arch-specific.
+#
+# The ``weight_scale`` pair is shared by both lanes: CB fp8 rungs and native
+# NVFP4 both land on ``w13_weight_scale`` / ``w2_weight_scale``, and the
+# resolver keys on the param that actually exists, so one entry serves both.
 _CB_EXPERT_SUFFIX_TO_LEAF: dict[str, str] = {
     ".experts.gate_up_proj.cb_qweight": "w13_cb_qweight",
     ".experts.down_proj.cb_qweight": "w2_cb_qweight",
     ".experts.gate_up_proj.weight_scale": "w13_weight_scale",
     ".experts.down_proj.weight_scale": "w2_weight_scale",
+    # -- native NVFP4 fused stacks (stock compressed-tensors MoE method) --
+    ".experts.gate_up_proj.weight_packed": "w13_weight_packed",
+    ".experts.down_proj.weight_packed": "w2_weight_packed",
+    ".experts.gate_up_proj.weight_global_scale": "w13_weight_global_scale",
+    ".experts.down_proj.weight_global_scale": "w2_weight_global_scale",
+    ".experts.gate_up_proj.input_global_scale": "w13_input_global_scale",
+    ".experts.down_proj.input_global_scale": "w2_input_global_scale",
 }
 
 
@@ -573,10 +630,15 @@ def install_toplevel_cb_expert_loader(model_cls: type) -> None:
                     param = params_dict[mapped]
                     if tuple(param.shape) != tuple(w.shape):
                         raise ValueError(
-                            f"prismaquant CB expert '{name}' -> '{mapped}': "
-                            f"checkpoint shape {tuple(w.shape)} != param "
-                            f"shape {tuple(param.shape)} — stacked "
-                            "(E, out, bytes) contract violated")
+                            f"prismaquant fused expert '{name}' -> "
+                            f"'{mapped}': checkpoint shape {tuple(w.shape)} "
+                            f"!= param shape {tuple(param.shape)} — fused "
+                            "whole-stack contract violated. This is the "
+                            "INTENDED failure when the param is TP/EP-sharded "
+                            "(the param holds this rank's slice, so a "
+                            "whole-stack copy_ would silently place the wrong "
+                            "rows), or when gate/up are ordered differently "
+                            "from vLLM's gate-first w13 convention.")
                     param.data.copy_(w.to(param.dtype))
                     # fill path 2 of 2 (top-level): stamp the sentinel that
                     # process_weights_after_loading checks (cb_fill_guard).

--- a/tests/test_toplevel_loader.py
+++ b/tests/test_toplevel_loader.py
@@ -739,13 +739,12 @@ def test_install_wraps_subclass_with_own_load_weights():
 
 
 # ---------------------------------------------------------------------------
-# Fused NATIVE-NVFP4 expert stacks. A heterogeneous artifact leaves some layers
-# on stock compressed-tensors NVFP4; those experts are written as ONE 3D tensor
-# per role (…experts.gate_up_proj.weight_packed, …), which vLLM's per-expert
-# ``expert_params_mapping`` never matches -> the arch loader KeyErrors. The
-# params are the ones CompressedTensorsW4A4Nvfp4MoEMethod.create_weights
-# registers, and their shapes/order are identical to the whole-stack tensor, so
-# the same plain copy_ path serves them.
+# Fused NATIVE-NVFP4 expert stacks (legacy/external compatibility only).
+# vLLM's per-expert ``expert_params_mapping`` cannot match one 3D tensor per
+# role. Raw whole-stack copy is accepted only when vLLM's registered metadata
+# proves compressed-tensors NVFP4, TP=EP=1, no padding, exact dtype/shape and a
+# complete eight-tensor stack. Current PrismaQuant producers do not emit this
+# layout; see the module documentation.
 # ---------------------------------------------------------------------------
 
 def test_map_cb_expert_name_native_nvfp4_fused_stack():
@@ -784,102 +783,305 @@ def test_map_cb_expert_name_nvfp4_excludes_non_experts():
         assert map_cb_expert_name(n) is None, n
 
 
-def test_wrapper_routes_native_nvfp4_fused_stack():
-    """End-to-end: the eight fused native-NVFP4 tensors land in the eight params
-    CompressedTensorsW4A4Nvfp4MoEMethod registers, none leaks to the original."""
-    E, HID, INTER, GROUP = 4, 32, 16, 16
-    P = "model.layers.42.mlp.experts.routed_experts."   # SharedFusedMoE nesting
+class CompressedTensorsW4A4Nvfp4MoEMethod:
+    """Name-compatible stand-in for the import-light unit tests below."""
 
+
+class _FakeNativeNvfp4Owner:
+    """Minimum metadata vLLM attaches through each param's weight_loader."""
+
+    def __init__(self, *, experts, hidden, intermediate, tp=1, ep=1,
+                 use_ep=False, enable_eplb=False, hidden_unpadded=None,
+                 intermediate_unpadded=None):
+        self.quant_method = CompressedTensorsW4A4Nvfp4MoEMethod()
+        self.hidden_size = hidden
+        self.intermediate_size_per_partition = intermediate
+        self.moe_config = types.SimpleNamespace(
+            num_experts=experts,
+            num_local_experts=experts,
+            num_logical_experts=experts,
+            hidden_dim=hidden,
+            hidden_dim_unpadded=(hidden if hidden_unpadded is None
+                                 else hidden_unpadded),
+            intermediate_size_per_partition=intermediate,
+            intermediate_size_per_partition_unpadded=(
+                intermediate if intermediate_unpadded is None
+                else intermediate_unpadded),
+            moe_parallel_config=types.SimpleNamespace(
+                tp_size=tp, ep_size=ep, use_ep=use_ep,
+                enable_eplb=enable_eplb),
+        )
+        self.weight_loader_calls = 0
+
+    def weight_loader(self, *args, **kwargs):
+        self.weight_loader_calls += 1
+        raise AssertionError(
+            "whole fused stacks must not be fed to the per-expert loader")
+
+
+def _native_nvfp4_params(prefix, *, experts=3, hidden=32, intermediate=16,
+                         **owner_kwargs):
+    group = 16
+    params = {
+        prefix + "w13_weight_packed": torch.zeros(
+            experts, 2 * intermediate, hidden // 2, dtype=torch.uint8),
+        prefix + "w2_weight_packed": torch.zeros(
+            experts, hidden, intermediate // 2, dtype=torch.uint8),
+        prefix + "w13_weight_scale": torch.zeros(
+            experts, 2 * intermediate, hidden // group,
+            dtype=torch.float8_e4m3fn),
+        prefix + "w2_weight_scale": torch.zeros(
+            experts, hidden, intermediate // group,
+            dtype=torch.float8_e4m3fn),
+        prefix + "w13_weight_global_scale": torch.zeros(experts, 2),
+        prefix + "w2_weight_global_scale": torch.zeros(experts),
+        prefix + "w13_input_global_scale": torch.zeros(experts, 2),
+        prefix + "w2_input_global_scale": torch.zeros(experts),
+    }
+    owner = _FakeNativeNvfp4Owner(
+        experts=experts, hidden=hidden, intermediate=intermediate,
+        **owner_kwargs)
+    for param in params.values():
+        param.weight_loader = owner.weight_loader
+    return params, owner
+
+
+def _pack_nvfp4_codes(codes):
+    """Pack independent E2M1-code nibbles, low column first."""
+    return (codes[..., 0::2] | (codes[..., 1::2] << 4)).to(torch.uint8)
+
+
+def _native_nvfp4_fixture(prefix, *, experts=3, hidden=32, intermediate=16):
+    """Producer-shaped fused fixture with traceable expert/gate/up patterns.
+
+    This is intentionally independent of the loader mapping: it first builds
+    semantic gate/up/down code planes, packs adjacent input nibbles, and only
+    then gives them checkpoint names. Uniform fill tensors would not detect a
+    swapped expert, gate/up row block, or packed input pair.
+    """
+    def codes(rows, seed):
+        e = torch.arange(experts)[:, None, None]
+        r = torch.arange(rows)[None, :, None]
+        c = torch.arange(hidden)[None, None, :]
+        return ((seed + 5 * e + 3 * r + 7 * c) % 16).to(torch.uint8)
+
+    gate = codes(intermediate, 1)
+    up = codes(intermediate, 9)
+    down_e = torch.arange(experts)[:, None, None]
+    down_r = torch.arange(hidden)[None, :, None]
+    down_c = torch.arange(intermediate)[None, None, :]
+    down = ((4 + 5 * down_e + 3 * down_r + 7 * down_c) % 16).to(
+        torch.uint8)
+
+    scale_grid = torch.tensor([0.5, 1.0, 2.0, 4.0])
+    w13_scale_idx = (
+        torch.arange(experts)[:, None, None]
+        + torch.arange(2 * intermediate)[None, :, None]
+        + torch.arange(hidden // 16)[None, None, :]) % len(scale_grid)
+    w2_scale_idx = (
+        2 * torch.arange(experts)[:, None, None]
+        + torch.arange(hidden)[None, :, None]
+        + torch.arange(intermediate // 16)[None, None, :]) % len(scale_grid)
+
+    return {
+        prefix + "gate_up_proj.weight_packed": _pack_nvfp4_codes(
+            torch.cat([gate, up], dim=1)),
+        prefix + "down_proj.weight_packed": _pack_nvfp4_codes(down),
+        prefix + "gate_up_proj.weight_scale": scale_grid[
+            w13_scale_idx].to(torch.float8_e4m3fn),
+        prefix + "down_proj.weight_scale": scale_grid[
+            w2_scale_idx].to(torch.float8_e4m3fn),
+        prefix + "gate_up_proj.weight_global_scale": torch.stack([
+            torch.arange(experts, dtype=torch.float32) + 11,
+            torch.arange(experts, dtype=torch.float32) + 21,
+        ], dim=1),
+        prefix + "down_proj.weight_global_scale": (
+            torch.arange(experts, dtype=torch.float32) + 31),
+        prefix + "gate_up_proj.input_global_scale": torch.stack([
+            torch.arange(experts, dtype=torch.float32) + 41,
+            torch.arange(experts, dtype=torch.float32) + 51,
+        ], dim=1),
+        prefix + "down_proj.input_global_scale": (
+            torch.arange(experts, dtype=torch.float32) + 61),
+    }
+
+
+def _make_native_model(params, mapper=None):
     class _FakeCausalLM:
         def __init__(self):
-            self._params = {
-                P + "w13_weight_packed":
-                    torch.zeros(E, 2 * INTER, HID // 2, dtype=torch.uint8),
-                P + "w2_weight_packed":
-                    torch.zeros(E, HID, INTER // 2, dtype=torch.uint8),
-                P + "w13_weight_scale":
-                    torch.zeros(E, 2 * INTER, HID // GROUP,
-                                dtype=torch.float8_e4m3fn),
-                P + "w2_weight_scale":
-                    torch.zeros(E, HID, INTER // GROUP,
-                                dtype=torch.float8_e4m3fn),
-                P + "w13_weight_global_scale": torch.zeros(E, 2),
-                P + "w2_weight_global_scale": torch.zeros(E),
-                P + "w13_input_global_scale": torch.zeros(E, 2),
-                P + "w2_input_global_scale": torch.zeros(E),
-                "model.layers.42.mlp.gate.weight": torch.zeros(E, HID),
-            }
+            self._params = params
             self.delegated = []
 
         def named_parameters(self):
             return list(self._params.items())
 
-        def load_weights(self, weights):     # ORIGINAL (stub stock loader)
+        def load_weights(self, weights):
             loaded = set()
-            for name, w in weights:
+            for name, weight in weights:
                 self.delegated.append(name)
                 if name in self._params:
-                    self._params[name].copy_(w)
+                    self._params[name].copy_(weight)
                     loaded.add(name)
             return loaded
 
+    if mapper is not None:
+        _FakeCausalLM.hf_to_vllm_mapper = mapper
     install_toplevel_cb_expert_loader(_FakeCausalLM)
-    m = _FakeCausalLM()
-    C = "model.layers.42.mlp.experts."        # checkpoint: flat, no nesting
-    loaded = m.load_weights(iter([
-        (C + "gate_up_proj.weight_packed",
-         torch.full((E, 2 * INTER, HID // 2), 7, dtype=torch.uint8)),
-        (C + "down_proj.weight_packed",
-         torch.full((E, HID, INTER // 2), 9, dtype=torch.uint8)),
-        (C + "gate_up_proj.weight_scale",
-         torch.full((E, 2 * INTER, HID // GROUP), 2.0).to(torch.float8_e4m3fn)),
-        (C + "down_proj.weight_scale",
-         torch.full((E, HID, INTER // GROUP), 3.0).to(torch.float8_e4m3fn)),
-        (C + "gate_up_proj.weight_global_scale", torch.full((E, 2), 4.0)),
-        (C + "down_proj.weight_global_scale", torch.full((E,), 5.0)),
-        (C + "gate_up_proj.input_global_scale", torch.full((E, 2), 6.0)),
-        (C + "down_proj.input_global_scale", torch.full((E,), 8.0)),
-        ("model.layers.42.mlp.gate.weight", torch.full((E, HID), 1.0)),
-    ]))
-
-    assert torch.all(m._params[P + "w13_weight_packed"] == 7)
-    assert torch.all(m._params[P + "w2_weight_packed"] == 9)
-    assert torch.all(m._params[P + "w13_weight_scale"].float() == 2.0)
-    assert torch.all(m._params[P + "w2_weight_scale"].float() == 3.0)
-    assert torch.all(m._params[P + "w13_weight_global_scale"] == 4.0)
-    assert torch.all(m._params[P + "w2_weight_global_scale"] == 5.0)
-    assert torch.all(m._params[P + "w13_input_global_scale"] == 6.0)
-    assert torch.all(m._params[P + "w2_input_global_scale"] == 8.0)
-    # router still delegates; no expert tensor leaks (no double-load)
-    assert m.delegated == ["model.layers.42.mlp.gate.weight"]
-    assert loaded == set(m._params)
+    return _FakeCausalLM()
 
 
-def test_wrapper_nvfp4_sharded_param_raises_diagnosable_error():
-    """A TP/EP-sharded param holds only this rank's slice, so a whole-stack
-    copy_ would silently place the wrong rows. The shape guard must fire, and
-    say so."""
-    E, HID, INTER = 4, 32, 16
+def test_wrapper_routes_native_nvfp4_fused_stack_without_weight_loader():
+    experts, hidden, intermediate = 3, 32, 16
+    checkpoint_prefix = "model.layers.42.mlp.experts."
+    param_prefix = "model.layers.42.mlp.experts.routed_experts."
+    params, owner = _native_nvfp4_params(
+        param_prefix, experts=experts, hidden=hidden,
+        intermediate=intermediate)
+    router = "model.layers.42.mlp.gate.weight"
+    params[router] = torch.zeros(experts, hidden)
+    source = _native_nvfp4_fixture(
+        checkpoint_prefix, experts=experts, hidden=hidden,
+        intermediate=intermediate)
+    source[router] = torch.arange(experts * hidden, dtype=torch.float32).reshape(
+        experts, hidden)
 
-    class _FakeCausalLM:
-        def __init__(self):
-            self._params = {           # EP=2: half the experts on this rank
-                "model.layers.42.mlp.experts.w13_weight_packed":
-                    torch.zeros(E // 2, 2 * INTER, HID // 2, dtype=torch.uint8),
-            }
+    model = _make_native_model(params)
+    loaded = model.load_weights(iter(source.items()))
 
-        def named_parameters(self):
-            return list(self._params.items())
+    suffix_to_leaf = {
+        suffix: leaf for suffix, leaf in
+        moe_toplevel_loader._NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF.items()
+    }
+    for name, expected in source.items():
+        if name == router:
+            assert torch.equal(params[router], expected)
+            continue
+        suffix = next(s for s in suffix_to_leaf if name.endswith(s))
+        actual = params[param_prefix + suffix_to_leaf[suffix]]
+        assert torch.equal(actual, expected), suffix
+    # Gate/up have deliberately distinct rows/scale columns, so equality above
+    # proves the raw copy retained their producer-side order.
+    assert not torch.equal(
+        params[param_prefix + "w13_weight_packed"][:, :intermediate],
+        params[param_prefix + "w13_weight_packed"][:, intermediate:])
+    assert owner.weight_loader_calls == 0
+    assert model.delegated == [router]
+    assert loaded == set(params)
 
-        def load_weights(self, weights):
-            for _ in weights:
-                pass
-            return set()
 
-    install_toplevel_cb_expert_loader(_FakeCausalLM)
-    m = _FakeCausalLM()
-    with pytest.raises(ValueError, match="TP/EP-sharded"):
-        m.load_weights(iter([
-            ("model.layers.42.mlp.experts.gate_up_proj.weight_packed",
-             torch.zeros(E, 2 * INTER, HID // 2, dtype=torch.uint8)),
-        ]))
+def test_wrapper_native_nvfp4_rejects_incomplete_stack():
+    checkpoint_prefix = "model.layers.5.mlp.experts."
+    param_prefix = "model.layers.5.mlp.experts.routed_experts."
+    params, _ = _native_nvfp4_params(param_prefix)
+    source = _native_nvfp4_fixture(checkpoint_prefix)
+    source.pop(checkpoint_prefix + "down_proj.input_global_scale")
+    model = _make_native_model(params)
+
+    with pytest.raises(ValueError, match=r"incomplete.*input_global_scale"):
+        model.load_weights(iter(source.items()))
+
+
+def test_wrapper_native_nvfp4_rejects_duplicate_stack_tensor():
+    checkpoint_prefix = "model.layers.5.mlp.experts."
+    param_prefix = "model.layers.5.mlp.experts.routed_experts."
+    params, _ = _native_nvfp4_params(param_prefix)
+    first = next(iter(_native_nvfp4_fixture(checkpoint_prefix).items()))
+    model = _make_native_model(params)
+
+    with pytest.raises(ValueError, match="duplicate tensor suffix"):
+        model.load_weights(iter([first, first]))
+
+
+@pytest.mark.parametrize(
+    ("owner_kwargs", "message"),
+    [
+        ({"tp": 2}, r"TP=EP=1.*TP=2"),
+        ({"ep": 2, "use_ep": True}, r"TP=EP=1.*EP=2"),
+        ({"hidden_unpadded": 24}, r"padded MoE dimensions"),
+        ({"intermediate_unpadded": 8}, r"padded MoE dimensions"),
+        ({"enable_eplb": True}, r"EPLB"),
+    ],
+)
+def test_wrapper_native_nvfp4_rejects_parallel_or_padded_target(
+        owner_kwargs, message):
+    checkpoint_prefix = "model.layers.6.mlp.experts."
+    param_prefix = "model.layers.6.mlp.experts.routed_experts."
+    params, _ = _native_nvfp4_params(param_prefix, **owner_kwargs)
+    model = _make_native_model(params)
+    first = next(iter(_native_nvfp4_fixture(checkpoint_prefix).items()))
+
+    with pytest.raises(ValueError, match=message):
+        model.load_weights(iter([first]))
+
+
+def test_wrapper_native_nvfp4_shape_dtype_and_metadata_fail_closed():
+    checkpoint_prefix = "model.layers.7.mlp.experts."
+    param_prefix = "model.layers.7.mlp.experts.routed_experts."
+
+    params, _ = _native_nvfp4_params(param_prefix)
+    model = _make_native_model(params)
+    source = _native_nvfp4_fixture(checkpoint_prefix)
+    key = checkpoint_prefix + "gate_up_proj.weight_packed"
+    with pytest.raises(ValueError, match="checkpoint shape"):
+        model.load_weights(iter([(key, source[key][:, :-1].contiguous())]))
+
+    params, _ = _native_nvfp4_params(param_prefix)
+    model = _make_native_model(params)
+    with pytest.raises(ValueError, match="checkpoint dtype"):
+        model.load_weights(iter([(key, source[key].to(torch.int16))]))
+
+    params, _ = _native_nvfp4_params(param_prefix)
+    model = _make_native_model(params)
+    noncontiguous = torch.empty(
+        source[key].shape[0], source[key].shape[1],
+        source[key].shape[2] * 2, dtype=source[key].dtype)[..., ::2]
+    noncontiguous.copy_(source[key])
+    assert not noncontiguous.is_contiguous()
+    with pytest.raises(ValueError, match="non-contiguous"):
+        model.load_weights(iter([(key, noncontiguous)]))
+
+    params, _ = _native_nvfp4_params(param_prefix)
+    del params[param_prefix + "w13_weight_packed"].weight_loader
+    model = _make_native_model(params)
+    with pytest.raises(ValueError, match="no inspectable.*metadata"):
+        model.load_weights(iter([(key, source[key])]))
+
+    params, owner = _native_nvfp4_params(param_prefix)
+    owner.moe_config.num_local_experts -= 1
+    model = _make_native_model(params)
+    with pytest.raises(ValueError, match="expert counts must be identical"):
+        model.load_weights(iter([(key, source[key])]))
+
+
+def test_wrapper_routes_native_nvfp4_after_hf_mapper_rename():
+    experts, hidden, intermediate = 3, 32, 16
+    checkpoint_prefix = "model.language_model.layers.8.mlp.experts."
+    param_prefix = (
+        "language_model.model.layers.8.mlp.experts.routed_experts.")
+    params, _ = _native_nvfp4_params(
+        param_prefix, experts=experts, hidden=hidden,
+        intermediate=intermediate)
+    source = _native_nvfp4_fixture(
+        checkpoint_prefix, experts=experts, hidden=hidden,
+        intermediate=intermediate)
+    model = _make_native_model(params, mapper=_QWEN35_MAPPER)
+
+    loaded = model.load_weights(iter(source.items()))
+
+    assert model.delegated == []
+    assert loaded == set(params)
+    assert torch.equal(
+        params[param_prefix + "w13_weight_global_scale"],
+        source[checkpoint_prefix + "gate_up_proj.weight_global_scale"])
+
+
+def test_wrapper_defers_mapper_dropped_native_nvfp4_name():
+    mapper = _FakeWeightsMapper({"drop.this.": None})
+    name = "drop.this.layers.0.mlp.experts.gate_up_proj.weight_packed"
+    model = _make_native_model({}, mapper=mapper)
+
+    loaded = model.load_weights(iter([(name, torch.zeros(2, 4, 4,
+                                                          dtype=torch.uint8))]))
+
+    assert loaded == set()
+    assert model.delegated == [name]

--- a/tests/test_toplevel_loader.py
+++ b/tests/test_toplevel_loader.py
@@ -736,3 +736,150 @@ def test_install_wraps_subclass_with_own_load_weights():
     # idempotent
     install_toplevel_cb_expert_loader(_Base)
     assert _Base.__dict__["load_weights"] is base_fn
+
+
+# ---------------------------------------------------------------------------
+# Fused NATIVE-NVFP4 expert stacks. A heterogeneous artifact leaves some layers
+# on stock compressed-tensors NVFP4; those experts are written as ONE 3D tensor
+# per role (…experts.gate_up_proj.weight_packed, …), which vLLM's per-expert
+# ``expert_params_mapping`` never matches -> the arch loader KeyErrors. The
+# params are the ones CompressedTensorsW4A4Nvfp4MoEMethod.create_weights
+# registers, and their shapes/order are identical to the whole-stack tensor, so
+# the same plain copy_ path serves them.
+# ---------------------------------------------------------------------------
+
+def test_map_cb_expert_name_native_nvfp4_fused_stack():
+    P = "model.layers.42.mlp.experts."
+    assert map_cb_expert_name(P + "gate_up_proj.weight_packed") == \
+        P + "w13_weight_packed"
+    assert map_cb_expert_name(P + "down_proj.weight_packed") == \
+        P + "w2_weight_packed"
+    assert map_cb_expert_name(P + "gate_up_proj.weight_global_scale") == \
+        P + "w13_weight_global_scale"
+    assert map_cb_expert_name(P + "down_proj.weight_global_scale") == \
+        P + "w2_weight_global_scale"
+    assert map_cb_expert_name(P + "gate_up_proj.input_global_scale") == \
+        P + "w13_input_global_scale"
+    assert map_cb_expert_name(P + "down_proj.input_global_scale") == \
+        P + "w2_input_global_scale"
+    # the block-scale pair is shared with the CB fp8-rung lane (one entry,
+    # both lanes) — the resolver keys on whichever param actually exists
+    assert map_cb_expert_name(P + "gate_up_proj.weight_scale") == \
+        P + "w13_weight_scale"
+
+
+def test_map_cb_expert_name_nvfp4_excludes_non_experts():
+    # The .experts. anchor governs the NVFP4 suffixes exactly as it does the CB
+    # ones: dense / shared-expert NVFP4 tensors reach the ORIGINAL loader, which
+    # already handles them via the arch's stacked_params_mapping.
+    for n in [
+        "model.layers.0.mlp.gate_up_proj.weight_packed",          # dense L0
+        "model.layers.0.mlp.down_proj.weight_packed",
+        "model.layers.5.mlp.shared_mlp.gate_proj.weight_packed",  # shared expert
+        "model.layers.5.mlp.shared_mlp.down_proj.input_global_scale",
+        "model.layers.1.self_attn.qkv_proj.weight_packed",        # dense attn
+        # per-expert (unfused) NVFP4 — vLLM's expert_params_mapping owns these
+        "model.layers.7.mlp.experts.3.gate_proj.weight_packed",
+    ]:
+        assert map_cb_expert_name(n) is None, n
+
+
+def test_wrapper_routes_native_nvfp4_fused_stack():
+    """End-to-end: the eight fused native-NVFP4 tensors land in the eight params
+    CompressedTensorsW4A4Nvfp4MoEMethod registers, none leaks to the original."""
+    E, HID, INTER, GROUP = 4, 32, 16, 16
+    P = "model.layers.42.mlp.experts.routed_experts."   # SharedFusedMoE nesting
+
+    class _FakeCausalLM:
+        def __init__(self):
+            self._params = {
+                P + "w13_weight_packed":
+                    torch.zeros(E, 2 * INTER, HID // 2, dtype=torch.uint8),
+                P + "w2_weight_packed":
+                    torch.zeros(E, HID, INTER // 2, dtype=torch.uint8),
+                P + "w13_weight_scale":
+                    torch.zeros(E, 2 * INTER, HID // GROUP,
+                                dtype=torch.float8_e4m3fn),
+                P + "w2_weight_scale":
+                    torch.zeros(E, HID, INTER // GROUP,
+                                dtype=torch.float8_e4m3fn),
+                P + "w13_weight_global_scale": torch.zeros(E, 2),
+                P + "w2_weight_global_scale": torch.zeros(E),
+                P + "w13_input_global_scale": torch.zeros(E, 2),
+                P + "w2_input_global_scale": torch.zeros(E),
+                "model.layers.42.mlp.gate.weight": torch.zeros(E, HID),
+            }
+            self.delegated = []
+
+        def named_parameters(self):
+            return list(self._params.items())
+
+        def load_weights(self, weights):     # ORIGINAL (stub stock loader)
+            loaded = set()
+            for name, w in weights:
+                self.delegated.append(name)
+                if name in self._params:
+                    self._params[name].copy_(w)
+                    loaded.add(name)
+            return loaded
+
+    install_toplevel_cb_expert_loader(_FakeCausalLM)
+    m = _FakeCausalLM()
+    C = "model.layers.42.mlp.experts."        # checkpoint: flat, no nesting
+    loaded = m.load_weights(iter([
+        (C + "gate_up_proj.weight_packed",
+         torch.full((E, 2 * INTER, HID // 2), 7, dtype=torch.uint8)),
+        (C + "down_proj.weight_packed",
+         torch.full((E, HID, INTER // 2), 9, dtype=torch.uint8)),
+        (C + "gate_up_proj.weight_scale",
+         torch.full((E, 2 * INTER, HID // GROUP), 2.0).to(torch.float8_e4m3fn)),
+        (C + "down_proj.weight_scale",
+         torch.full((E, HID, INTER // GROUP), 3.0).to(torch.float8_e4m3fn)),
+        (C + "gate_up_proj.weight_global_scale", torch.full((E, 2), 4.0)),
+        (C + "down_proj.weight_global_scale", torch.full((E,), 5.0)),
+        (C + "gate_up_proj.input_global_scale", torch.full((E, 2), 6.0)),
+        (C + "down_proj.input_global_scale", torch.full((E,), 8.0)),
+        ("model.layers.42.mlp.gate.weight", torch.full((E, HID), 1.0)),
+    ]))
+
+    assert torch.all(m._params[P + "w13_weight_packed"] == 7)
+    assert torch.all(m._params[P + "w2_weight_packed"] == 9)
+    assert torch.all(m._params[P + "w13_weight_scale"].float() == 2.0)
+    assert torch.all(m._params[P + "w2_weight_scale"].float() == 3.0)
+    assert torch.all(m._params[P + "w13_weight_global_scale"] == 4.0)
+    assert torch.all(m._params[P + "w2_weight_global_scale"] == 5.0)
+    assert torch.all(m._params[P + "w13_input_global_scale"] == 6.0)
+    assert torch.all(m._params[P + "w2_input_global_scale"] == 8.0)
+    # router still delegates; no expert tensor leaks (no double-load)
+    assert m.delegated == ["model.layers.42.mlp.gate.weight"]
+    assert loaded == set(m._params)
+
+
+def test_wrapper_nvfp4_sharded_param_raises_diagnosable_error():
+    """A TP/EP-sharded param holds only this rank's slice, so a whole-stack
+    copy_ would silently place the wrong rows. The shape guard must fire, and
+    say so."""
+    E, HID, INTER = 4, 32, 16
+
+    class _FakeCausalLM:
+        def __init__(self):
+            self._params = {           # EP=2: half the experts on this rank
+                "model.layers.42.mlp.experts.w13_weight_packed":
+                    torch.zeros(E // 2, 2 * INTER, HID // 2, dtype=torch.uint8),
+            }
+
+        def named_parameters(self):
+            return list(self._params.items())
+
+        def load_weights(self, weights):
+            for _ in weights:
+                pass
+            return set()
+
+    install_toplevel_cb_expert_loader(_FakeCausalLM)
+    m = _FakeCausalLM()
+    with pytest.raises(ValueError, match="TP/EP-sharded"):
+        m.load_weights(iter([
+            ("model.layers.42.mlp.experts.gate_up_proj.weight_packed",
+             torch.zeros(E, 2 * INTER, HID // 2, dtype=torch.uint8)),
+        ]))

--- a/tests/test_toplevel_loader_vllm.py
+++ b/tests/test_toplevel_loader_vllm.py
@@ -1,0 +1,148 @@
+"""Live vLLM contract for the legacy fused native-NVFP4 compatibility path.
+
+The torch-only suite proves routing and rejection behavior. This file verifies
+that vLLM 0.24's actual CompressedTensorsW4A4Nvfp4MoEMethod registers the shapes,
+dtypes, and bound weight-loader metadata that the fail-closed shim inspects.
+"""
+from __future__ import annotations
+
+from math import prod
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+if not torch.cuda.is_available():
+    pytest.skip("live NVFP4 backend selection needs CUDA", allow_module_level=True)
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.\
+    compressed_tensors_moe.compressed_tensors_moe_w4a4_nvfp4 import (
+        CompressedTensorsW4A4Nvfp4MoEMethod,
+    )
+
+from gridbook.moe_toplevel_loader import (
+    _NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF,
+    install_toplevel_cb_expert_loader,
+)
+
+
+def _source_stack(prefix: str, experts: int, hidden: int, intermediate: int):
+    def u8(shape, offset):
+        return ((torch.arange(prod(shape)).reshape(shape)
+                 + offset) % 256).to(torch.uint8)
+
+    def fp8(shape, offset):
+        values = torch.tensor([0.5, 1.0, 2.0, 4.0])
+        idx = ((torch.arange(prod(shape)).reshape(shape)
+                + offset) % values.numel())
+        return values[idx].to(torch.float8_e4m3fn)
+
+    return {
+        prefix + "gate_up_proj.weight_packed": u8(
+            (experts, 2 * intermediate, hidden // 2), 1),
+        prefix + "down_proj.weight_packed": u8(
+            (experts, hidden, intermediate // 2), 17),
+        prefix + "gate_up_proj.weight_scale": fp8(
+            (experts, 2 * intermediate, hidden // 16), 0),
+        prefix + "down_proj.weight_scale": fp8(
+            (experts, hidden, intermediate // 16), 1),
+        prefix + "gate_up_proj.weight_global_scale": (
+            torch.arange(experts * 2, dtype=torch.float32).reshape(experts, 2)
+            + 11),
+        prefix + "down_proj.weight_global_scale": (
+            torch.arange(experts, dtype=torch.float32) + 21),
+        prefix + "gate_up_proj.input_global_scale": (
+            torch.arange(experts * 2, dtype=torch.float32).reshape(experts, 2)
+            + 31),
+        prefix + "down_proj.input_global_scale": (
+            torch.arange(experts, dtype=torch.float32) + 41),
+    }
+
+
+def test_actual_vllm_nvfp4_method_registration_and_whole_stack_copy():
+    experts, hidden, intermediate = 2, 32, 16
+    parallel = FusedMoEParallelConfig.make_no_parallel()
+    config = FusedMoEConfig(
+        num_experts=experts,
+        experts_per_token=1,
+        hidden_dim=hidden,
+        intermediate_size=intermediate,
+        num_local_experts=experts,
+        num_logical_experts=experts,
+        activation=MoEActivation.SILU,
+        device="cuda",
+        routing_method=RoutingMethodType.Default,
+        moe_parallel_config=parallel,
+        in_dtype=torch.bfloat16,
+    )
+    method = CompressedTensorsW4A4Nvfp4MoEMethod(
+        config, layer_name="model.layers.0.mlp.experts", use_a16=False)
+
+    class _Owner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.moe_config = config
+            self.quant_method = method
+            self.hidden_size = hidden
+            self.intermediate_size_per_partition = intermediate
+            self.weight_loader_calls = 0
+
+        def weight_loader(self, *args, **kwargs):
+            self.weight_loader_calls += 1
+            raise AssertionError("raw whole-stack copy must not call this")
+
+    owner = _Owner()
+    method.create_weights(
+        layer=owner,
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size_per_partition=intermediate,
+        params_dtype=torch.bfloat16,
+        weight_loader=owner.weight_loader,
+    )
+
+    class _Top(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([torch.nn.Module()])
+            layer = self.model.layers[0]
+            layer.mlp = torch.nn.Module()
+            layer.mlp.experts = torch.nn.Module()
+            layer.mlp.experts.routed_experts = owner
+            self.delegated = []
+
+        def load_weights(self, weights):
+            self.delegated.extend(name for name, _ in weights)
+            return set()
+
+    install_toplevel_cb_expert_loader(_Top)
+    model = _Top()
+    checkpoint_prefix = "model.layers.0.mlp.experts."
+    param_prefix = "model.layers.0.mlp.experts.routed_experts."
+    source = _source_stack(
+        checkpoint_prefix, experts, hidden, intermediate)
+
+    loaded = model.load_weights(iter(source.items()))
+
+    assert model.delegated == []
+    assert owner.weight_loader_calls == 0
+    assert loaded == {
+        param_prefix + leaf
+        for leaf in _NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF.values()
+    }
+    params = dict(model.named_parameters())
+    for name, expected in source.items():
+        suffix = next(
+            suffix for suffix in _NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF
+            if name.endswith(suffix))
+        param = params[
+            param_prefix + _NATIVE_NVFP4_EXPERT_SUFFIX_TO_LEAF[suffix]]
+        assert param.weight_loader.__self__ is owner
+        assert torch.equal(param, expected), suffix


### PR DESCRIPTION
Bundle 03 from the supplied archive, ported as a fail-closed compatibility path.

Implemented safeguards:
- preserves the current CB fill guard and mark_filled contract
- accepts only the real vLLM 0.24 CompressedTensors W4A4 NVFP4 MoE method
- requires TP=EP=1, no EPLB, no padding, exact global/local/logical expert counts, exact shape/dtype/contiguity, and all eight tensors exactly once
- handles mapper rename/drop behavior and rejects duplicate or incomplete stacks
- uses distinct expert/gate/up/down patterns so tests can detect ordering and axis mistakes

Validation:
- 35 focused host tests pass
- 43 installed-wheel CUDA/vLLM 0.24 tests pass
- the live vLLM test instantiates the actual NVFP4 MoE method and exercises its registered parameters

Why this remains draft:
No current PrismaQuant exporter produces this layout. The native exporter splits non-BF16 packed experts per expert, the mixed streaming exporter rejects stock expert stacks, and the direct rank-3 quantizer path errors. No real external fused-stack artifact was available for an inference smoke test. This PR should remain held until an external artifact fixture and forward pass validate the compatibility contract.

Attribution:
Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.