### PR TITLE
csrc: accelerate FP4 activation QDQ with a single CUDA launch

### DIFF
--- a/gridbook/csrc/cb_gemv.cu
+++ b/gridbook/csrc/cb_gemv.cu
@@ -459,7 +459,7 @@ __global__ __launch_bounds__(WARPS * 32) void cb_gemv_fp8_kernel(
 // grid is sorted({+/-x for x in (0,.5,1,1.5,2,3,4,6)}) = 15 entries (+0 and -0
 // collapse to one), i.e. codec._fp4_qdq_grid.  Any deviation here is a numerics
 // change, not an optimisation — tests/test_fp4_act_qdq.py compares against the
-// codec element-wise with torch.equal, never a tolerance.
+// codec element-wise through the raw bf16 bits, never a tolerance.
 //
 // THE SCALE IS A **MULTIPLY BY THE RECIPROCAL**, NOT A DIVIDE.  This is the
 // single most load-bearing line in the file.
@@ -555,10 +555,14 @@ torch::Tensor fp8_act_qdq(torch::Tensor x) {
   TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kBFloat16,
               "fp8_act_qdq wants a CUDA bf16 tensor");
   auto x2 = x.contiguous();
+  TORCH_CHECK(x2.dim() >= 1,
+              "fp8_act_qdq needs at least one dimension");
   const int64_t K = x2.size(-1);
+  TORCH_CHECK(K > 0,
+              "fp8_act_qdq needs a positive last dimension");
   const int64_t M = x2.numel() / K;
   auto out = torch::empty_like(x2);
-  if (M == 0 || K == 0) return out;
+  if (M == 0) return out;
   const c10::cuda::OptionalCUDAGuard guard(x2.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   fp8_act_qdq_kernel<<<(unsigned)M, kThreads, 0, stream>>>(

--- a/gridbook/csrc/cb_gemv.cu
+++ b/gridbook/csrc/cb_gemv.cu
@@ -429,6 +429,119 @@ __global__ __launch_bounds__(WARPS * 32) void cb_gemv_fp8_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Fused group-16 fp4 (E2M1) activation QDQ — bit-exact mirror of
+// codec.fp4_group16_act_qdq.
+//
+// WHY THIS EXISTS.  The fp8 lane has had a CUDA act-QDQ since day one
+// (fp8_act_qdq_kernel above), so an fp8-CB projection costs ONE launch.  The
+// fp4 lane had no twin, so every fp4-CB projection ran
+// `codec.fp4_group16_act_qdq` — roughly two dozen eager tensor ops (count them
+// over codec.py:126-133: float/reshape/abs/amax/clamp/div/div/contiguous/
+// bucketize/2x gather/2x clamp/2x sub/2x abs/lt/where/mul/reshape/cast) plus
+// the matching allocator round-trips, PER MODULE CALL, in eager mode.  The
+// grouped MoE decode path calls it twice per layer per token (moe.py:1959 for
+// the module input, moe.py:1977 for the intermediate), so a model with L CB'd
+// MoE layers pays 2L such call chains per decoded token, all of it host
+// dispatch on a tensor that a single block can chew through.
+//
+// BIT-EXACTNESS CONTRACT.  linear.py:362-366 and moe.py:1955-1958 both document
+// that the fp4 act-QDQ runs OUTSIDE the kernel specifically so CUDA-vs-Triton
+// numerics stay aligned.  This kernel therefore reproduces the python EXACTLY,
+// not approximately:
+//   scale = fmaxf(amax_over_16, 1e-8f) * (1/6)           (clamp THEN scale)
+//   idx   = lower_bound(grid, v)                          (torch.bucketize,
+//                                                          right=False)
+//   lo    = grid[max(idx-1, 0)],  hi = grid[min(idx, 14)]
+//   q     = (|hi - v| <  |v - lo|) ? hi : lo              (STRICT <, so an exact
+//                                                          tie resolves LOW,
+//                                                          matching torch.where)
+//   out   = f32_to_bf16_rn(q * scale)
+// grid is sorted({+/-x for x in (0,.5,1,1.5,2,3,4,6)}) = 15 entries (+0 and -0
+// collapse to one), i.e. codec._fp4_qdq_grid.  Any deviation here is a numerics
+// change, not an optimisation — tests/test_fp4_act_qdq.py compares against the
+// codec element-wise with torch.equal, never a tolerance.
+//
+// THE SCALE IS A **MULTIPLY BY THE RECIPROCAL**, NOT A DIVIDE.  This is the
+// single most load-bearing line in the file.
+//
+// codec.py:127 writes `amax.clamp_min(1e-8) / NVFP4_GRID_MAX`, which LOOKS like
+// a division -- but torch lowers tensor-by-SCALAR division to a multiply by the
+// float32 reciprocal, and `1.0f/6.0f` (0x3E2AAAAB) is very slightly ABOVE 1/6.
+// So torch's scale is one ulp HIGHER than the correctly rounded quotient.
+// `__fdiv_rn(amax, 6.0f)` is correctly rounded, i.e. one ulp LOWER, and that
+// single ulp is enough to change the answer:
+//
+//   amax = 1.7265625, x = -amax/8  ->  the exact quotient x/(amax/6) is EXACTLY
+//   -0.75, a grid midpoint.  With torch's (larger) scale it computes to
+//   -0.7499999404, a hair on the -0.5 side, and torch picks hi = -0.5.  With the
+//   correctly-rounded (smaller) scale it lands at or past -0.75 and picks
+//   lo = -1.0.  Adjacent rungs 0.5 and 1.0 differ by exactly 2x, which is why
+//   every mismatching element is wrong by exactly 2x -- the signature that
+//   identifies this bug if anyone "simplifies" the line.
+//
+// The failing set is precisely `x == +/-amax/8`; nothing else reaches a
+// midpoint.  Rare, entirely value-dependent, and invisible to any tolerance-
+// based test -- which is why the battery asserts torch.equal.
+//
+// The `v / scale` division, by contrast, IS a real tensor-by-TENSOR division in
+// torch and must stay `__fdiv_rn`.  The two lines are deliberately asymmetric.
+// Do not "simplify" either back to a bare operator, and do not reach for
+// -prec-div/-fmad flags instead: those are file-wide and would silently move the
+// GEMV kernels' numerics too.
+//
+// Layout: one block per token row; 16 lanes cooperate on one group of 16 so the
+// loads coalesce.  The trip count is uniform across the block, and the `live`
+// guard is applied only AFTER the shuffle reduction, so every lane named in the
+// 0xffffffff mask is active at the shuffle even when nGroups is not a multiple
+// of (blockDim.x / 16).
+// ---------------------------------------------------------------------------
+DEVINL float fp4_rtn_e2m1(float v) {
+  const float g[15] = {-6.0f, -4.0f, -3.0f, -2.0f, -1.5f, -1.0f, -0.5f, 0.0f,
+                       0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f};
+  int idx = 15;                       // torch.bucketize(v, grid, right=False)
+#pragma unroll
+  for (int i = 14; i >= 0; --i) {
+    if (g[i] >= v) idx = i;
+  }
+  const float lo = g[idx > 0 ? idx - 1 : 0];
+  const float hi = g[idx < 15 ? idx : 14];
+  return (fabsf(__fsub_rn(hi, v)) < fabsf(__fsub_rn(v, lo))) ? hi : lo;
+}
+
+__global__ __launch_bounds__(kThreads) void fp4_group16_act_qdq_kernel(
+    const uint16_t* __restrict__ x,   // [M, K] bf16 (as u16)
+    uint16_t* __restrict__ out,       // [M, K] bf16 (as u16)
+    int64_t K) {
+  const int64_t m = blockIdx.x;
+  const uint16_t* row = x + m * K;
+  uint16_t* orow = out + m * K;
+
+  const int64_t nGroups = K >> 4;              // K % 16 == 0 checked host-side
+  const int lane = threadIdx.x & 15;
+  const int gSlot = threadIdx.x >> 4;
+  const int gStride = blockDim.x >> 4;
+  const int64_t iters = (nGroups + gStride - 1) / gStride;
+
+  for (int64_t it = 0; it < iters; ++it) {
+    const int64_t g = (int64_t)gSlot + it * gStride;
+    const bool live = g < nGroups;
+    const int64_t i = (g << 4) + lane;
+    const float v = live ? bf16_to_f32(row[i]) : 0.0f;
+
+    float amax = fabsf(v);
+#pragma unroll
+    for (int off = 8; off > 0; off >>= 1) {
+      amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, off));
+    }
+    if (!live) continue;
+
+    const float scale = __fmul_rn(fmaxf(amax, 1e-8f), 1.0f / 6.0f);
+    orow[i] = f32_to_bf16_rn(
+        __fmul_rn(fp4_rtn_e2m1(__fdiv_rn(v, scale)), scale));
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Host launchers
 // ---------------------------------------------------------------------------
 torch::Tensor fp8_act_qdq(torch::Tensor x) {
@@ -442,6 +555,26 @@ torch::Tensor fp8_act_qdq(torch::Tensor x) {
   const c10::cuda::OptionalCUDAGuard guard(x2.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   fp8_act_qdq_kernel<<<(unsigned)M, kThreads, 0, stream>>>(
+      reinterpret_cast<const uint16_t*>(x2.data_ptr()),
+      reinterpret_cast<uint16_t*>(out.data_ptr()), K);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+torch::Tensor fp4_act_qdq(torch::Tensor x) {
+  TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kBFloat16,
+              "fp4_act_qdq wants a CUDA bf16 tensor");
+  auto x2 = x.contiguous();
+  const int64_t K = x2.size(-1);
+  TORCH_CHECK(K % 16 == 0,
+              "fp4_act_qdq needs a last dim that is a multiple of the fp4 "
+              "group (16); got ", K);
+  const int64_t M = x2.numel() / K;
+  auto out = torch::empty_like(x2);
+  if (M == 0 || K == 0) return out;
+  const c10::cuda::OptionalCUDAGuard guard(x2.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  fp4_group16_act_qdq_kernel<<<(unsigned)M, kThreads, 0, stream>>>(
       reinterpret_cast<const uint16_t*>(x2.data_ptr()),
       reinterpret_cast<uint16_t*>(out.data_ptr()), K);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -1873,6 +2006,9 @@ torch::Tensor qdq_scale_probe(torch::Tensor x) {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fp8_act_qdq", &fp8_act_qdq,
         "Fused per-token fp8 dynamic QDQ (bit-exact to codec.fp8_dynamic_act_qdq)");
+  m.def("fp4_act_qdq", &fp4_act_qdq,
+        "Fused group-16 fp4 E2M1 activation QDQ (bit-exact to "
+        "codec.fp4_group16_act_qdq)");
   m.def("cb_gemv_fp8", &cb_gemv_fp8,
         "FP8_CB product-mode decode GEMV (bandwidth-bound, INV-1)");
   m.def("cb_gemv_fp4_v2", &cb_gemv_fp4_v2,

--- a/gridbook/csrc/cb_gemv.cu
+++ b/gridbook/csrc/cb_gemv.cu
@@ -529,13 +529,20 @@ __global__ __launch_bounds__(kThreads) void fp4_group16_act_qdq_kernel(
     const float v = live ? bf16_to_f32(row[i]) : 0.0f;
 
     float amax = fabsf(v);
+    int has_nan = isnan(v) ? 1 : 0;
 #pragma unroll
     for (int off = 8; off > 0; off >>= 1) {
       amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, off));
+      has_nan |= __shfl_xor_sync(0xffffffffu, has_nan, off);
     }
     if (!live) continue;
 
-    const float scale = __fmul_rn(fmaxf(amax, 1e-8f), 1.0f / 6.0f);
+    // torch.amax propagates NaN while CUDA fmaxf deliberately ignores it.
+    // Preserve the codec's group semantics: one NaN makes the scale, and thus
+    // every output in that group, NaN.
+    const float scale = has_nan
+        ? nanf("")
+        : __fmul_rn(fmaxf(amax, 1e-8f), 1.0f / 6.0f);
     orow[i] = f32_to_bf16_rn(
         __fmul_rn(fp4_rtn_e2m1(__fdiv_rn(v, scale)), scale));
   }
@@ -565,13 +572,17 @@ torch::Tensor fp4_act_qdq(torch::Tensor x) {
   TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kBFloat16,
               "fp4_act_qdq wants a CUDA bf16 tensor");
   auto x2 = x.contiguous();
+  TORCH_CHECK(x2.dim() >= 1,
+              "fp4_act_qdq needs at least one dimension");
   const int64_t K = x2.size(-1);
+  TORCH_CHECK(K > 0,
+              "fp4_act_qdq needs a positive last dimension");
   TORCH_CHECK(K % 16 == 0,
               "fp4_act_qdq needs a last dim that is a multiple of the fp4 "
               "group (16); got ", K);
   const int64_t M = x2.numel() / K;
   auto out = torch::empty_like(x2);
-  if (M == 0 || K == 0) return out;
+  if (M == 0) return out;
   const c10::cuda::OptionalCUDAGuard guard(x2.device());
   auto stream = at::cuda::getCurrentCUDAStream();
   fp4_group16_act_qdq_kernel<<<(unsigned)M, kThreads, 0, stream>>>(

--- a/gridbook/linear.py
+++ b/gridbook/linear.py
@@ -25,7 +25,8 @@ from vllm.model_executor.parameter import (
 
 from . import codec
 from .expand import expand_cb_to_fp8, expand_fp4_v2_to_weight
-from .ops import cb_gemm, cb_gemv_fp4_v2, cb_gemv_fp8, dispatch_via_op
+from .ops import (cb_gemm, cb_gemv_fp4_v2, cb_gemv_fp8, dispatch_via_op,
+                  fp4_act_qdq_or_codec)
 
 # NOTE: the fused-sibling fallback map (qkv_proj, gate_up_proj, in_proj_qkvz,
 # in_proj_ba) used to be duplicated here. It — and the namespace handling around
@@ -504,11 +505,14 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
             if M <= CUDA_GEMV_M_MAX and self._cuda_gemv_ok():
                 if self.is_fp4:
                     # fp4-v2 CUDA GEMV: act-QDQ (fp4 group-16 RTN) runs OUTSIDE
-                    # the kernel via codec — exactly as the Triton fp4 path — so
-                    # CUDA-vs-Triton numerics stay aligned. The kernel gathers
-                    # the bf16 codebook and composes the two-tier scale
+                    # the kernel — exactly as the Triton fp4 path — so
+                    # CUDA-vs-Triton numerics stay aligned. The resolver picks
+                    # the fused CUDA op when the ext has it and the eager codec
+                    # otherwise; the two are bit-identical (tests/
+                    # test_fp4_act_qdq.py asserts torch.equal). The kernel
+                    # gathers the bf16 codebook and composes the two-tier scale
                     # in-register from the packed 9-byte plane.
-                    xq = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+                    xq = fp4_act_qdq_or_codec(x)
                     y = cb_gemv_fp4_v2(xq, layer._cb_qw_padded, layer._cb_flat,
                                        layer._cb_row_offset, layer._cb_compose,
                                        N, K, self.k, self.n_sub, self.type_size)
@@ -539,7 +543,7 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
             # the [N,K] tile is bounded to one layer, freed per forward. (bf16
             # MMA — INV-2 waived; the FP4-MMA CUTLASS prefill is prototype iii.)
             import torch.nn.functional as F
-            xq = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+            xq = fp4_act_qdq_or_codec(x)
             W = expand_fp4_v2_to_weight(
                 layer._cb_qw_padded, layer._cb_flat, layer._cb_row_offset,
                 layer._cb_compose, N, K, self.k, self.n_sub, self.type_size)

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -65,7 +65,7 @@ from .moe_l2 import (
     cb_l2_plan,
 )
 from .moe_routing import cb_grouped_pad_routing
-from .ops import dispatch_via_op
+from .ops import dispatch_via_op, fp4_act_qdq_or_codec
 
 
 def _row_bytes(in_features: int, type_size: int) -> int:
@@ -1921,7 +1921,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             a1, a1s = moe_kernel_quantize_input(
                 x, None, fp8_dtype, per_act_token_quant=True)
         else:
-            a1 = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+            a1 = fp4_act_qdq_or_codec(x)
             a1s = None
         if _timing:
             torch.cuda.synchronize(); _t["qdq"] += _time.time() - _t0
@@ -1989,7 +1989,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
                     ic2, None, fp8_dtype, per_act_token_quant=True)
                 b2s = layer.w2_weight_scale[c0:c1]            # [nE, hidden]
             else:
-                a2 = codec.fp4_group16_act_qdq(ic2).to(torch.bfloat16)
+                a2 = fp4_act_qdq_or_codec(ic2)
                 a2s = b2s = None
             if _timing:
                 torch.cuda.synchronize(); _t["qdq"] += _time.time() - _t0
@@ -2159,7 +2159,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             # bit-identical to the loop's codec.fp4_group16_act_qdq; the kernel
             # composes the two-tier weight scale in-register from the packed
             # 9-byte section + the resident (256,16) compose table.
-            xq = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+            xq = fp4_act_qdq_or_codec(x)
             gate_up = pq_ops.cb_moe_gemv_fp4_v2(
                 xq, layer.w13_cb_qweight.data, layer._cb_flat,
                 layer._cb_compose, pair_expert, pair_xrow,
@@ -2177,7 +2177,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         apply_moe_activation(act, a, gate_up)
 
         if self.is_fp4:
-            aq = codec.fp4_group16_act_qdq(a).to(torch.bfloat16)
+            aq = fp4_act_qdq_or_codec(a)
             y_down = pq_ops.cb_moe_gemv_fp4_v2(
                 aq, layer.w2_cb_qweight.data, layer._cb_flat,
                 layer._cb_compose, pair_expert, pair_self,

--- a/gridbook/ops.py
+++ b/gridbook/ops.py
@@ -253,7 +253,7 @@ def fp4_act_qdq_or_codec(x: torch.Tensor) -> torch.Tensor:
     OUTSIDE the kernel precisely so CUDA-vs-Triton numerics stay aligned, so a
     tolerance here would silently break that contract.
     """
-    if x.dtype is torch.bfloat16 and fp4_act_qdq_ok():
+    if x.is_cuda and x.dtype is torch.bfloat16 and fp4_act_qdq_ok():
         return fp4_act_qdq(x)
     from . import codec
     return codec.fp4_group16_act_qdq(x).to(torch.bfloat16)

--- a/gridbook/ops.py
+++ b/gridbook/ops.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import torch
 
 import os
+import sys
 
 from .kernels import cb_decode_linear
 
@@ -191,6 +192,71 @@ def fp8_act_qdq(x: torch.Tensor) -> torch.Tensor:
 @fp8_act_qdq.register_fake
 def _fp8_act_qdq_fake(x):
     return torch.empty_like(x)
+
+
+@torch.library.custom_op("prismaquant::fp4_act_qdq", mutates_args=(), tags=_PQ_UNSAFE)
+def fp4_act_qdq(x: torch.Tensor) -> torch.Tensor:
+    """Fused group-16 fp4 (E2M1) activation QDQ (bit-exact to
+    codec.fp4_group16_act_qdq) as a custom op for the compile path."""
+    from .cuda_ext import get_ext
+    return get_ext().fp4_act_qdq(x)
+
+
+@fp4_act_qdq.register_fake
+def _fp4_act_qdq_fake(x):
+    return torch.empty_like(x)
+
+
+# One-shot resolution of the fp4 act-QDQ implementation.
+#
+# The fp8 CB lane has always fused its activation QDQ into ONE CUDA launch
+# (fp8_act_qdq above); the fp4 lane ran codec.fp4_group16_act_qdq, roughly two
+# dozen eager torch dispatches plus the matching allocator round-trips per
+# module call. The grouped MoE decode path pays that twice per layer per token
+# (moe.py, the module input and the intermediate), which is milliseconds of pure
+# host dispatch on a many-layer MoE.
+#
+# The fallback is bit-identical, only slow, so correctness never depends on the
+# ext being present. But a SILENT fallback would make a decode benchmark measure
+# the wrong throughput class while looking valid. So the resolution prints its
+# verdict once, loudly, on BOTH branches -- the same discipline as
+# cb_expand_fp8_into_available()'s degrade-never-crash contract, with the
+# addition that the degraded branch says so out loud.
+_FP4_ACT_QDQ_OK = None
+
+
+def fp4_act_qdq_ok() -> bool:
+    """True when the CUDA fp4 act-QDQ is available (resolved once, cached)."""
+    global _FP4_ACT_QDQ_OK
+    if _FP4_ACT_QDQ_OK is None:
+        from .cuda_ext import get_ext
+        ext = get_ext()
+        _FP4_ACT_QDQ_OK = ext is not None and hasattr(ext, "fp4_act_qdq")
+        if _FP4_ACT_QDQ_OK:
+            print("[prismaquant-cb] act-qdq fp4=cuda "
+                  "(prismaquant::fp4_act_qdq, 1 launch/call)", flush=True)
+        else:
+            print("[prismaquant-cb] WARNING: act-qdq fp4=EAGER-CODEC -- the "
+                  "CUDA fp4_act_qdq symbol is missing from the ext, so every "
+                  "fp4-CB projection pays ~two dozen torch dispatches instead "
+                  "of one kernel launch. Numerics are unchanged; DECODE "
+                  "THROUGHPUT IS NOT REPRESENTATIVE -- do not bench.",
+                  file=sys.stderr, flush=True)
+    return _FP4_ACT_QDQ_OK
+
+
+def fp4_act_qdq_or_codec(x: torch.Tensor) -> torch.Tensor:
+    """fp4 group-16 activation QDQ: CUDA op when available, eager codec else.
+
+    Bit-identical either way (tests/test_fp4_act_qdq.py asserts torch.equal,
+    never a tolerance) -- linear.py and moe.py both document that this QDQ runs
+    OUTSIDE the kernel precisely so CUDA-vs-Triton numerics stay aligned, so a
+    tolerance here would silently break that contract.
+    """
+    if x.dtype is torch.bfloat16 and fp4_act_qdq_ok():
+        return fp4_act_qdq(x)
+    from . import codec
+    return codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
 
 
 @torch.library.custom_op("prismaquant::cb_moe_gemv_fp4_v2", mutates_args=(), tags=_PQ_UNSAFE)

--- a/gridbook/ops.py
+++ b/gridbook/ops.py
@@ -204,7 +204,19 @@ def fp4_act_qdq(x: torch.Tensor) -> torch.Tensor:
 
 @fp4_act_qdq.register_fake
 def _fp4_act_qdq_fake(x):
-    return torch.empty_like(x)
+    if not x.is_cuda or x.dtype is not torch.bfloat16:
+        raise RuntimeError("fp4_act_qdq wants a CUDA bf16 tensor")
+    if x.dim() < 1:
+        raise RuntimeError("fp4_act_qdq needs at least one dimension")
+    torch._check(x.shape[-1] > 0,
+                 lambda: "fp4_act_qdq needs a positive last dimension")
+    torch._check(
+        x.shape[-1] % 16 == 0,
+        lambda: "fp4_act_qdq needs a last dim that is a multiple of the fp4 "
+                "group (16)")
+    # Native calls x.contiguous() before allocating its output. FakeTensor
+    # stride metadata must describe that same contiguous result.
+    return torch.empty_like(x, memory_format=torch.contiguous_format)
 
 
 # One-shot resolution of the fp4 act-QDQ implementation.

--- a/tests/test_fp4_act_qdq.py
+++ b/tests/test_fp4_act_qdq.py
@@ -1,0 +1,166 @@
+"""Bit-exactness battery for the fp4 group-16 activation-QDQ CUDA op.
+
+The contract is EQUALITY, not tolerance. ``gridbook/linear.py`` and
+``gridbook/moe.py`` both document that the fp4 act-QDQ deliberately runs OUTSIDE
+the CB kernel so CUDA-vs-Triton numerics stay aligned; a tolerance here would
+silently break that alignment and the divergence would only surface as a quality
+delta nobody could attribute. So every comparison below is ``torch.equal`` on the
+raw bf16 bits.
+
+The eager codec is the oracle. It is still live at the per-expert reference loop
+(``moe._apply_prefill_loop``), the batched prefill (``moe._apply_prefill_batched``)
+and the Triton ``cb_gemm`` path (``linear._apply_inline``) — this change
+deliberately did NOT rewrite those — so the oracle is an independent
+implementation, not the thing under test wearing a hat.
+
+Entirely CUDA-gated: with no extension build (no nvcc / no GPU) the whole module
+skips, in line with the suite's runtime self-selection convention
+(.github/scripts/run_cpu_tests.sh, "WHY NO PYTEST MARKERS").
+"""
+import time
+
+import pytest
+import torch
+
+codec = pytest.importorskip("gridbook.codec",
+                            reason="gridbook plugin not importable")
+from gridbook.cuda_ext import get_ext  # noqa: E402
+
+ext = get_ext()
+if ext is None:
+    pytest.skip("CUDA extension unavailable (no nvcc?)",
+                allow_module_level=True)
+if not hasattr(ext, "fp4_act_qdq"):
+    pytest.skip("extension build predates fp4_act_qdq — delete the JIT build "
+                "dir (PRISMAQUANT_CB_EXT_DIR or ~/.cache/prismaquant-cb-ext) "
+                "and re-import so the new cb_gemv.cu is compiled",
+                allow_module_level=True)
+
+DEV = "cuda"
+
+# 3072 / 1024 / 12288 / 1536 are shipped hidden, moe-intermediate, dense-MLP and
+# HY3-intermediate widths; the rest are awkward-but-legal K and M.
+SHAPES = [(1, 3072), (1, 1024), (1, 12288), (1, 1536), (1, 16),
+          (2, 3072), (8, 3072), (64, 1024), (313, 3072), (1024, 1024),
+          (7, 48), (1, 128)]
+
+
+def _inputs(m, k, gen):
+    base = torch.randn(m, k, device=DEV, dtype=torch.bfloat16, generator=gen)
+    yield "randn", base
+    yield "randn*1e-4", base * 1e-4
+    yield "randn*1e+4", base * 1e4
+    yield "zeros", torch.zeros(m, k, device=DEV, dtype=torch.bfloat16)
+
+
+@pytest.mark.parametrize("m,k", SHAPES, ids=lambda v: str(v))
+def test_bit_exact_vs_codec(m, k):
+    """CUDA op == codec.fp4_group16_act_qdq, bit for bf16 bit."""
+    gen = torch.Generator(device=DEV).manual_seed(1234)
+    for name, x in _inputs(m, k, gen):
+        ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+        got = ext.fp4_act_qdq(x)
+        if not torch.equal(ref, got):
+            bad = ref != got
+            n = int(bad.sum())
+            i = int(bad.flatten().nonzero()[0])
+            pytest.fail(
+                f"M={m} K={k} {name}: {n}/{ref.numel()} elements differ; "
+                f"first at flat index {i}: ref={ref.flatten()[i].item()} "
+                f"got={got.flatten()[i].item()} x={x.flatten()[i].item()}")
+
+
+def test_exact_midpoints_resolve_low():
+    """Exact E2M1 midpoints must round to the LOWER rung.
+
+    ``codec.fp4_group16_act_qdq`` picks ``hi`` only on a STRICT ``<``
+    (codec.py, ``torch.where((hi - xg).abs() < (xg - lo).abs(), hi, lo)``), so an
+    exact tie falls through to ``lo``. Adjacent E2M1 rungs differ by up to 2x, so
+    getting this backwards is a 2x error on the affected elements — and it is
+    invisible to any tolerance-based test.
+
+    amax is 6.0 here, so scale == 1.0 and the listed values ARE the quotients.
+    """
+    ties = [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0,
+            -0.25, -0.75, -1.25, -1.75, -2.5, -3.5, -5.0, 6.0, 0.0]
+    x = torch.tensor([ties], device=DEV, dtype=torch.bfloat16)
+    ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+    got = ext.fp4_act_qdq(x)
+    assert torch.equal(ref, got), (
+        f"midpoint tie-break diverged\n  ref={ref.flatten().tolist()}\n"
+        f"  got={got.flatten().tolist()}")
+
+
+def test_reciprocal_scale_midpoint_case():
+    """The `x == +/-amax/8` case that distinguishes reciprocal-multiply from divide.
+
+    ``codec.py`` writes ``amax.clamp_min(1e-8) / NVFP4_GRID_MAX``; torch lowers
+    tensor-by-SCALAR division to a multiply by the float32 reciprocal, which for
+    1/6 rounds one ulp HIGH. A kernel using a correctly-rounded ``__fdiv_rn``
+    lands one ulp LOW, and at ``x == +/-amax/8`` the exact quotient is the
+    midpoint -0.75, so the two implementations pick rungs that differ by exactly
+    2x. This test pins that case directly rather than hoping randn hits it.
+    """
+    amax = 1.7265625                      # exactly representable in bf16
+    row = [amax] + [-amax / 8.0] * 15
+    x = torch.tensor([row], device=DEV, dtype=torch.bfloat16)
+    ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+    got = ext.fp4_act_qdq(x)
+    assert torch.equal(ref, got), (
+        f"reciprocal-vs-divide divergence\n  ref={ref.flatten().tolist()}\n"
+        f"  got={got.flatten().tolist()}")
+
+
+def test_refuses_k_not_multiple_of_group():
+    """A last dim that is not a multiple of 16 must raise, not silently corrupt."""
+    x = torch.randn(1, 30, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="multiple of the fp4 group"):
+        ext.fp4_act_qdq(x)
+
+
+def test_refuses_non_bf16():
+    x = torch.randn(1, 32, device=DEV, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="CUDA bf16"):
+        ext.fp4_act_qdq(x)
+
+
+def test_resolver_matches_codec():
+    """``ops.fp4_act_qdq_or_codec`` is bit-identical on both of its branches."""
+    from gridbook import ops
+    x = torch.randn(4, 3072, device=DEV, dtype=torch.bfloat16)
+    ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+    assert torch.equal(ref, ops.fp4_act_qdq_or_codec(x))
+    # fp32 input takes the eager branch by dtype (the op is bf16-only).
+    xf = x.float()
+    ref32 = codec.fp4_group16_act_qdq(xf).to(torch.bfloat16)
+    assert torch.equal(ref32, ops.fp4_act_qdq_or_codec(xf))
+
+
+def _host_us(fn, x, iters=300, warmup=30):
+    for _ in range(warmup):
+        fn(x)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn(x)
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+@pytest.mark.parametrize("m,k", [(1, 3072), (1, 1024), (8, 3072), (256, 3072)])
+def test_cuda_cheaper_than_eager_codec(m, k, capsys):
+    """One launch must beat ~two dozen eager dispatches.
+
+    The assertion threshold is 1x — deliberately not a tuned number, because a
+    tuned one would flake on a shared GPU. The point of the test is the printed
+    comparison; the assert only catches a catastrophic regression (e.g. the
+    resolver silently falling back).
+    """
+    x = torch.randn(m, k, device=DEV, dtype=torch.bfloat16)
+    eager = _host_us(lambda t: codec.fp4_group16_act_qdq(t).to(torch.bfloat16), x)
+    cuda = _host_us(ext.fp4_act_qdq, x)
+    with capsys.disabled():
+        print(f"\n  M={m:4d} K={k:5d}  eager-codec {eager:7.2f} us   "
+              f"cuda-fp4 {cuda:6.2f} us   saved {eager - cuda:7.2f} us "
+              f"[{eager / cuda:5.1f}x]")
+    assert cuda < eager

--- a/tests/test_fp4_act_qdq.py
+++ b/tests/test_fp4_act_qdq.py
@@ -4,8 +4,8 @@ The contract is EQUALITY, not tolerance. ``gridbook/linear.py`` and
 ``gridbook/moe.py`` both document that the fp4 act-QDQ deliberately runs OUTSIDE
 the CB kernel so CUDA-vs-Triton numerics stay aligned; a tolerance here would
 silently break that alignment and the divergence would only surface as a quality
-delta nobody could attribute. So every comparison below is ``torch.equal`` on the
-raw bf16 bits.
+delta nobody could attribute. Finite outputs are compared through an integer
+view of the raw bf16 bits, including the sign bit of zero.
 
 The eager codec is the oracle. It is still live at the per-expert reference loop
 (``moe._apply_prefill_loop``), the batched prefill (``moe._apply_prefill_batched``)
@@ -53,6 +53,14 @@ def _inputs(m, k, gen):
     yield "zeros", torch.zeros(m, k, device=DEV, dtype=torch.bfloat16)
 
 
+def _bits(t):
+    return t.contiguous().view(torch.int16)
+
+
+def _bit_equal(a, b):
+    return torch.equal(_bits(a), _bits(b))
+
+
 @pytest.mark.parametrize("m,k", SHAPES, ids=lambda v: str(v))
 def test_bit_exact_vs_codec(m, k):
     """CUDA op == codec.fp4_group16_act_qdq, bit for bf16 bit."""
@@ -60,8 +68,8 @@ def test_bit_exact_vs_codec(m, k):
     for name, x in _inputs(m, k, gen):
         ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
         got = ext.fp4_act_qdq(x)
-        if not torch.equal(ref, got):
-            bad = ref != got
+        if not _bit_equal(ref, got):
+            bad = _bits(ref) != _bits(got)
             n = int(bad.sum())
             i = int(bad.flatten().nonzero()[0])
             pytest.fail(
@@ -86,7 +94,7 @@ def test_exact_midpoints_resolve_low():
     x = torch.tensor([ties], device=DEV, dtype=torch.bfloat16)
     ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
     got = ext.fp4_act_qdq(x)
-    assert torch.equal(ref, got), (
+    assert _bit_equal(ref, got), (
         f"midpoint tie-break diverged\n  ref={ref.flatten().tolist()}\n"
         f"  got={got.flatten().tolist()}")
 
@@ -106,7 +114,7 @@ def test_reciprocal_scale_midpoint_case():
     x = torch.tensor([row], device=DEV, dtype=torch.bfloat16)
     ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
     got = ext.fp4_act_qdq(x)
-    assert torch.equal(ref, got), (
+    assert _bit_equal(ref, got), (
         f"reciprocal-vs-divide divergence\n  ref={ref.flatten().tolist()}\n"
         f"  got={got.flatten().tolist()}")
 
@@ -134,6 +142,26 @@ def test_nonfinite_groups_match_codec_classification():
     assert torch.equal(ref[finite], got[finite])
 
 
+def test_signed_zero_and_bf16_subnormal_bits():
+    # Construct +/- minimum bf16 subnormals by bit pattern so the test does not
+    # depend on a host float conversion preserving them.
+    raw = torch.tensor([0, -32768, 1, -32767] * 4, dtype=torch.int16)
+    x = raw.view(torch.bfloat16).reshape(1, 16).to(DEV)
+    ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+    got = ext.fp4_act_qdq(x)
+    assert _bit_equal(ref, got)
+
+
+def test_noncontiguous_higher_rank_input_returns_contiguous_output():
+    x = torch.randn(2, 48, 3, device=DEV,
+                    dtype=torch.bfloat16).transpose(1, 2)
+    assert not x.is_contiguous() and x.shape == (2, 3, 48)
+    ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+    got = ext.fp4_act_qdq(x)
+    assert got.is_contiguous()
+    assert _bit_equal(ref, got)
+
+
 def test_refuses_k_not_multiple_of_group():
     """A last dim that is not a multiple of 16 must raise, not silently corrupt."""
     x = torch.randn(1, 30, device=DEV, dtype=torch.bfloat16)
@@ -159,22 +187,50 @@ def test_accepts_empty_leading_dimension():
     assert got.shape == x.shape and got.dtype == x.dtype and got.numel() == 0
 
 
+def test_fp8_twin_rejects_zero_last_dim_without_dividing_by_zero():
+    x = torch.empty(2, 0, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="positive last dimension"):
+        ext.fp8_act_qdq(x)
+
+
 def test_resolver_matches_codec():
     """``ops.fp4_act_qdq_or_codec`` is bit-identical on both of its branches."""
     from gridbook import ops
     x = torch.randn(4, 3072, device=DEV, dtype=torch.bfloat16)
     ref = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
-    assert torch.equal(ref, ops.fp4_act_qdq_or_codec(x))
+    assert _bit_equal(ref, ops.fp4_act_qdq_or_codec(x))
     # fp32 input takes the eager branch by dtype (the op is bf16-only).
     xf = x.float()
     ref32 = codec.fp4_group16_act_qdq(xf).to(torch.bfloat16)
-    assert torch.equal(ref32, ops.fp4_act_qdq_or_codec(xf))
+    assert _bit_equal(ref32, ops.fp4_act_qdq_or_codec(xf))
 
     # An available CUDA extension must not make a CPU bf16 tensor call a CUDA-
     # only op.  The resolver's eager fallback is device-generic.
     x_cpu = torch.randn(2, 32, dtype=torch.bfloat16)
     ref_cpu = codec.fp4_group16_act_qdq(x_cpu).to(torch.bfloat16)
-    assert torch.equal(ref_cpu, ops.fp4_act_qdq_or_codec(x_cpu))
+    assert _bit_equal(ref_cpu, ops.fp4_act_qdq_or_codec(x_cpu))
+
+
+def test_cuda_graph_replay_matches_eager_bits():
+    from gridbook import ops
+    x = torch.randn(4, 3072, device=DEV, dtype=torch.bfloat16)
+    ref = ops.fp4_act_qdq_or_codec(x)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = ops.fp4_act_qdq_or_codec(x)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert _bit_equal(ref, captured)
+
+
+def test_torch_compile_custom_op_matches_eager_bits():
+    from gridbook import ops
+    x = torch.randn(4, 3072, device=DEV, dtype=torch.bfloat16)
+    expected = ops.fp4_act_qdq_or_codec(x)
+    compiled = torch.compile(ops.fp4_act_qdq_or_codec, fullgraph=True)
+    actual = compiled(x)
+    assert _bit_equal(expected, actual)
 
 
 def _host_us(fn, x, iters=300, warmup=30):

--- a/tests/test_fp4_act_qdq.py
+++ b/tests/test_fp4_act_qdq.py
@@ -111,6 +111,29 @@ def test_reciprocal_scale_midpoint_case():
         f"  got={got.flatten().tolist()}")
 
 
+def test_nonfinite_groups_match_codec_classification():
+    """NaN propagation must match ``torch.amax`` group semantics.
+
+    CUDA ``fmaxf`` ignores a lone NaN, whereas the codec's ``torch.amax``
+    propagates it.  Without an explicit group flag the fused path would return
+    plausible finite values for a group the reference turns entirely into NaN.
+    NaN payload bits are not part of the contract, but the value classes and
+    all finite outputs are.
+    """
+    rows = torch.tensor([
+        [float("nan"), 1.0] + [0.0] * 14,
+        [float("inf"), -1.0] + [0.0] * 14,
+        [float("-inf"), 1.0] + [0.0] * 14,
+    ], device=DEV, dtype=torch.bfloat16)
+    ref = codec.fp4_group16_act_qdq(rows).to(torch.bfloat16)
+    got = ext.fp4_act_qdq(rows)
+    assert torch.equal(torch.isnan(ref), torch.isnan(got))
+    assert torch.equal(torch.isposinf(ref), torch.isposinf(got))
+    assert torch.equal(torch.isneginf(ref), torch.isneginf(got))
+    finite = torch.isfinite(ref)
+    assert torch.equal(ref[finite], got[finite])
+
+
 def test_refuses_k_not_multiple_of_group():
     """A last dim that is not a multiple of 16 must raise, not silently corrupt."""
     x = torch.randn(1, 30, device=DEV, dtype=torch.bfloat16)
@@ -124,6 +147,18 @@ def test_refuses_non_bf16():
         ext.fp4_act_qdq(x)
 
 
+def test_refuses_zero_last_dim_without_dividing_by_zero():
+    x = torch.empty(2, 0, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="positive last dimension"):
+        ext.fp4_act_qdq(x)
+
+
+def test_accepts_empty_leading_dimension():
+    x = torch.empty(0, 32, device=DEV, dtype=torch.bfloat16)
+    got = ext.fp4_act_qdq(x)
+    assert got.shape == x.shape and got.dtype == x.dtype and got.numel() == 0
+
+
 def test_resolver_matches_codec():
     """``ops.fp4_act_qdq_or_codec`` is bit-identical on both of its branches."""
     from gridbook import ops
@@ -134,6 +169,12 @@ def test_resolver_matches_codec():
     xf = x.float()
     ref32 = codec.fp4_group16_act_qdq(xf).to(torch.bfloat16)
     assert torch.equal(ref32, ops.fp4_act_qdq_or_codec(xf))
+
+    # An available CUDA extension must not make a CPU bf16 tensor call a CUDA-
+    # only op.  The resolver's eager fallback is device-generic.
+    x_cpu = torch.randn(2, 32, dtype=torch.bfloat16)
+    ref_cpu = codec.fp4_group16_act_qdq(x_cpu).to(torch.bfloat16)
+    assert torch.equal(ref_cpu, ops.fp4_act_qdq_or_codec(x_cpu))
 
 
 def _host_us(fn, x, iters=300, warmup=30):

--- a/tests/test_fp4_act_qdq_dispatch.py
+++ b/tests/test_fp4_act_qdq_dispatch.py
@@ -1,0 +1,60 @@
+"""CPU-safe dispatch and FakeTensor contracts for fp4 activation QDQ."""
+import types
+
+import pytest
+import torch
+
+from gridbook import codec, ops
+from gridbook import cuda_ext
+
+
+@pytest.fixture(autouse=True)
+def _reset_capability(monkeypatch):
+    monkeypatch.setattr(ops, "_FP4_ACT_QDQ_OK", None)
+
+
+def test_missing_symbol_is_a_supported_eager_fallback(monkeypatch, capsys):
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    assert ops.fp4_act_qdq_ok() is False
+    assert "symbol is missing" in capsys.readouterr().err
+
+
+def test_capability_probe_accepts_the_required_symbol(monkeypatch, capsys):
+    ext = types.SimpleNamespace(fp4_act_qdq=object())
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: ext)
+    assert ops.fp4_act_qdq_ok() is True
+    assert "act-qdq fp4=cuda" in capsys.readouterr().out
+
+
+def test_cpu_bf16_never_reaches_the_cuda_only_op(monkeypatch):
+    monkeypatch.setattr(
+        ops, "fp4_act_qdq_ok",
+        lambda: pytest.fail("CPU input should short-circuit before the probe"))
+    monkeypatch.setattr(
+        ops, "fp4_act_qdq",
+        lambda x: pytest.fail("CPU input reached the CUDA-only op"))
+    x = torch.randn(2, 32, dtype=torch.bfloat16)
+    expected = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
+    actual = ops.fp4_act_qdq_or_codec(x)
+    assert torch.equal(expected.view(torch.int16), actual.view(torch.int16))
+
+
+def test_fake_tensor_matches_native_contiguous_stride():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        x = torch.empty(2, 48, 3, device="cuda",
+                        dtype=torch.bfloat16).transpose(1, 2)
+        assert not x.is_contiguous()
+        out = ops.fp4_act_qdq(x)
+        assert out.shape == (2, 3, 48)
+        assert out.is_contiguous()
+
+
+def test_fake_tensor_rejects_invalid_width():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        x = torch.empty(2, 15, device="cuda", dtype=torch.bfloat16)
+        with pytest.raises(RuntimeError, match="multiple of the fp4 group"):
+            ops.fp4_act_qdq(x)


### PR DESCRIPTION
Bundle 04 from the supplied archive, corrected and validated on the local GB10.

Outcome:
- adds a single-launch CUDA implementation of group-16 FP4 activation QDQ
- retains codec fallback for CPU, missing/stale extensions, and unsupported inputs
- registers a FakeTensor-compatible custom op for compile and graph use

Review fixes:
- propagates NaNs instead of suppressing them through fmaxf
- rejects K=0 before division in both FP4 and inherited FP8 launchers
- prevents CPU BF16 tensors from entering the CUDA-only op
- makes fake and real output stride contracts agree
- compares raw BF16 storage bits, including signed zero and subnormals
- adds nonfinite, empty-shape, noncontiguous, higher-rank, CUDA graph, FakeTensor, and torch.compile coverage

Validation on GB10 sm_121:
- 34/34 focused contract and performance tests pass
- 73 neighboring CUDA tests pass; 74 capability/path-specific cases skip cleanly
- measured speedups remain 15.7x to 26.3x across submitted decode shapes
- CPU dispatcher suite: 5/5 pass
- full CPU suite has no branch-specific failures; baseline harness failures are separately fixed by PR #2

Attribution:
Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.