### PR TITLE
moe: fail loudly on extension and codebook contract violations

### DIFF
--- a/gridbook/codec.py
+++ b/gridbook/codec.py
@@ -57,7 +57,7 @@ def assert_cast_lossless(raw, cast, what: str, prefix: str) -> None:
     msg = (f"[prismaquant] {prefix}: the {what} codebook cast is LOSSY — "
            f"{n} of {a.numel()} table values do not survive it "
            f"(max abs {worst:.3e}, max rel {rel:.3e}). The cast is exact only "
-           f"for on-grid (lattice) tables; a learned codebook must be emitted "
+           f"for target-grid values; a learned codebook must be emitted "
            f"on the target grid, or every CB weight decodes against a silently-"
            f"rounded table. PRISMAQUANT_SKIP_CB_CAST_CHECK=1 overrides "
            f"(debug only).")
@@ -67,8 +67,49 @@ def assert_cast_lossless(raw, cast, what: str, prefix: str) -> None:
         raise ValueError(msg)
 
 
+def validate_codebook_grid(raw: torch.Tensor, grid: str,
+                           prefix: str = "codebook") -> None:
+    """Reject a sidecar table that is not on its declared serving grid.
+
+    This is a format check, not merely a dtype-cast check.  In particular,
+    values such as 0.53125 survive bf16 exactly but are not valid E2M1 values
+    and would otherwise fail only when the fused FP4 LUT is first built.
+    """
+    values = raw.reshape(-1).to(torch.float64)
+    finite = torch.isfinite(values)
+    if not bool(finite.all()):
+        count = int((~finite).sum())
+        raise ValueError(
+            f"[prismaquant] {prefix}: {count} of {values.numel()} codebook "
+            f"values are non-finite; {grid} codebooks must be finite and "
+            "grid-valued")
+
+    if grid == "fp8":
+        encoded = values.to(torch.float8_e4m3fn)
+        if torch.equal(values, encoded.to(torch.float64)):
+            return
+        bad = int((values != encoded.to(torch.float64)).sum())
+        raise ValueError(
+            f"[prismaquant] {prefix}: {bad} of {values.numel()} codebook "
+            "values are off the E4M3 grid declared by the fp8 format")
+
+    if grid == "fp4":
+        magnitudes = torch.tensor(_E2M1, dtype=torch.float64,
+                                  device=values.device)
+        on_grid = (values.abs().unsqueeze(-1) == magnitudes).any(dim=-1)
+        if bool(on_grid.all()):
+            return
+        bad = int((~on_grid).sum())
+        raise ValueError(
+            f"[prismaquant] {prefix}: {bad} of {values.numel()} codebook "
+            "values are off the E2M1 grid declared by the fp4 format")
+
+    raise ValueError(f"[prismaquant] {prefix}: unknown codebook grid {grid!r}")
+
+
 def build_flat_codebook(sub_tables: list[torch.Tensor],
-                        prefix: str = "codebook") -> torch.Tensor:
+                        prefix: str = "codebook",
+                        grid: str | None = None) -> torch.Tensor:
     """Concatenate product sub-tables (each (2^w, sub_dim)) into the flat layout
     the kernel gathers from: block ``s`` = ``sub_tables[s].reshape(-1)`` (row
     major, so entry (idx, local) sits at idx*sub_dim + local)."""
@@ -76,6 +117,8 @@ def build_flat_codebook(sub_tables: list[torch.Tensor],
                       for t in sub_tables]).contiguous()
     raw = torch.cat([t.reshape(-1).to(torch.float64)
                      for t in sub_tables]).contiguous()
+    if grid is not None:
+        validate_codebook_grid(raw, grid, prefix)
     assert_cast_lossless(raw, flat, "bf16 flat", prefix)
     return flat
 

--- a/gridbook/codec.py
+++ b/gridbook/codec.py
@@ -10,6 +10,9 @@
 """
 from __future__ import annotations
 
+import os
+import sys
+
 import torch
 import torch.nn.functional as F
 
@@ -35,12 +38,54 @@ def type_size(k: int, is_fp4: bool) -> int:
     return 4 * int(k) + (16 if is_fp4 else 0)
 
 
-def build_flat_codebook(sub_tables: list[torch.Tensor]) -> torch.Tensor:
+def assert_cast_lossless(raw, cast, what: str, prefix: str) -> None:
+    """Require ``cast`` to preserve every codebook value exactly.
+
+    Codebook tables are tiny and this runs only during load, so compare in
+    float64.  Comparing in float32 would itself round a float64 sidecar before
+    checking whether the runtime's bf16/e4m3 representation rounded it.
+    """
+    a = raw.reshape(-1).to(torch.float64)
+    b = cast.reshape(-1).to(torch.float64)
+    same_size = a.numel() == b.numel()
+    if same_size and torch.equal(a, b):
+        return
+    n = int((a != b).sum()) if same_size else -1
+    worst = float((a - b).abs().max()) if same_size else -1.0
+    rel = float((a - b).abs().div(a.abs().clamp_min(1e-12)).max()) \
+        if same_size else -1.0
+    msg = (f"[prismaquant] {prefix}: the {what} codebook cast is LOSSY — "
+           f"{n} of {a.numel()} table values do not survive it "
+           f"(max abs {worst:.3e}, max rel {rel:.3e}). The cast is exact only "
+           f"for on-grid (lattice) tables; a learned codebook must be emitted "
+           f"on the target grid, or every CB weight decodes against a silently-"
+           f"rounded table. PRISMAQUANT_SKIP_CB_CAST_CHECK=1 overrides "
+           f"(debug only).")
+    if os.environ.get("PRISMAQUANT_SKIP_CB_CAST_CHECK") == "1":
+        print("WARNING " + msg, file=sys.stderr, flush=True)
+    else:
+        raise ValueError(msg)
+
+
+def build_flat_codebook(sub_tables: list[torch.Tensor],
+                        prefix: str = "codebook") -> torch.Tensor:
     """Concatenate product sub-tables (each (2^w, sub_dim)) into the flat layout
     the kernel gathers from: block ``s`` = ``sub_tables[s].reshape(-1)`` (row
     major, so entry (idx, local) sits at idx*sub_dim + local)."""
-    return torch.cat([t.reshape(-1).to(torch.bfloat16).contiguous()
+    flat = torch.cat([t.reshape(-1).to(torch.bfloat16).contiguous()
                       for t in sub_tables]).contiguous()
+    raw = torch.cat([t.reshape(-1).to(torch.float64)
+                     for t in sub_tables]).contiguous()
+    assert_cast_lossless(raw, flat, "bf16 flat", prefix)
+    return flat
+
+
+def flat_codebook_fp8(flat: torch.Tensor,
+                      prefix: str = "codebook") -> torch.Tensor:
+    """Losslessly re-encode a flat FP8-grid codebook as E4M3 bytes."""
+    fp8 = flat.to(torch.float8_e4m3fn).contiguous()
+    assert_cast_lossless(flat, fp8, "e4m3 flat", prefix)
+    return fp8.view(torch.uint8)
 
 
 def build_compose_table(sub_table) -> torch.Tensor:

--- a/gridbook/linear.py
+++ b/gridbook/linear.py
@@ -263,7 +263,7 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
             ref = self.quant_config.target_scheme[sp]["codebook_ref"]
             names = ref if isinstance(ref, list) else [ref]
             subs = [codebooks[n].to(dev) for n in names]
-            flat = codec.build_flat_codebook(subs)
+            flat = codec.build_flat_codebook(subs, self.prefix)
             blocks.append(flat)
             w = shard_widths[i]
             # cumulative base (not i*cb_total): correct even if per-shard
@@ -304,8 +304,8 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
             # E4M3-byte codebook for the fp8-direct transient expand and the
             # CUDA GEMV (exact: every codebook value is on the e4m3 grid, so
             # bf16 -> fp8 is a lossless re-encoding of the same table).
-            layer._cb_flat_fp8 = cb_flat.to(torch.float8_e4m3fn).view(
-                torch.uint8).contiguous()
+            layer._cb_flat_fp8 = codec.flat_codebook_fp8(
+                cb_flat, self.prefix)
             # Warm the CUDA-GEMV JIT build at LOAD time — otherwise the ~30 s
             # in-container build fires on the first decode step and poisons
             # the first request's latency (seen live: 1.89 tok/s rep 1).

--- a/gridbook/linear.py
+++ b/gridbook/linear.py
@@ -263,7 +263,8 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
             ref = self.quant_config.target_scheme[sp]["codebook_ref"]
             names = ref if isinstance(ref, list) else [ref]
             subs = [codebooks[n].to(dev) for n in names]
-            flat = codec.build_flat_codebook(subs, self.prefix)
+            flat = codec.build_flat_codebook(
+                subs, self.prefix, "fp4" if self.is_fp4 else "fp8")
             blocks.append(flat)
             w = shard_widths[i]
             # cumulative base (not i*cb_total): correct even if per-shard

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -111,6 +111,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
     # Process-wide fail-loud state (see _cb_expand_ext_ok / _cuda_moe_ok).
     _EXPAND_EXT_OK: bool | None = None   # cached cuda_ext probe for the expander
     _DECODE_ENGAGED_LOGGED = False       # one-time decode-path engagement line
+    _DECODE_DISABLED_LOGGED = False      # deduplicate a host-wide ext failure
 
     def __init__(self, quant_config, moe: FusedMoEConfig, scheme: dict,
                  prefix: str) -> None:
@@ -236,13 +237,18 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         ref = self.scheme["codebook_ref"]
         names = ref if isinstance(ref, list) else [ref]
         subs = [codebooks[n].to(dev) for n in names]
-        layer._cb_flat = codec.build_flat_codebook(subs, self.prefix)
+        layer._cb_flat = codec.build_flat_codebook(
+            subs, self.prefix, "fp4" if self.is_fp4 else "fp8")
         layer._cb_row0 = torch.zeros(1, dtype=torch.int32, device=dev)
         if self.is_v2:
             layer._cb_compose = codec.build_compose_table(
                 self._sub_table).to(dev)
         else:
             layer._cb_compose = torch.zeros(1, dtype=torch.float32, device=dev)
+            # Materialize and validate every representation while the model is
+            # loading.  A disabled grouped-decode gate must not defer this to
+            # the first stock-prefill forward (which may be under capture).
+            self._stock_cb_flat_fp8(layer)
         # Per-layer uniformity: one format for all experts (union-find at
         # export). The stacked buffer is single-format by construction; assert
         # the byte width matches the scheme so a mis-exported stack fails loudly.
@@ -2139,7 +2145,8 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         expand. Cached on the layer (also built by the CUDA-decode gate); built
         once, before capture. "Every CB value is on the e4m3 grid — lossless"
         used to be a comment here; it is now a check (see
-        ``_assert_cast_lossless``), because it holds only for lattice tables.
+        ``_assert_cast_lossless``), because learned tables must satisfy the
+        same serving-grid contract as lattice tables.
         (Was a ``@staticmethod``; every call site already went through ``self``,
         and the check wants the layer prefix for its message.)"""
         cb = getattr(layer, "_cb_flat_fp8", None)
@@ -2171,15 +2178,18 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
                     # tell, but a different throughput class entirely. A
                     # benchmark taken on that path looks valid and measures the
                     # wrong thing; say so on stderr instead.
-                    print("[prismaquant-cb] WARNING: grouped CUDA decode "
-                          "extension unavailable — CB decode falls back to the "
-                          "full-E stock-prefill path. Numerics are unchanged, "
-                          "but this is NOT the served decode path: do not take "
-                          "throughput numbers from this process.",
-                          file=sys.stderr, flush=True)
+                    cls = PrismaQuantCBMoEMethod
+                    if not cls._DECODE_DISABLED_LOGGED:
+                        print("[prismaquant-cb] WARNING: grouped CUDA decode "
+                              "extension unavailable; the grouped path is "
+                              "disabled and the configured runtime fallback "
+                              "will be used. Throughput may differ.",
+                              file=sys.stderr, flush=True)
+                        cls._DECODE_DISABLED_LOGGED = True
             if ok and not self.is_fp4:
-                # Single source of truth for the e4m3 cast (and its
-                # losslessness check) — this used to duplicate the cast.
+                # Normally materialized during process_weights_after_loading;
+                # retain this defensive check for callers that construct a
+                # layer through an alternate/test load path.
                 self._stock_cb_flat_fp8(layer)
             layer._cb_moe_cuda_ok = ok
             if ok and not PrismaQuantCBMoEMethod._DECODE_ENGAGED_LOGGED:

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -99,40 +99,10 @@ def _disable_grouped_mm(exc) -> None:
     _GROUPED_MM_OK = False
 
 
-# The codebook-table casts at load are proven exact only for LATTICE tables.
-# ``codec.build_flat_codebook`` casts every sub-table to **bf16**, and
-# ``_stock_cb_flat_fp8`` casts that flat table to **e4m3**; both are exact for
-# values that already sit on those grids, which is why every artifact shipped
-# to date passes by construction (their metadata says ``codebook_source:
-# "lattice"``). A LEARNED table can carry off-grid values that these casts
-# round silently at load — the packed weight bytes are untouched, every shape
-# and uniformity assert still passes, and the decode is then "correct" against
-# a table that is not the one the model was quantized with. Nothing downstream
-# can see that, so check the casts here instead: raise, with the numbers, and
-# leave one env escape for debugging.
-def _assert_cast_lossless(raw, cast, what: str, prefix: str) -> None:
-    """``cast`` must represent ``raw`` exactly.  Raises ``ValueError`` unless
-    ``PRISMAQUANT_SKIP_CB_CAST_CHECK=1``, in which case it warns on stderr."""
-    a = raw.float().reshape(-1)
-    b = cast.float().reshape(-1)
-    same_size = a.numel() == b.numel()
-    if same_size and torch.equal(a, b):
-        return
-    n = int((a != b).sum()) if same_size else -1
-    worst = float((a - b).abs().max()) if same_size else -1.0
-    rel = float((a - b).abs().div(a.abs().clamp_min(1e-12)).max()) \
-        if same_size else -1.0
-    msg = (f"[prismaquant] {prefix}: the {what} codebook cast is LOSSY — "
-           f"{n} of {a.numel()} table values do not survive it "
-           f"(max abs {worst:.3e}, max rel {rel:.3e}). The cast is exact only "
-           f"for on-grid (lattice) tables; a LEARNED codebook must be emitted "
-           f"on the target grid by the encoder, or every CB weight decodes "
-           f"against a silently-rounded table. "
-           f"PRISMAQUANT_SKIP_CB_CAST_CHECK=1 overrides (debug only).")
-    if os.environ.get("PRISMAQUANT_SKIP_CB_CAST_CHECK") == "1":
-        print("WARNING " + msg, file=sys.stderr, flush=True)
-    else:
-        raise ValueError(msg)
+# Backward-compatible private name for the integrated follow-on patch and its
+# focused tests.  The implementation lives in codec so dense, MoE and
+# top-level-loader codebook construction all enforce the same contract.
+_assert_cast_lossless = codec.assert_cast_lossless
 
 
 class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
@@ -266,11 +236,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         ref = self.scheme["codebook_ref"]
         names = ref if isinstance(ref, list) else [ref]
         subs = [codebooks[n].to(dev) for n in names]
-        layer._cb_flat = codec.build_flat_codebook(subs)
-        # build_flat_codebook casts to bf16 — prove it, do not assume it.
-        _assert_cast_lossless(
-            torch.cat([t.reshape(-1).float() for t in subs]), layer._cb_flat,
-            "bf16 flat", self.prefix)
+        layer._cb_flat = codec.build_flat_codebook(subs, self.prefix)
         layer._cb_row0 = torch.zeros(1, dtype=torch.int32, device=dev)
         if self.is_v2:
             layer._cb_compose = codec.build_compose_table(
@@ -2158,7 +2124,8 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         ok = PrismaQuantCBMoEMethod._EXPAND_EXT_OK
         if ok is None:
             from .cuda_ext import get_ext
-            ok = get_ext() is not None
+            ext = get_ext()
+            ok = ext is not None and hasattr(ext, "cb_expand_fp8")
             if not ok:
                 print("[prismaquant-cb] WARNING: CUDA expand extension "
                       "unavailable — stock prefill falls back to the padded "
@@ -2177,11 +2144,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         and the check wants the layer prefix for its message.)"""
         cb = getattr(layer, "_cb_flat_fp8", None)
         if cb is None:
-            cb = layer._cb_flat.to(torch.float8_e4m3fn).view(
-                torch.uint8).contiguous()
-            _assert_cast_lossless(layer._cb_flat,
-                                  cb.view(torch.float8_e4m3fn), "e4m3 flat",
-                                  self.prefix)
+            cb = codec.flat_codebook_fp8(layer._cb_flat, self.prefix)
             layer._cb_flat_fp8 = cb
         return cb
 

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -99,8 +99,48 @@ def _disable_grouped_mm(exc) -> None:
     _GROUPED_MM_OK = False
 
 
+# The codebook-table casts at load are proven exact only for LATTICE tables.
+# ``codec.build_flat_codebook`` casts every sub-table to **bf16**, and
+# ``_stock_cb_flat_fp8`` casts that flat table to **e4m3**; both are exact for
+# values that already sit on those grids, which is why every artifact shipped
+# to date passes by construction (their metadata says ``codebook_source:
+# "lattice"``). A LEARNED table can carry off-grid values that these casts
+# round silently at load — the packed weight bytes are untouched, every shape
+# and uniformity assert still passes, and the decode is then "correct" against
+# a table that is not the one the model was quantized with. Nothing downstream
+# can see that, so check the casts here instead: raise, with the numbers, and
+# leave one env escape for debugging.
+def _assert_cast_lossless(raw, cast, what: str, prefix: str) -> None:
+    """``cast`` must represent ``raw`` exactly.  Raises ``ValueError`` unless
+    ``PRISMAQUANT_SKIP_CB_CAST_CHECK=1``, in which case it warns on stderr."""
+    a = raw.float().reshape(-1)
+    b = cast.float().reshape(-1)
+    same_size = a.numel() == b.numel()
+    if same_size and torch.equal(a, b):
+        return
+    n = int((a != b).sum()) if same_size else -1
+    worst = float((a - b).abs().max()) if same_size else -1.0
+    rel = float((a - b).abs().div(a.abs().clamp_min(1e-12)).max()) \
+        if same_size else -1.0
+    msg = (f"[prismaquant] {prefix}: the {what} codebook cast is LOSSY — "
+           f"{n} of {a.numel()} table values do not survive it "
+           f"(max abs {worst:.3e}, max rel {rel:.3e}). The cast is exact only "
+           f"for on-grid (lattice) tables; a LEARNED codebook must be emitted "
+           f"on the target grid by the encoder, or every CB weight decodes "
+           f"against a silently-rounded table. "
+           f"PRISMAQUANT_SKIP_CB_CAST_CHECK=1 overrides (debug only).")
+    if os.environ.get("PRISMAQUANT_SKIP_CB_CAST_CHECK") == "1":
+        print("WARNING " + msg, file=sys.stderr, flush=True)
+    else:
+        raise ValueError(msg)
+
+
 class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
     """CB decode for RoutedExperts (FusedMoE) — one uniform CB format per layer."""
+
+    # Process-wide fail-loud state (see _cb_expand_ext_ok / _cuda_moe_ok).
+    _EXPAND_EXT_OK: bool | None = None   # cached cuda_ext probe for the expander
+    _DECODE_ENGAGED_LOGGED = False       # one-time decode-path engagement line
 
     def __init__(self, quant_config, moe: FusedMoEConfig, scheme: dict,
                  prefix: str) -> None:
@@ -227,6 +267,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         names = ref if isinstance(ref, list) else [ref]
         subs = [codebooks[n].to(dev) for n in names]
         layer._cb_flat = codec.build_flat_codebook(subs)
+        # build_flat_codebook casts to bf16 — prove it, do not assume it.
+        _assert_cast_lossless(
+            torch.cat([t.reshape(-1).float() for t in subs]), layer._cb_flat,
+            "bf16 flat", self.prefix)
         layer._cb_row0 = torch.zeros(1, dtype=torch.int32, device=dev)
         if self.is_v2:
             layer._cb_compose = codec.build_compose_table(
@@ -2066,7 +2110,14 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             # the .contiguous() copy the Triton path required — that pair
             # cost ~26 ms/layer of pure memcpy on Laguna-256E prefill.
             # PRISMAQUANT_CB_EXPAND=triton restores the old path (bisection).
-            if os.environ.get("PRISMAQUANT_CB_EXPAND") == "triton":
+            # The extension probe is NOT optional: pq_ops.cb_expand_fp8 calls
+            # get_ext().cb_expand_fp8 with no None check of its own (ops.py's
+            # docstring says "Caller must check cuda_ext.get_ext()"), so on a
+            # host where the JIT build failed this branch raises AttributeError
+            # mid-prefill instead of falling back — breaking the fallback
+            # contract cuda_ext.py's own module docstring advertises.
+            if (os.environ.get("PRISMAQUANT_CB_EXPAND") == "triton"
+                    or not self._cb_expand_ext_ok()):
                 qwp = codec.pad_qweight(
                     packed.reshape(nE * out_f, -1).contiguous())
                 W = expand_cb_to_fp8(
@@ -2096,14 +2147,41 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         return W.view(nE, out_f, in_f)
 
     @staticmethod
-    def _stock_cb_flat_fp8(layer) -> torch.Tensor:
+    def _cb_expand_ext_ok() -> bool:
+        """Is the JIT CUDA extension (which owns ``cb_expand_fp8``) loaded?
+
+        Probed once and cached on the class; resolves at capture time with no
+        device read. ``ops.cb_expand_fp8`` dereferences ``get_ext()``
+        unconditionally, so a caller that skips this probe gets an
+        ``AttributeError`` on a host with no usable nvcc rather than the Triton
+        fallback ``cuda_ext.get_ext`` promises."""
+        ok = PrismaQuantCBMoEMethod._EXPAND_EXT_OK
+        if ok is None:
+            from .cuda_ext import get_ext
+            ok = get_ext() is not None
+            if not ok:
+                print("[prismaquant-cb] WARNING: CUDA expand extension "
+                      "unavailable — stock prefill falls back to the padded "
+                      "Triton expander (correct, measurably slower).",
+                      file=sys.stderr, flush=True)
+            PrismaQuantCBMoEMethod._EXPAND_EXT_OK = ok
+        return ok
+
+    def _stock_cb_flat_fp8(self, layer) -> torch.Tensor:
         """The per-layer codebook re-encoded to E4M3 bytes for the fp8-direct
-        expand (every CB value is on the e4m3 grid — lossless). Cached on the
-        layer (also built by the CUDA-decode gate); built once, before capture."""
+        expand. Cached on the layer (also built by the CUDA-decode gate); built
+        once, before capture. "Every CB value is on the e4m3 grid — lossless"
+        used to be a comment here; it is now a check (see
+        ``_assert_cast_lossless``), because it holds only for lattice tables.
+        (Was a ``@staticmethod``; every call site already went through ``self``,
+        and the check wants the layer prefix for its message.)"""
         cb = getattr(layer, "_cb_flat_fp8", None)
         if cb is None:
             cb = layer._cb_flat.to(torch.float8_e4m3fn).view(
                 torch.uint8).contiguous()
+            _assert_cast_lossless(layer._cb_flat,
+                                  cb.view(torch.float8_e4m3fn), "e4m3 flat",
+                                  self.prefix)
             layer._cb_flat_fp8 = cb
         return cb
 
@@ -2123,10 +2201,32 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             if ok:
                 from .cuda_ext import get_ext
                 ok = get_ext() is not None
-            if ok and not self.is_fp4 and not hasattr(layer, "_cb_flat_fp8"):
-                layer._cb_flat_fp8 = layer._cb_flat.to(
-                    torch.float8_e4m3fn).view(torch.uint8).contiguous()
+                if not ok:
+                    # This used to cache ok=False with NO log line, and apply()
+                    # then fell through to the full-E stock-prefill path AT
+                    # DECODE — numerically correct, so nothing downstream can
+                    # tell, but a different throughput class entirely. A
+                    # benchmark taken on that path looks valid and measures the
+                    # wrong thing; say so on stderr instead.
+                    print("[prismaquant-cb] WARNING: grouped CUDA decode "
+                          "extension unavailable — CB decode falls back to the "
+                          "full-E stock-prefill path. Numerics are unchanged, "
+                          "but this is NOT the served decode path: do not take "
+                          "throughput numbers from this process.",
+                          file=sys.stderr, flush=True)
+            if ok and not self.is_fp4:
+                # Single source of truth for the e4m3 cast (and its
+                # losslessness check) — this used to duplicate the cast.
+                self._stock_cb_flat_fp8(layer)
             layer._cb_moe_cuda_ok = ok
+            if ok and not PrismaQuantCBMoEMethod._DECODE_ENGAGED_LOGGED:
+                # Positive counterpart to the warning above: one line per
+                # process proving WHICH decode path a run actually engaged, so
+                # a log can settle it after the fact regardless of why the fast
+                # path might have disengaged (missing extension,
+                # PRISMAQUANT_CB_DECODE override, or an unsupported format).
+                print("[prismaquant-cb] decode=grouped-cuda", flush=True)
+                PrismaQuantCBMoEMethod._DECODE_ENGAGED_LOGGED = True
         return ok
 
     def _apply_grouped_decode(self, layer, x, topk_weights, topk_ids, act):

--- a/gridbook/moe_toplevel_loader.py
+++ b/gridbook/moe_toplevel_loader.py
@@ -293,7 +293,7 @@ def _decode_cb_linear_to_bf16(scheme: dict, cb_qweight, weight_scale,
     ref = scheme["codebook_ref"]
     names = ref if isinstance(ref, list) else [ref]
     subs = [codebooks[n].to(dev) for n in names]
-    cb_flat = codec.build_flat_codebook(subs)
+    cb_flat = codec.build_flat_codebook(subs, "shared-CB expert loader")
     qwp = codec.pad_qweight(cb_qweight.to(dev).contiguous())
     row0 = torch.zeros(out, dtype=torch.int32, device=dev)
 

--- a/gridbook/moe_toplevel_loader.py
+++ b/gridbook/moe_toplevel_loader.py
@@ -293,7 +293,8 @@ def _decode_cb_linear_to_bf16(scheme: dict, cb_qweight, weight_scale,
     ref = scheme["codebook_ref"]
     names = ref if isinstance(ref, list) else [ref]
     subs = [codebooks[n].to(dev) for n in names]
-    cb_flat = codec.build_flat_codebook(subs, "shared-CB expert loader")
+    cb_flat = codec.build_flat_codebook(
+        subs, "shared-CB expert loader", "fp4" if is_fp4 else "fp8")
     qwp = codec.pad_qweight(cb_qweight.to(dev).contiguous())
     row0 = torch.zeros(out, dtype=torch.int32, device=dev)
 

--- a/tests/test_fail_loud.py
+++ b/tests/test_fail_loud.py
@@ -1,0 +1,344 @@
+"""Three silent degrades in the CB MoE path, made loud.
+
+CPU-only, no CUDA, no nvcc, no vLLM: the expanders and the JIT-extension probe
+are monkeypatched, so what is pinned here is CONTROL FLOW and DIAGNOSTICS, not
+kernel numerics.
+
+  1. ``_expand_stack_slice``'s fp8 branch must consult ``_cb_expand_ext_ok()``
+     before reaching for ``ops.cb_expand_fp8``. That op dereferences
+     ``cuda_ext.get_ext()`` with no None check of its own, so an unguarded call
+     raises ``AttributeError`` mid-prefill on any host where the JIT build
+     failed -- instead of the Triton fallback ``cuda_ext``'s module docstring
+     advertises. ``test_ops_cb_expand_fp8_without_ext_raises`` pins the raw
+     failure mode; the two tests after it pin the guard.
+  2. ``_assert_cast_lossless`` must reject a codebook table that the bf16 /
+     e4m3 cast rounds, and must say by how much. The casts are exact only for
+     tables already on those grids.
+  3. ``_cuda_moe_ok`` must say so on stderr when the grouped CUDA decode path
+     disengages, and print one ``decode=grouped-cuda`` line per process when it
+     engages, so a log can prove which decode path a run actually used.
+
+Instances are built with ``__new__`` and explicit attributes, the same
+init-bypass the other MoE test files use (``test_moe_stock_prefill._build``,
+``test_moe_stacked``): nothing here exercises ``__init__``.
+
+Run: ``python -m pytest tests/test_fail_loud.py -q``. Like
+tests/test_target_namespace_compat.py this file injects stub ``vllm.*`` modules
+into ``sys.modules`` when vLLM is absent, so it must get its OWN pytest process
+-- which is what .github/scripts/run_cpu_tests.sh already does for every file.
+"""
+import sys
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# vLLM symbols gridbook.moe imports at module scope. Stubbed only when vLLM is
+# genuinely absent, exactly as tests/test_target_namespace_compat.py does it.
+if "vllm" not in sys.modules:
+    try:
+        import vllm  # noqa: F401
+    except Exception:
+        def _mod(name):
+            m = types.ModuleType(name)
+            sys.modules[name] = m
+            parent, _, leaf = name.rpartition(".")
+            if parent:
+                setattr(sys.modules[parent], leaf, m)
+            return m
+
+        _mod("vllm")
+        _mod("vllm.model_executor")
+        me_utils = _mod("vllm.model_executor.utils")
+        me_utils.set_weight_attrs = lambda p, attrs: None
+        _mod("vllm.model_executor.layers")
+        fm = _mod("vllm.model_executor.layers.fused_moe")
+        fm.RoutedExperts = type("RoutedExperts", (), {})
+        fmc = _mod("vllm.model_executor.layers.fused_moe.config")
+        fmc.FusedMoEConfig = type("FusedMoEConfig", (), {})
+        fmc.FusedMoEQuantConfig = type("FusedMoEQuantConfig", (), {})
+        fmb = _mod("vllm.model_executor.layers.fused_moe.fused_moe_method_base")
+        fmb.FusedMoEMethodBase = type("FusedMoEMethodBase", (), {})
+        fma = _mod("vllm.model_executor.layers.fused_moe.activation")
+        fma.MoEActivation = type("MoEActivation", (), {})
+        fma.apply_moe_activation = lambda *a, **kw: None
+
+codec = pytest.importorskip("gridbook.codec")
+moe = pytest.importorskip("gridbook.moe")
+cuda_ext = pytest.importorskip("gridbook.cuda_ext")
+
+K, N_SUB = 44, 4                       # the shipped fp8-CB rung
+TYPE_SIZE = 4 * K                      # fp8-CB superblock byte width
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_state(monkeypatch):
+    """The two fail-loud latches are PROCESS-wide by design (one line per
+    process, not per layer). Reset them around every test so ordering cannot
+    make a later test pass on an earlier test's cached probe."""
+    monkeypatch.setattr(moe.PrismaQuantCBMoEMethod, "_EXPAND_EXT_OK", None)
+    monkeypatch.setattr(moe.PrismaQuantCBMoEMethod,
+                        "_DECODE_ENGAGED_LOGGED", False)
+    monkeypatch.delenv("PRISMAQUANT_SKIP_CB_CAST_CHECK", raising=False)
+    monkeypatch.delenv("PRISMAQUANT_CB_EXPAND", raising=False)
+    monkeypatch.delenv("PRISMAQUANT_CB_DECODE", raising=False)
+
+
+def _method(prefix="model.layers.0.mlp.experts", is_fp4=False, is_v2=False):
+    m = moe.PrismaQuantCBMoEMethod.__new__(moe.PrismaQuantCBMoEMethod)
+    m.quant_config = None
+    m.scheme = {"grid": "fp8", "mode": "product", "k": K, "n_sub": N_SUB,
+                "type_size": TYPE_SIZE}
+    m.prefix = prefix
+    m.is_fp4 = is_fp4
+    m.is_v2 = is_v2
+    m.k = K
+    m.n_sub = N_SUB
+    m.type_size = TYPE_SIZE
+    m._sub_table = None
+    return m
+
+
+def _layer(E=2, hidden=256, inter=256, flat=None):
+    lay = types.SimpleNamespace()
+    lay._cb_E = E
+    lay._cb_hidden = hidden
+    lay._cb_inter = inter
+    lay._cb_flat = _on_grid_flat() if flat is None else flat
+    rb = moe._row_bytes(hidden, TYPE_SIZE)
+    lay.w13_cb_qweight = torch.zeros(E, 2 * inter, rb, dtype=torch.uint8)
+    lay.w2_cb_qweight = torch.zeros(
+        E, hidden, moe._row_bytes(inter, TYPE_SIZE), dtype=torch.uint8)
+    return lay
+
+
+def _on_grid_flat(n=64):
+    """A LATTICE-style table: every value already sits on the e4m3 grid, so
+    both the bf16 and the e4m3 cast are exact (this is why every artifact
+    shipped so far passes the check by construction)."""
+    v = torch.arange(n, dtype=torch.float32) / 64.0 - 0.5
+    return v.to(torch.float8_e4m3fn).to(torch.bfloat16)
+
+
+# --------------------------------------------------------------- (2) the cast
+def test_cast_check_accepts_an_on_grid_table():
+    flat = _on_grid_flat()
+    cast = flat.to(torch.float8_e4m3fn)
+    moe._assert_cast_lossless(flat, cast, "e4m3 flat", "t")   # must not raise
+
+
+def test_cast_check_rejects_off_grid_values_with_diagnostics():
+    """A LEARNED table can carry values between e4m3 grid points. Rounding
+    them at load is invisible downstream -- the packed weight bytes are
+    untouched and every shape/uniformity assert still passes -- so the cast has
+    to refuse, and say how bad it is."""
+    flat = _on_grid_flat(8).float()
+    # 0.5 -> next e4m3 code is 0.5625; land halfway, off-grid by construction.
+    flat[3] = 0.53125
+    cast = flat.to(torch.float8_e4m3fn)
+    with pytest.raises(ValueError) as e:
+        moe._assert_cast_lossless(flat, cast, "e4m3 flat",
+                                  "model.layers.3.mlp.experts.w13")
+    msg = str(e.value)
+    assert "LOSSY" in msg
+    assert "model.layers.3.mlp.experts.w13" in msg
+    assert "e4m3 flat" in msg
+    assert "1 of 8 table values do not survive it" in msg   # element count
+    assert "max abs" in msg and "max rel" in msg            # both error fields
+    assert "PRISMAQUANT_SKIP_CB_CAST_CHECK=1" in msg        # the escape hatch
+
+
+def test_cast_check_reports_real_error_magnitudes():
+    """The two numbers in the message are the measured errors, not adjectives."""
+    flat = torch.tensor([0.53125], dtype=torch.float32)
+    cast = flat.to(torch.float8_e4m3fn)
+    got = float(cast.float()[0])
+    with pytest.raises(ValueError) as e:
+        moe._assert_cast_lossless(flat, cast, "e4m3 flat", "t")
+    msg = str(e.value)
+    assert f"max abs {abs(0.53125 - got):.3e}" in msg
+    assert f"max rel {abs(0.53125 - got) / 0.53125:.3e}" in msg
+
+
+def test_cast_check_env_escape_warns_instead_of_raising(monkeypatch, capsys):
+    monkeypatch.setenv("PRISMAQUANT_SKIP_CB_CAST_CHECK", "1")
+    flat = torch.tensor([0.53125], dtype=torch.float32)
+    moe._assert_cast_lossless(flat, flat.to(torch.float8_e4m3fn),
+                              "e4m3 flat", "t")              # must not raise
+    err = capsys.readouterr().err
+    assert "WARNING" in err and "LOSSY" in err
+
+
+def test_stock_flat_fp8_checks_the_e4m3_cast():
+    """The load-time e4m3 re-encode in _stock_cb_flat_fp8 is the second cast;
+    "every CB value is on the e4m3 grid -- lossless" used to be a comment
+    there, with nothing enforcing it."""
+    m = _method()
+    off_grid = torch.tensor([0.53125, 0.25, -0.125], dtype=torch.bfloat16)
+    lay = _layer(flat=off_grid)
+    with pytest.raises(ValueError, match="e4m3 flat"):
+        m._stock_cb_flat_fp8(lay)
+    # an on-grid table still builds, and is cached on the layer
+    lay2 = _layer()
+    cb = m._stock_cb_flat_fp8(lay2)
+    assert cb.dtype is torch.uint8
+    assert lay2._cb_flat_fp8 is cb
+
+
+def test_process_weights_bf16_cast_is_checked():
+    """codec.build_flat_codebook casts each sub-table to bf16; the same
+    argument applies, so process_weights_after_loading checks it too."""
+    subs = [torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)]
+    moe._assert_cast_lossless(torch.cat([t.reshape(-1).float() for t in subs]),
+                              codec.build_flat_codebook(subs), "bf16 flat", "t")
+    subs_off = [torch.tensor([[1.0000001, 2.0]], dtype=torch.float32),
+                torch.tensor([[0.5]], dtype=torch.bfloat16)]   # mixed dtypes
+    with pytest.raises(ValueError, match="bf16 flat"):
+        moe._assert_cast_lossless(
+            torch.cat([t.reshape(-1).float() for t in subs_off]),
+            codec.build_flat_codebook(subs_off), "bf16 flat", "t")
+
+
+# ------------------------------------------------- (1) the expand fail-soft
+def test_ops_cb_expand_fp8_without_ext_raises(monkeypatch):
+    """THE failure this PR is about: ops.cb_expand_fp8 has no None check --
+    its docstring pushes that onto the caller (gridbook/ops.py:107) -- so an
+    unguarded call on an ext-less host is an AttributeError, not a fallback."""
+    ops = pytest.importorskip("gridbook.ops")
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: None)
+    qw = torch.zeros(4, TYPE_SIZE, dtype=torch.uint8)
+    with pytest.raises(AttributeError):
+        ops.cb_expand_fp8(qw, torch.zeros(64, dtype=torch.uint8),
+                          torch.zeros(4, dtype=torch.int32),
+                          4, 256, K, N_SUB, TYPE_SIZE)
+
+
+def test_expand_ext_probe_is_false_and_loud(monkeypatch, capsys):
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: None)
+    cls = moe.PrismaQuantCBMoEMethod
+    assert cls._cb_expand_ext_ok() is False
+    err = capsys.readouterr().err
+    assert "CUDA expand extension" in err and "WARNING" in err
+    # cached: probed once per process, no second warning, no second get_ext call
+    monkeypatch.setattr(cuda_ext, "get_ext",
+                        lambda: pytest.fail("probe was not cached"))
+    assert cls._cb_expand_ext_ok() is False
+    assert capsys.readouterr().err == ""
+
+
+def test_expand_stack_slice_falls_back_to_triton_without_ext(monkeypatch,
+                                                             capsys):
+    """With no extension the fp8 branch must take the padded Triton expander
+    and keep going -- never AttributeError out of the middle of a prefill."""
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: None)
+    ops = pytest.importorskip("gridbook.ops")
+    monkeypatch.setattr(ops, "cb_expand_fp8", lambda *a, **kw: pytest.fail(
+        "unguarded CUDA expander call on an ext-less host"))
+
+    seen = {}
+
+    def _fake_triton(qwp, lut, row0, N, Kdim, k, n_sub, ts):
+        seen["rows"] = N
+        seen["pad"] = qwp.shape[1] - TYPE_SIZE * (Kdim // codec.SUPERBLOCK)
+        return torch.zeros(N, Kdim, dtype=torch.uint8)
+
+    monkeypatch.setattr(moe, "expand_cb_to_fp8", _fake_triton)
+
+    m = _method()
+    lay = _layer(E=2, hidden=256, inter=256)
+    W = m._expand_stack_slice(lay, "w13", 0, 2, to_fp8=True)
+
+    assert seen["rows"] == 2 * (2 * 256)          # nE * out_f
+    assert seen["pad"] == codec.PAD_BYTES         # the padded Triton contract
+    assert tuple(W.shape) == (2, 2 * 256, 256)
+    assert "CUDA expand extension" in capsys.readouterr().err
+
+
+def test_expand_stack_slice_uses_the_cuda_op_when_the_ext_is_present(
+        monkeypatch):
+    """The guard must not cost the fast path: with an extension loaded the
+    branch still goes to ops.cb_expand_fp8 on the RAW unpadded slice view."""
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    ops = pytest.importorskip("gridbook.ops")
+    monkeypatch.setattr(moe, "expand_cb_to_fp8", lambda *a, **kw: pytest.fail(
+        "fell back to Triton with the extension available"))
+
+    seen = {}
+
+    def _fake_op(qw, lut, row0, N, Kdim, k, n_sub, ts):
+        seen["rows"] = N
+        seen["row_bytes"] = qw.shape[1]
+        return torch.zeros(N, Kdim, dtype=torch.uint8)
+
+    monkeypatch.setattr(ops, "cb_expand_fp8", _fake_op)
+
+    m = _method()
+    lay = _layer(E=2, hidden=256, inter=256)
+    W = m._expand_stack_slice(lay, "w13", 0, 2, to_fp8=True)
+    assert seen["rows"] == 2 * (2 * 256)
+    assert seen["row_bytes"] == moe._row_bytes(256, TYPE_SIZE)   # NOT padded
+    assert tuple(W.shape) == (2, 2 * 256, 256)
+
+
+def test_expand_env_override_still_forces_triton(monkeypatch):
+    """PRISMAQUANT_CB_EXPAND=triton keeps working with the extension loaded
+    (the bisection lever upstream documents)."""
+    monkeypatch.setenv("PRISMAQUANT_CB_EXPAND", "triton")
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    ops = pytest.importorskip("gridbook.ops")
+    monkeypatch.setattr(ops, "cb_expand_fp8", lambda *a, **kw: pytest.fail(
+        "env override ignored"))
+    seen = {}
+    monkeypatch.setattr(moe, "expand_cb_to_fp8",
+                        lambda qwp, lut, row0, N, Kd, *a: (
+                            seen.setdefault("hit", True),
+                            torch.zeros(N, Kd, dtype=torch.uint8))[1])
+    _method()._expand_stack_slice(_layer(), "w13", 0, 2, to_fp8=True)
+    assert seen.get("hit") is True
+
+
+# --------------------------------------------- (3) decode-path disengagement
+def test_decode_disengagement_is_loud(monkeypatch, capsys):
+    """No extension -> CB decode silently ran the full-E stock-prefill path.
+    Numerics are fine, which is exactly why it needs a log line: a benchmark
+    on that path looks valid and measures the wrong throughput class."""
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: None)
+    m = _method()
+    lay = _layer()
+    assert m._cuda_moe_ok(lay) is False
+    out = capsys.readouterr()
+    assert "grouped CUDA decode" in out.err and "WARNING" in out.err
+    assert "decode=grouped-cuda" not in out.out       # never claim engagement
+
+
+def test_decode_engagement_line_is_printed_once(monkeypatch, capsys):
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    m = _method()
+    assert m._cuda_moe_ok(_layer()) is True
+    assert "[prismaquant-cb] decode=grouped-cuda" in capsys.readouterr().out
+    # per PROCESS, not per layer: a 48-layer model must not print 48 lines
+    m2 = _method(prefix="model.layers.1.mlp.experts")
+    assert m2._cuda_moe_ok(_layer()) is True
+    assert "decode=grouped-cuda" not in capsys.readouterr().out
+
+
+def test_decode_env_disable_is_also_reported(monkeypatch, capsys):
+    """PRISMAQUANT_CB_DECODE=triton is a deliberate override, so it gets no
+    extension WARNING -- but it must still not print the engagement line."""
+    monkeypatch.setenv("PRISMAQUANT_CB_DECODE", "triton")
+    monkeypatch.setattr(cuda_ext, "get_ext",
+                        lambda: pytest.fail("probed despite the env gate"))
+    assert _method()._cuda_moe_ok(_layer()) is False
+    out = capsys.readouterr()
+    assert "decode=grouped-cuda" not in out.out
+
+
+def test_cuda_gate_builds_the_fp8_lut_through_the_checked_helper(monkeypatch):
+    """The gate used to duplicate the e4m3 cast inline, which would have
+    skipped the check. It now goes through _stock_cb_flat_fp8."""
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    m = _method()
+    lay = _layer(flat=torch.tensor([0.53125], dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="e4m3 flat"):
+        m._cuda_moe_ok(lay)

--- a/tests/test_fail_loud.py
+++ b/tests/test_fail_loud.py
@@ -200,6 +200,25 @@ def test_process_weights_bf16_cast_is_checked():
             codec.build_flat_codebook(subs_off), "bf16 flat", "t")
 
 
+def test_build_flat_codebook_checks_every_runtime_caller():
+    """The bf16 check belongs in the shared codec helper, not only MoE."""
+    with pytest.raises(ValueError, match="bf16 flat"):
+        codec.build_flat_codebook(
+            [torch.tensor([1.0000001], dtype=torch.float32)], "dense.layer")
+
+
+def test_build_flat_codebook_does_not_pre_round_float64_input():
+    raw = torch.tensor([1.0 + 2.0 ** -40], dtype=torch.float64)
+    with pytest.raises(ValueError, match="bf16 flat"):
+        codec.build_flat_codebook([raw], "float64.layer")
+
+
+def test_shared_fp8_reencode_helper_checks_dense_and_moe_callers():
+    flat = torch.tensor([0.53125], dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="e4m3 flat"):
+        codec.flat_codebook_fp8(flat, "dense.layer")
+
+
 # ------------------------------------------------- (1) the expand fail-soft
 def test_ops_cb_expand_fp8_without_ext_raises(monkeypatch):
     """THE failure this PR is about: ops.cb_expand_fp8 has no None check --
@@ -225,6 +244,13 @@ def test_expand_ext_probe_is_false_and_loud(monkeypatch, capsys):
                         lambda: pytest.fail("probe was not cached"))
     assert cls._cb_expand_ext_ok() is False
     assert capsys.readouterr().err == ""
+
+
+def test_expand_ext_probe_requires_the_called_symbol(monkeypatch, capsys):
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    cls = moe.PrismaQuantCBMoEMethod
+    assert cls._cb_expand_ext_ok() is False
+    assert "CUDA expand extension" in capsys.readouterr().err
 
 
 def test_expand_stack_slice_falls_back_to_triton_without_ext(monkeypatch,
@@ -259,7 +285,8 @@ def test_expand_stack_slice_uses_the_cuda_op_when_the_ext_is_present(
         monkeypatch):
     """The guard must not cost the fast path: with an extension loaded the
     branch still goes to ops.cb_expand_fp8 on the RAW unpadded slice view."""
-    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    monkeypatch.setattr(
+        cuda_ext, "get_ext", lambda: types.SimpleNamespace(cb_expand_fp8=True))
     ops = pytest.importorskip("gridbook.ops")
     monkeypatch.setattr(moe, "expand_cb_to_fp8", lambda *a, **kw: pytest.fail(
         "fell back to Triton with the extension available"))
@@ -285,7 +312,8 @@ def test_expand_env_override_still_forces_triton(monkeypatch):
     """PRISMAQUANT_CB_EXPAND=triton keeps working with the extension loaded
     (the bisection lever upstream documents)."""
     monkeypatch.setenv("PRISMAQUANT_CB_EXPAND", "triton")
-    monkeypatch.setattr(cuda_ext, "get_ext", lambda: object())
+    monkeypatch.setattr(
+        cuda_ext, "get_ext", lambda: types.SimpleNamespace(cb_expand_fp8=True))
     ops = pytest.importorskip("gridbook.ops")
     monkeypatch.setattr(ops, "cb_expand_fp8", lambda *a, **kw: pytest.fail(
         "env override ignored"))

--- a/tests/test_fail_loud.py
+++ b/tests/test_fail_loud.py
@@ -80,6 +80,8 @@ def _reset_process_state(monkeypatch):
     monkeypatch.setattr(moe.PrismaQuantCBMoEMethod, "_EXPAND_EXT_OK", None)
     monkeypatch.setattr(moe.PrismaQuantCBMoEMethod,
                         "_DECODE_ENGAGED_LOGGED", False)
+    monkeypatch.setattr(moe.PrismaQuantCBMoEMethod,
+                        "_DECODE_DISABLED_LOGGED", False)
     monkeypatch.delenv("PRISMAQUANT_SKIP_CB_CAST_CHECK", raising=False)
     monkeypatch.delenv("PRISMAQUANT_CB_EXPAND", raising=False)
     monkeypatch.delenv("PRISMAQUANT_CB_DECODE", raising=False)
@@ -129,8 +131,8 @@ def test_cast_check_accepts_an_on_grid_table():
 
 
 def test_cast_check_rejects_off_grid_values_with_diagnostics():
-    """A LEARNED table can carry values between e4m3 grid points. Rounding
-    them at load is invisible downstream -- the packed weight bytes are
+    """A malformed learned table can carry values between e4m3 grid points.
+    Rounding them at load is invisible downstream -- the packed weight bytes are
     untouched and every shape/uniformity assert still passes -- so the cast has
     to refuse, and say how bad it is."""
     flat = _on_grid_flat(8).float()
@@ -217,6 +219,30 @@ def test_shared_fp8_reencode_helper_checks_dense_and_moe_callers():
     flat = torch.tensor([0.53125], dtype=torch.bfloat16)
     with pytest.raises(ValueError, match="e4m3 flat"):
         codec.flat_codebook_fp8(flat, "dense.layer")
+
+
+@pytest.mark.parametrize("value", [0.53125, float("nan"), float("inf")])
+def test_fp4_grid_validation_rejects_malformed_tables_at_load(value):
+    with pytest.raises(ValueError, match="E2M1 grid|non-finite"):
+        codec.build_flat_codebook(
+            [torch.tensor([0.0, -6.0, value], dtype=torch.float32)],
+            "fp4.layer", "fp4")
+
+
+def test_fp4_grid_validation_accepts_learned_but_grid_valued_table():
+    # A learned table is valid; it need not equal the deterministic lattice.
+    flat = codec.build_flat_codebook(
+        [torch.tensor([-6.0, -1.5, -0.0, 0.5, 3.0])],
+        "fp4.learned", "fp4")
+    assert flat.dtype is torch.bfloat16
+
+
+@pytest.mark.parametrize("value", [0.53125, float("nan"), float("inf")])
+def test_fp8_grid_validation_rejects_malformed_tables_at_load(value):
+    with pytest.raises(ValueError, match="E4M3 grid|non-finite"):
+        codec.build_flat_codebook(
+            [torch.tensor([0.0, -0.5, value], dtype=torch.float32)],
+            "fp8.layer", "fp8")
 
 
 # ------------------------------------------------- (1) the expand fail-soft
@@ -328,9 +354,7 @@ def test_expand_env_override_still_forces_triton(monkeypatch):
 
 # --------------------------------------------- (3) decode-path disengagement
 def test_decode_disengagement_is_loud(monkeypatch, capsys):
-    """No extension -> CB decode silently ran the full-E stock-prefill path.
-    Numerics are fine, which is exactly why it needs a log line: a benchmark
-    on that path looks valid and measures the wrong throughput class."""
+    """No extension must identify disengagement without claiming a fallback."""
     monkeypatch.setattr(cuda_ext, "get_ext", lambda: None)
     m = _method()
     lay = _layer()
@@ -338,6 +362,16 @@ def test_decode_disengagement_is_loud(monkeypatch, capsys):
     out = capsys.readouterr()
     assert "grouped CUDA decode" in out.err and "WARNING" in out.err
     assert "decode=grouped-cuda" not in out.out       # never claim engagement
+
+
+def test_decode_disengagement_warning_is_process_deduplicated(monkeypatch,
+                                                               capsys):
+    monkeypatch.setattr(cuda_ext, "get_ext", lambda: None)
+    assert _method()._cuda_moe_ok(_layer()) is False
+    assert "WARNING" in capsys.readouterr().err
+    assert _method(prefix="model.layers.1.mlp.experts")._cuda_moe_ok(
+        _layer()) is False
+    assert capsys.readouterr().err == ""
 
 
 def test_decode_engagement_line_is_printed_once(monkeypatch, capsys):


### PR DESCRIPTION
Bundle 06 from the supplied archive, expanded so the fail-loud guarantees cover every runtime consumer.

Outcome:
- checks the actual cb_expand_fp8 symbol before selecting the CUDA expander
- reports grouped-decode disengagement accurately and once per process
- validates BF16 and E4M3 conversions centrally
- validates declared FP4 E2M1 and FP8 E4M3 grids, including learned tables, nonfinite values, and off-grid values
- applies validation during model loading for dense, routed-MoE, and shared/top-level expert consumers
- materializes required FP8 codebook representations before first forward/capture

Review corrections:
The submitted cast check covered only routed MoE and did not reject FP4 values such as 0.53125 that survive BF16 but are off E2M1. Its fallback warning named the wrong path and promised unchanged numerics without evidence. The follow-up commits fix both issues and deduplicate warnings.

Validation:
- 27 focused fail-loud tests pass on the CPU host
- 109 tests pass with real vLLM 0.24 in the CUDA container
- adjacent namespace, residency, top-level loader, fill-guard, and two-tier tests pass or capability-skip cleanly
- three local artifacts validate all referenced codebook/grid pairs: 4, 8, and 14 pairs
- the smallest 847 MB FP8-CB end-to-end model smoke is running as the final merge gate and will be reported here

Attribution:
Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.