### PR TITLE
cuda_ext: validate loaded extension capabilities

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -267,7 +267,7 @@ A healthy install prints `BUILD : CUDA extension LOADED`, four symbols,
 The `symbols:` line above is informational. The loader itself asserts the
 symbols its callers dereference unconditionally, so `BUILD : CUDA extension
 LOADED` already means those are present; a build that lacks one reports
-*"stale CUDA decode-GEMV extension"* and returns `UNAVAILABLE` instead of
+*"incompatible CUDA decode-GEMV extension"* and returns `UNAVAILABLE` instead of
 loading. Symbols listed there but **not** required — `cb_expand_fp8_into` is
 one — are optional bindings that older extensions may not have; their absence
 costs a fast path, not correctness.
@@ -278,15 +278,15 @@ Four distinct failures are reported differently, on purpose:
   error — a **packaging** problem with your install (reinstall gridbook).
 - **`BUILD : CUDA extension UNAVAILABLE`** preceded by a compiler error — a
   **toolchain** problem on your machine (usually no `nvcc`).
-- **`BUILD : CUDA extension UNAVAILABLE`** preceded by a *"stale ... extension"*
-  error naming missing symbols — a **build-cache** problem: the cached `.so`
-  predates the sources. Delete the directory it names and restart. See
-  [TROUBLESHOOTING.md](TROUBLESHOOTING.md#stale-jit-build-cache-the-extension-loaded-but-is-the-wrong-build).
+- **`BUILD : CUDA extension UNAVAILABLE`** preceded by an *"incompatible ...
+  extension"* error naming missing symbols — the loaded binary does not match
+  the current Python call contract. Use the named cache diagnostics and see
+  [TROUBLESHOOTING.md](TROUBLESHOOTING.md#incompatible-jit-extension-the-module-loaded-but-has-the-wrong-api).
 - **`BUILD : ... LOADED` but `RESULT : FALLBACK path`** — nothing is broken; an
   environment variable is forcing the slow path. `PRISMAQUANT_CB_DECODE=triton`
   is a bisection switch that some scripts and model cards set. Unset it.
 
-All three are covered in [TROUBLESHOOTING](TROUBLESHOOTING.md).
+All four are covered in [TROUBLESHOOTING](TROUBLESHOOTING.md).
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -264,12 +264,24 @@ PY
 A healthy install prints `BUILD : CUDA extension LOADED`, four symbols,
 `CB_DECODE : cuda`, and `RESULT : CUDA decode path`.
 
-Three distinct failures are reported differently, on purpose:
+The `symbols:` line above is informational. The loader itself asserts the
+symbols its callers dereference unconditionally, so `BUILD : CUDA extension
+LOADED` already means those are present; a build that lacks one reports
+*"stale CUDA decode-GEMV extension"* and returns `UNAVAILABLE` instead of
+loading. Symbols listed there but **not** required — `cb_expand_fp8_into` is
+one — are optional bindings that older extensions may not have; their absence
+costs a fast path, not correctness.
+
+Four distinct failures are reported differently, on purpose:
 
 - **`cb_gemv.cu found: False`** plus an *"installed without its CUDA sources"*
   error — a **packaging** problem with your install (reinstall gridbook).
 - **`BUILD : CUDA extension UNAVAILABLE`** preceded by a compiler error — a
   **toolchain** problem on your machine (usually no `nvcc`).
+- **`BUILD : CUDA extension UNAVAILABLE`** preceded by a *"stale ... extension"*
+  error naming missing symbols — a **build-cache** problem: the cached `.so`
+  predates the sources. Delete the directory it names and restart. See
+  [TROUBLESHOOTING.md](TROUBLESHOOTING.md#stale-jit-build-cache-the-extension-loaded-but-is-the-wrong-build).
 - **`BUILD : ... LOADED` but `RESULT : FALLBACK path`** — nothing is broken; an
   environment variable is forcing the slow path. `PRISMAQUANT_CB_DECODE=triton`
   is a bisection switch that some scripts and model cards set. Unset it.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,6 +15,7 @@ for "gridbook" will find nothing. Search for **`[prismaquant-cb]`**.
 
 - [The CUDA extension did not load (Triton fallback)](#the-cuda-extension-did-not-load-triton-fallback)
 - [Broken install: CUDA sources missing from the package](#broken-install-cuda-sources-missing-from-the-package)
+- [Incompatible JIT extension: the module loaded but has the wrong API](#incompatible-jit-extension-the-module-loaded-but-has-the-wrong-api)
 - [Fused prefill extension unavailable](#fused-prefill-extension-unavailable)
 - [Invalid quantization method: gridbook](#invalid-quantization-method-gridbook)
 - [Missing codebook sidecar or quant config](#missing-codebook-sidecar-or-quant-config)
@@ -102,45 +103,49 @@ found` must print `True`. Do **not** work around this by copying `csrc/` into
 
 ---
 
-## Stale JIT build cache: the extension loaded but is the wrong build
+## Incompatible JIT extension: the module loaded but has the wrong API
 
 **Symptom** — on stderr:
 
 ```
-[prismaquant-cb] ERROR: stale CUDA decode-GEMV extension — the extension built
-from cb_gemv.cu loaded from /opt/gridbook/ext-cache, but does not export
-['cb_gemv_fp4_v2'] (needs [...]). The JIT build cache is persistent and shared
-by design, so the usual cause is a STALE .so left there by an older cb_gemv.cu
-— the current source was never compiled. Delete /opt/gridbook/ext-cache and
-start again ...
+[prismaquant-cb] ERROR: incompatible CUDA decode-GEMV extension — the module
+loaded for cb_gemv.cu from '<module path>' does not satisfy the current call
+contract: missing ['cb_gemv_fp4_v2']; every required symbol is [...]. requested
+build directory '/opt/gridbook/ext-cache' has mode ..., owner uid:gid ..., and
+is ... by this process. Clear this extension's build directory ...
 ```
 
-Same message shape for `stale fused prefill extension` and, as a
-`UserWarning`, `stale persistent-TC ext`.
+The persistent-TC and fused loaders report the same module path, missing
+contract, and build-directory diagnostics. They remain fail-soft and return
+`None`, so their callers take the existing correct fallback.
 
-**Cause** — the build cache is *meant* to persist across restarts
+**Cause** — this symptom proves only that a module loaded successfully but does
+not export the API the current Python code will call. A stale or corrupt build
+artifact is possible, especially when one cache is carried across upgrades or
+image versions; an unexpected module supplied by the environment is another
+possibility. The error reports both the loaded module's `__file__` and the
+requested build directory so those cases can be distinguished.
+
+The build cache is *meant* to persist across restarts
 ([persisting the cache](INSTALL.md#persisting-the-jit-build-cache); the
-reference image pins `PRISMAQUANT_CB_EXT_DIR=/opt/gridbook/ext-cache`). When
-the cached `.so` is not rebuilt, the process runs a binary from older sources.
-The two ways to get there:
+reference image pins `PRISMAQUANT_CB_EXT_DIR=/opt/gridbook/ext-cache`), but use
+one cache directory per gridbook version when mounting it from the host.
 
-* **one cache directory, two gridbook versions** — a host directory mounted
-  into images of different versions, or a package upgrade/rollback against a
-  kept cache;
-* **the cache is not writable by the serving user** — most often a directory
-  created root-owned by an earlier `docker run` without `--user`, so the
-  rebuild cannot land.
+An **unwritable cache does not by itself explain a successfully loaded old
+module**. PyTorch normally needs to acquire a lock and write build metadata or
+outputs before loading; insufficient permissions ordinarily raise during that
+lock/build phase and land in the separate *"extension could not be built"*
+warning. Check ownership when that warning contains `PermissionError`, rather
+than inferring root ownership from a missing-symbol error.
 
 **Fix** — delete the directory (or point `PRISMAQUANT_CB_EXT_DIR` at a fresh
-one) and restart; you pay one ~30 s rebuild. If it recurs, check the ownership
-and mode of the directory from *inside* the serving container:
+one) and restart; you pay one ~30 s rebuild. Compare the module path in the
+error with the requested cache path. If a build error reports permissions,
+inspect the directory from *inside* the serving container:
 
 ```bash
-docker exec <container> ls -ld "$PRISMAQUANT_CB_EXT_DIR"
-docker exec <container> id
+docker exec <container> sh -lc 'ls -ld "$PRISMAQUANT_CB_EXT_DIR"; id'
 ```
-
-Use one cache directory per gridbook version if you mount one from the host.
 
 **Why it is reported rather than tolerated** — until the loaders checked, the
 module was returned unexamined. A missing symbol then surfaced either as

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -102,6 +102,55 @@ found` must print `True`. Do **not** work around this by copying `csrc/` into
 
 ---
 
+## Stale JIT build cache: the extension loaded but is the wrong build
+
+**Symptom** — on stderr:
+
+```
+[prismaquant-cb] ERROR: stale CUDA decode-GEMV extension — the extension built
+from cb_gemv.cu loaded from /opt/gridbook/ext-cache, but does not export
+['cb_gemv_fp4_v2'] (needs [...]). The JIT build cache is persistent and shared
+by design, so the usual cause is a STALE .so left there by an older cb_gemv.cu
+— the current source was never compiled. Delete /opt/gridbook/ext-cache and
+start again ...
+```
+
+Same message shape for `stale fused prefill extension` and, as a
+`UserWarning`, `stale persistent-TC ext`.
+
+**Cause** — the build cache is *meant* to persist across restarts
+([persisting the cache](INSTALL.md#persisting-the-jit-build-cache); the
+reference image pins `PRISMAQUANT_CB_EXT_DIR=/opt/gridbook/ext-cache`). When
+the cached `.so` is not rebuilt, the process runs a binary from older sources.
+The two ways to get there:
+
+* **one cache directory, two gridbook versions** — a host directory mounted
+  into images of different versions, or a package upgrade/rollback against a
+  kept cache;
+* **the cache is not writable by the serving user** — most often a directory
+  created root-owned by an earlier `docker run` without `--user`, so the
+  rebuild cannot land.
+
+**Fix** — delete the directory (or point `PRISMAQUANT_CB_EXT_DIR` at a fresh
+one) and restart; you pay one ~30 s rebuild. If it recurs, check the ownership
+and mode of the directory from *inside* the serving container:
+
+```bash
+docker exec <container> ls -ld "$PRISMAQUANT_CB_EXT_DIR"
+docker exec <container> id
+```
+
+Use one cache directory per gridbook version if you mount one from the host.
+
+**Why it is reported rather than tolerated** — until the loaders checked, the
+module was returned unexamined. A missing symbol then surfaced either as
+`AttributeError: module 'prismaquant_cb_ext' has no attribute '<name>'` raised
+mid-forward from inside a custom op, or — for the optional bindings, which read
+an absent symbol as "an older build" — as no error at all and a quietly slower
+server.
+
+---
+
 ## Fused prefill extension unavailable
 
 **Symptom**

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -184,11 +184,13 @@ def _require_any_symbol_family(mod, families, *, build_dir: str, source: str):
 
 
 # Symbols ``get_ext()``'s module must export, asserted on EVERY load rather
-# than only at build time. Each is dereferenced unconditionally by a custom op
-# in ``ops.py`` -- there is no probe upstream of these, so a module missing one
-# is strictly worse than no module at all:
+# than only at build time. Most are dereferenced unconditionally by a custom op
+# in ``ops.py``. ``fp4_act_qdq`` does have a correct codec fallback, but keeping
+# it in the same revision contract prevents a pre-QDQ cache from being accepted
+# as the current main extension and silently losing the single-launch path.
 _EXT_SYMBOLS = (
     "fp8_act_qdq",          # ops.fp8_act_qdq
+    "fp4_act_qdq",          # ops.fp4_act_qdq
     "cb_gemv_fp8",          # ops.cb_gemv_fp8
     "cb_gemv_fp4_v2",       # ops.cb_gemv_fp4_v2
     "cb_expand_fp8",        # ops.cb_expand_fp8

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -18,6 +18,14 @@ container start; mount a host dir over it to persist). Never ``/tmp``.
 (~30 s is measured: cold ``get_ext()`` in ``vllm-node:latest``, no ``--gpus``,
 ``TORCH_CUDA_ARCH_LIST=12.1`` -> 29.4 s / 29.7 s on two runs.)
 
+Because that cache is persistent and reused, every loader here asserts the
+symbol set its callers need before returning the module — see
+:func:`_require_symbols`.
+A ``.so`` left in the cache by an older ``.cu`` would otherwise be handed back
+unexamined, and the miss would surface as an ``AttributeError`` mid-forward —
+or, worse, as a silent degrade where an optional-binding probe reads the stale
+module as "an older build".
+
 No fast-math: the QDQ kernel's division/conversion rounding must match torch
 bit-for-bit.
 """
@@ -43,6 +51,17 @@ class IncompleteInstallError(FileNotFoundError):
     Distinct from "no nvcc": this is a packaging/installation defect, not a
     property of the user's machine, and it is reported differently so the two
     are never confused.
+    """
+
+
+class StaleExtensionError(RuntimeError):
+    """An extension loaded, but does not export a symbol its callers need.
+
+    A third, distinct failure class: the toolchain worked and the package is
+    complete, but the binary that came out of the build cache is not the one
+    the current sources describe. That is a *deployment* defect, like
+    :class:`IncompleteInstallError` and unlike "this machine has no nvcc", so
+    it is reported at ERROR and it names the directory to delete.
     """
 
 
@@ -86,6 +105,64 @@ def _require_csrc(*names: str) -> str:
     return d
 
 
+def _require_symbols(mod, names, *, build_dir: str, source: str):
+    """Return ``mod``, refusing it unless it exports every name in ``names``.
+
+    ``torch.utils.cpp_extension.load`` hands back whatever the build cache
+    produced, and until this check nothing in the package ever looked at the
+    result. A cache that yields an OLD ``.so`` therefore surfaces only when a
+    call site dereferences a symbol that the old source never had: an
+    ``AttributeError`` raised from inside a ``torch.library.custom_op`` body
+    (``ops.py``), i.e. mid-forward and possibly mid-capture, whose message
+    names the attribute but not the directory that has to be deleted. Some
+    misses do not even raise — the optional-binding probes
+    (``ops.cb_expand_fp8_into_available``) read a missing symbol as "older
+    build", so a stale cache silently costs a fast path instead.
+
+    The cache is *designed* to be persistent and reused across restarts
+    (``PRISMAQUANT_CB_EXT_DIR``; docs/INSTALL.md "Persisting the JIT build
+    cache"; the reference image pins it to ``/opt/gridbook/ext-cache``), so
+    "the cache outlived the sources" is a supported configuration reached by
+    following the docs, not an exotic one.
+
+    ``names`` is deliberately only the symbols the package calls WITHOUT a
+    guard. Bindings that ship independently keep their existing call-site
+    ``hasattr`` probes and must stay optional, or this check would turn a
+    working degrade into a hard fallback: ``cb_expand_fp8_into``
+    (``ops.cb_expand_fp8_into_available``), the ``l2_*`` window API
+    (``moe.PrismaQuantCBMoEMethod._l2_ext_call``), and the grouped-MoE fused
+    bindings (``moe.PrismaQuantCBMoEMethod._gf2_ok`` / ``_gf2_tile_sizes``).
+    """
+    missing = [n for n in names if not hasattr(mod, n)]
+    if missing:
+        raise StaleExtensionError(
+            f"the extension built from {source} loaded from {build_dir}, but "
+            f"does not export {missing} (needs {list(names)}). The JIT build "
+            f"cache is persistent and shared by design, so the usual cause is "
+            f"a STALE .so left there by an older {source} — the current "
+            f"source was never compiled. Delete {build_dir} and start again, "
+            f"or point PRISMAQUANT_CB_EXT_DIR at a fresh dir. Check that the "
+            f"serving user can WRITE that directory: a cache dir owned by "
+            f"another user (e.g. created by an earlier `docker run` without "
+            f"`--user`) is the common way a rebuild does not happen.")
+    return mod
+
+
+# Symbols ``get_ext()``'s module must export, asserted on EVERY load rather
+# than only at build time. Each is dereferenced unconditionally by a custom op
+# in ``ops.py`` -- there is no probe upstream of these, so a module missing one
+# is strictly worse than no module at all:
+_EXT_SYMBOLS = (
+    "fp8_act_qdq",          # ops.fp8_act_qdq
+    "cb_gemv_fp8",          # ops.cb_gemv_fp8
+    "cb_gemv_fp4_v2",       # ops.cb_gemv_fp4_v2
+    "cb_expand_fp8",        # ops.cb_expand_fp8
+    "cb_moe_gemv_fp8",      # ops.cb_moe_gemv_fp8
+    "cb_moe_gemv_fp4_v2",   # ops.cb_moe_gemv_fp4_v2
+    "cb_moe_combine",       # ops.cb_moe_combine
+)
+
+
 def get_ext():
     """The compiled extension module, or None if unavailable."""
     global _ext, _tried
@@ -100,9 +177,23 @@ def get_ext():
         build_dir = os.environ.get("PRISMAQUANT_CB_EXT_DIR") or os.path.join(
             os.path.expanduser("~"), ".cache", "prismaquant-cb-ext")
         os.makedirs(build_dir, exist_ok=True)
-        _ext = load(name="prismaquant_cb_ext", sources=[src],
-                    build_directory=build_dir,
-                    extra_cuda_cflags=["-O3"], verbose=False)
+        mod = load(name="prismaquant_cb_ext", sources=[src],
+                   build_directory=build_dir,
+                   extra_cuda_cflags=["-O3"], verbose=False)
+        # Assign only after the symbol set checks out: a module missing one of
+        # these must never become the value `get_ext()` returns.
+        _ext = _require_symbols(mod, _EXT_SYMBOLS, build_dir=build_dir,
+                                source="cb_gemv.cu")
+    except StaleExtensionError as exc:
+        # Same severity as IncompleteInstallError and for the same reason: a
+        # deployment defect the operator can fix, not a property of the box.
+        # The cost of the fallback is the figure sourced in the arm below.
+        print(f"[prismaquant-cb] ERROR: stale CUDA decode-GEMV extension — "
+              f"{exc} Falling back to the Triton decode path until the cache "
+              f"is cleared: correct, but not production-eligible "
+              f"(docs/BENCHMARKS.md).",
+              file=sys.stderr, flush=True)
+        _ext = None
     except IncompleteInstallError as exc:
         # The speed figure is sourced, not asserted: docs/BENCHMARKS.md records
         # the CUDA grouped-GEMV decode path taking the reference 35B MoE
@@ -151,6 +242,10 @@ def _find_cutlass_include() -> str:
 _ptc = None
 _ptc_tried = False
 
+# ops.cb_prefill_persistent_tc dereferences this straight after the None check
+# (it has no probe), and it is the only binding cb_persistent_tc.cu exports.
+_PTC_SYMBOLS = ("cb_prefill_persistent_tc",)
+
 
 def get_persistent_ext():
     """JIT build/load of the persistent-N tensor-core prefill kernel
@@ -175,11 +270,21 @@ def get_persistent_ext():
         build_dir = os.path.join(build_dir, "ptc")
         os.makedirs(build_dir, exist_ok=True)
         cut = _find_cutlass_include()
-        _ptc = load(name="pq_cb_ptc",
-                    sources=[os.path.join(src_dir, "cb_persistent_tc.cu")],
-                    extra_include_paths=[cut, src_dir],
-                    extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
-                    build_directory=build_dir, verbose=False)
+        mod = load(name="pq_cb_ptc",
+                   sources=[os.path.join(src_dir, "cb_persistent_tc.cu")],
+                   extra_include_paths=[cut, src_dir],
+                   extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
+                   build_directory=build_dir, verbose=False)
+        _ptc = _require_symbols(mod, _PTC_SYMBOLS, build_dir=build_dir,
+                                source="cb_persistent_tc.cu")
+    except StaleExtensionError as exc:
+        # Worth a warning even though this ext is opt-in: without it the None
+        # return makes ops.cb_prefill_persistent_tc report "ext not enabled
+        # (PRISMAQUANT_ENABLE_PTC=1)", which is the wrong diagnosis for someone
+        # who has just set that variable.
+        import warnings
+        warnings.warn(f"stale persistent-TC ext — {exc}")
+        _ptc = None
     except IncompleteInstallError as exc:
         import warnings
         warnings.warn(f"broken gridbook install — {exc}")
@@ -252,6 +357,16 @@ def get_fused_fp4_ext():
     return _fused_fp4
 
 
+# The one binding this module exists for: BOTH fused entry points gate the
+# whole path on it (moe.PrismaQuantCBMoEMethod._gf_ok and the mid-M branch of
+# linear.PrismaQuantCBLinearMethod._apply_inline), so a module without it is
+# functionally identical to None -- except that it costs a multi-minute CUTLASS
+# build and hides the reason for the degrade. Everything else cb_fused_gemm.cu
+# exports stays OPTIONAL and keeps its call-site probe: the grouped-MoE
+# bindings ship independently of this one by design (moe.py, _gf2_ok).
+_FUSED_SYMBOLS = ("cb_fused_prefill_mm_scaled",)
+
+
 def get_fused_ext():
     """The CUTLASS decode-in-prologue prefill extension (cb_fused_gemm.cu),
     or None. Separate module from the GEMV ext: it needs the CUTLASS headers
@@ -288,14 +403,21 @@ def get_fused_ext():
             os.path.expanduser("~"), ".cache", "prismaquant-cb-ext"))
         build_dir = os.path.join(build_dir, "fused")
         os.makedirs(build_dir, exist_ok=True)
-        _fused = load(name="pq_cb_fused",
-                      sources=[os.path.join(src_dir, "cb_fused_gemm.cu")],
-                      extra_include_paths=[os.path.join(cut, "include"),
-                                           os.path.join(cut, "tools", "util",
-                                                        "include"),
-                                           src_dir],
-                      extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
-                      build_directory=build_dir, verbose=False)
+        mod = load(name="pq_cb_fused",
+                   sources=[os.path.join(src_dir, "cb_fused_gemm.cu")],
+                   extra_include_paths=[os.path.join(cut, "include"),
+                                        os.path.join(cut, "tools", "util",
+                                                     "include"),
+                                        src_dir],
+                   extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
+                   build_directory=build_dir, verbose=False)
+        _fused = _require_symbols(mod, _FUSED_SYMBOLS, build_dir=build_dir,
+                                  source="cb_fused_gemm.cu")
+    except StaleExtensionError as exc:
+        print(f"[prismaquant-cb] ERROR: stale fused prefill extension — {exc} "
+              f"Mid-M prefill stays on the transient expand path.",
+              file=sys.stderr, flush=True)
+        _fused = None
     except IncompleteInstallError as exc:
         print(f"[prismaquant-cb] ERROR: broken gridbook install — {exc} "
               f"Mid-M prefill stays on the transient expand path.",

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -18,13 +18,11 @@ container start; mount a host dir over it to persist). Never ``/tmp``.
 (~30 s is measured: cold ``get_ext()`` in ``vllm-node:latest``, no ``--gpus``,
 ``TORCH_CUDA_ARCH_LIST=12.1`` -> 29.4 s / 29.7 s on two runs.)
 
-Because that cache is persistent and reused, every loader here asserts the
-symbol set its callers need before returning the module — see
-:func:`_require_symbols`.
-A ``.so`` left in the cache by an older ``.cu`` would otherwise be handed back
-unexamined, and the miss would surface as an ``AttributeError`` mid-forward —
-or, worse, as a silent degrade where an optional-binding probe reads the stale
-module as "an older build".
+Every loader validates the symbols its callers will use before returning a
+module. Strict call contracts use :func:`_require_symbols`; fused FP4 uses
+independent symbol families because its dense and grouped call sites are
+separately guarded. An incompatible module would otherwise fail with
+``AttributeError`` mid-forward, or silently disable a probed fast path.
 
 No fast-math: the QDQ kernel's division/conversion rounding must match torch
 bit-for-bit.
@@ -55,13 +53,12 @@ class IncompleteInstallError(FileNotFoundError):
 
 
 class StaleExtensionError(RuntimeError):
-    """An extension loaded, but does not export a symbol its callers need.
+    """A loaded extension does not satisfy its current Python call contract.
 
-    A third, distinct failure class: the toolchain worked and the package is
-    complete, but the binary that came out of the build cache is not the one
-    the current sources describe. That is a *deployment* defect, like
-    :class:`IncompleteInstallError` and unlike "this machine has no nvcc", so
-    it is reported at ERROR and it names the directory to delete.
+    Kept separate from :class:`IncompleteInstallError` and compiler failures:
+    loading succeeded, but the resulting Python module is incompatible. A
+    stale/corrupt cache entry is one possible cause; so is an unexpected module
+    on the import path. The diagnostic names both the module and build cache.
     """
 
 
@@ -105,47 +102,85 @@ def _require_csrc(*names: str) -> str:
     return d
 
 
+def _cache_diagnostics(build_dir: str) -> str:
+    """Describe a JIT build directory without claiming why a load went stale.
+
+    An unwritable directory normally fails while acquiring the build lock or
+    writing build products; it is not evidence that ``load`` reused an old
+    module. Reporting the observed path/mode/owner/access lets an operator
+    distinguish that build failure from a binary API mismatch.
+    """
+    path = os.path.abspath(os.path.expanduser(os.fspath(build_dir)))
+    try:
+        info = os.stat(path)
+    except OSError as exc:
+        return (f"requested build directory {path!r} cannot be stat'ed "
+                f"({type(exc).__name__}: {exc})")
+    writable = os.access(path, os.W_OK | os.X_OK)
+    return (f"requested build directory {path!r} has mode "
+            f"{info.st_mode & 0o7777:04o}, owner uid:gid "
+            f"{info.st_uid}:{info.st_gid}, and is "
+            f"{'writable' if writable else 'not writable'} by this process")
+
+
+def _module_location(mod) -> str:
+    path = getattr(mod, "__file__", None)
+    return repr(os.fspath(path)) if path is not None else "<unknown>"
+
+
+def _mismatch_message(mod, *, build_dir: str, source: str,
+                      requirement: str) -> str:
+    return (
+        f"the module loaded for {source} from {_module_location(mod)} does not "
+        f"satisfy the current call contract: {requirement}. "
+        f"{_cache_diagnostics(build_dir)}. Clear this extension's build "
+        f"directory (or choose a fresh PRISMAQUANT_CB_EXT_DIR) and restart. "
+        f"A stale/corrupt cache or unexpected module is possible. If the "
+        f"build itself reported PermissionError, fix the directory ownership "
+        f"or mode; an unwritable cache ordinarily fails at lock/build time "
+        f"rather than proving that an old binary was reused."
+    )
+
+
 def _require_symbols(mod, names, *, build_dir: str, source: str):
     """Return ``mod``, refusing it unless it exports every name in ``names``.
 
-    ``torch.utils.cpp_extension.load`` hands back whatever the build cache
-    produced, and until this check nothing in the package ever looked at the
-    result. A cache that yields an OLD ``.so`` therefore surfaces only when a
-    call site dereferences a symbol that the old source never had: an
-    ``AttributeError`` raised from inside a ``torch.library.custom_op`` body
-    (``ops.py``), i.e. mid-forward and possibly mid-capture, whose message
-    names the attribute but not the directory that has to be deleted. Some
-    misses do not even raise — the optional-binding probes
-    (``ops.cb_expand_fp8_into_available``) read a missing symbol as "older
-    build", so a stale cache silently costs a fast path instead.
-
-    The cache is *designed* to be persistent and reused across restarts
-    (``PRISMAQUANT_CB_EXT_DIR``; docs/INSTALL.md "Persisting the JIT build
-    cache"; the reference image pins it to ``/opt/gridbook/ext-cache``), so
-    "the cache outlived the sources" is a supported configuration reached by
-    following the docs, not an exotic one.
-
-    ``names`` is deliberately only the symbols the package calls WITHOUT a
-    guard. Bindings that ship independently keep their existing call-site
-    ``hasattr`` probes and must stay optional, or this check would turn a
-    working degrade into a hard fallback: ``cb_expand_fp8_into``
-    (``ops.cb_expand_fp8_into_available``), the ``l2_*`` window API
-    (``moe.PrismaQuantCBMoEMethod._l2_ext_call``), and the grouped-MoE fused
-    bindings (``moe.PrismaQuantCBMoEMethod._gf2_ok`` / ``_gf2_tile_sizes``).
+    ``names`` must contain only symbols called without an upstream capability
+    probe. The helper intentionally keeps a small, stable signature so new JIT
+    loaders can share the same diagnostics.
     """
-    missing = [n for n in names if not hasattr(mod, n)]
+    required = tuple(names)
+    missing = [name for name in required if not hasattr(mod, name)]
     if missing:
-        raise StaleExtensionError(
-            f"the extension built from {source} loaded from {build_dir}, but "
-            f"does not export {missing} (needs {list(names)}). The JIT build "
-            f"cache is persistent and shared by design, so the usual cause is "
-            f"a STALE .so left there by an older {source} — the current "
-            f"source was never compiled. Delete {build_dir} and start again, "
-            f"or point PRISMAQUANT_CB_EXT_DIR at a fresh dir. Check that the "
-            f"serving user can WRITE that directory: a cache dir owned by "
-            f"another user (e.g. created by an earlier `docker run` without "
-            f"`--user`) is the common way a rebuild does not happen.")
+        requirement = (f"missing {missing}; every required symbol is "
+                       f"{list(required)}")
+        raise StaleExtensionError(_mismatch_message(
+            mod, build_dir=build_dir, source=source,
+            requirement=requirement))
     return mod
+
+
+def _require_any_symbol_family(mod, families, *, build_dir: str, source: str):
+    """Return ``mod`` when at least one independent call family is complete.
+
+    ``families`` is an iterable of ``(label, required_symbols)`` pairs. A
+    fused module may legitimately carry dense-prefill bindings, grouped-MoE
+    bindings, or both. Missing an entire family preserves its call-site
+    fallback; a module with no complete useful family is refused.
+    """
+    normalized = tuple((label, tuple(names)) for label, names in families)
+    if not normalized or any(not names for _label, names in normalized):
+        raise ValueError("symbol families must be non-empty")
+    if any(all(hasattr(mod, name) for name in names)
+           for _label, names in normalized):
+        return mod
+    detail = "; ".join(
+        f"{label} needs {list(names)} (missing "
+        f"{[name for name in names if not hasattr(mod, name)]})"
+        for label, names in normalized)
+    raise StaleExtensionError(_mismatch_message(
+        mod, build_dir=build_dir, source=source,
+        requirement=f"no usable symbol family; {detail}"))
 
 
 # Symbols ``get_ext()``'s module must export, asserted on EVERY load rather
@@ -185,10 +220,10 @@ def get_ext():
         _ext = _require_symbols(mod, _EXT_SYMBOLS, build_dir=build_dir,
                                 source="cb_gemv.cu")
     except StaleExtensionError as exc:
-        # Same severity as IncompleteInstallError and for the same reason: a
-        # deployment defect the operator can fix, not a property of the box.
-        # The cost of the fallback is the figure sourced in the arm below.
-        print(f"[prismaquant-cb] ERROR: stale CUDA decode-GEMV extension — "
+        # Loading succeeded, so distinguish an incompatible module from source
+        # packaging and compiler/toolchain failures.
+        print(f"[prismaquant-cb] ERROR: incompatible CUDA decode-GEMV "
+              f"extension — "
               f"{exc} Falling back to the Triton decode path until the cache "
               f"is cleared: correct, but not production-eligible "
               f"(docs/BENCHMARKS.md).",
@@ -283,7 +318,7 @@ def get_persistent_ext():
         # (PRISMAQUANT_ENABLE_PTC=1)", which is the wrong diagnosis for someone
         # who has just set that variable.
         import warnings
-        warnings.warn(f"stale persistent-TC ext — {exc}")
+        warnings.warn(f"incompatible persistent-TC ext — {exc}")
         _ptc = None
     except IncompleteInstallError as exc:
         import warnings
@@ -298,6 +333,16 @@ def get_persistent_ext():
 
 _fused_fp4 = None
 _fused_fp4_tried = False
+
+
+# Both families are guarded independently at their call sites
+# (linear._try_fused_fp4 and moe._gf4_ok). A binary containing either family
+# remains useful and must not be rejected merely because the other was built
+# from a different revision.
+_FUSED_FP4_SYMBOL_FAMILIES = (
+    ("dense prefill", ("cb_fused_fp4_prefill_mm_scaled",)),
+    ("grouped MoE prefill", ("cb_fused_fp4_moe_grouped",)),
+)
 
 
 def get_fused_fp4_ext():
@@ -336,13 +381,21 @@ def get_fused_fp4_ext():
         cc = torch.cuda.get_device_capability()
         arch = f"compute_{cc[0]}{cc[1]}a"
         code = f"sm_{cc[0]}{cc[1]}a"
-        _fused_fp4 = load(
+        mod = load(
             name="pq_cb_fused_fp4",
             sources=[os.path.join(src_dir, "cb_fused_fp4_gemm.cu")],
             extra_include_paths=incs + [src_dir],
             extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr",
                                f"-gencode=arch={arch},code={code}"],
             build_directory=build_dir, verbose=False)
+        _fused_fp4 = _require_any_symbol_family(
+            mod, _FUSED_FP4_SYMBOL_FAMILIES, build_dir=build_dir,
+            source="cb_fused_fp4_gemm.cu")
+    except StaleExtensionError as exc:
+        print(f"[prismaquant-cb] ERROR: incompatible fused fp4 prefill "
+              f"extension — {exc} fp4 prefill stays on the Triton/transient "
+              f"paths.", file=sys.stderr, flush=True)
+        _fused_fp4 = None
     except IncompleteInstallError as exc:
         print(f"[prismaquant-cb] ERROR: broken gridbook install — {exc} "
               f"fp4 prefill stays on the Triton/transient paths.",
@@ -357,13 +410,10 @@ def get_fused_fp4_ext():
     return _fused_fp4
 
 
-# The one binding this module exists for: BOTH fused entry points gate the
-# whole path on it (moe.PrismaQuantCBMoEMethod._gf_ok and the mid-M branch of
-# linear.PrismaQuantCBLinearMethod._apply_inline), so a module without it is
-# functionally identical to None -- except that it costs a multi-minute CUTLASS
-# build and hides the reason for the degrade. Everything else cb_fused_gemm.cu
-# exports stays OPTIONAL and keeps its call-site probe: the grouped-MoE
-# bindings ship independently of this one by design (moe.py, _gf2_ok).
+# `_gf_ok` is the prerequisite for both the dense and grouped FP8 fused paths,
+# and it dereferences this binding after its capability probe. Grouped bindings
+# remain optional additions: `_gf2_ok` requires `_gf_ok` first, then probes
+# `cb_fused_moe_grouped` and `cb_fused_moe_tile_m` separately.
 _FUSED_SYMBOLS = ("cb_fused_prefill_mm_scaled",)
 
 
@@ -377,27 +427,11 @@ def get_fused_ext():
         return _fused
     _fused_tried = True
     try:
-        import glob
-
         import torch  # noqa: F401
-        import vllm
         from torch.utils.cpp_extension import load
 
-        vroot = os.path.dirname(os.path.abspath(vllm.__file__))
-        cut = None
-        for pat in ("third_party/fmha_sm100/cutlass", "third_party/cutlass"):
-            cand = os.path.join(vroot, pat)
-            if os.path.isdir(os.path.join(cand, "include")):
-                cut = cand
-                break
-        if cut is None:
-            hits = glob.glob(os.path.join(
-                vroot, "third_party", "**", "cutlass", "include"),
-                recursive=True)
-            if hits:
-                cut = os.path.dirname(hits[0])
-        if cut is None:
-            raise FileNotFoundError("no bundled CUTLASS under vllm/third_party")
+        cut_inc = _find_cutlass_include()
+        cut_root = os.path.dirname(cut_inc)
         src_dir = _require_csrc("cb_fused_gemm.cu")
         build_dir = (os.environ.get("PRISMAQUANT_CB_EXT_DIR") or os.path.join(
             os.path.expanduser("~"), ".cache", "prismaquant-cb-ext"))
@@ -405,28 +439,30 @@ def get_fused_ext():
         os.makedirs(build_dir, exist_ok=True)
         mod = load(name="pq_cb_fused",
                    sources=[os.path.join(src_dir, "cb_fused_gemm.cu")],
-                   extra_include_paths=[os.path.join(cut, "include"),
-                                        os.path.join(cut, "tools", "util",
+                   extra_include_paths=[cut_inc,
+                                        os.path.join(cut_root, "tools", "util",
                                                      "include"),
                                         src_dir],
                    extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
                    build_directory=build_dir, verbose=False)
-        _fused = _require_symbols(mod, _FUSED_SYMBOLS, build_dir=build_dir,
+        _fused = _require_symbols(mod, _FUSED_SYMBOLS,
+                                  build_dir=build_dir,
                                   source="cb_fused_gemm.cu")
     except StaleExtensionError as exc:
-        print(f"[prismaquant-cb] ERROR: stale fused prefill extension — {exc} "
-              f"Mid-M prefill stays on the transient expand path.",
+        print(f"[prismaquant-cb] ERROR: incompatible fused prefill "
+              f"extension — {exc} Fused dense and grouped prefill stay on "
+              f"their fallback paths.",
               file=sys.stderr, flush=True)
         _fused = None
     except IncompleteInstallError as exc:
         print(f"[prismaquant-cb] ERROR: broken gridbook install — {exc} "
-              f"Mid-M prefill stays on the transient expand path.",
+              f"Fused dense and grouped prefill stay on their fallback paths.",
               file=sys.stderr, flush=True)
         _fused = None
     except Exception as exc:  # noqa: BLE001
         print(f"[prismaquant-cb] WARNING: fused prefill extension unavailable "
-              f"({type(exc).__name__}: {exc}); mid-M stays on the transient "
-              f"expand path (the shipping default — this is expected on "
+              f"({type(exc).__name__}: {exc}); fused dense and grouped "
+              f"prefill stay on their fallback paths (this is expected on "
               f"non-sm_120 GPUs and without nvcc).",
               file=sys.stderr, flush=True)
         _fused = None

--- a/tests/test_ext_symbols.py
+++ b/tests/test_ext_symbols.py
@@ -1,15 +1,12 @@
-"""Loader-side symbol assertion for the JIT extensions (``gridbook.cuda_ext``).
+"""CPU-only contract tests for :mod:`gridbook.cuda_ext` loaders.
 
-GPU-FREE and TOOLCHAIN-FREE: nothing here builds or loads a real extension.
-``_require_symbols`` is exercised against stand-in module objects, and the
-required-symbol tuples are cross-checked against the ``m.def(...)`` bindings in
-the packaged ``.cu`` sources so the two cannot drift apart. Runs anywhere the
-package imports (``cuda_ext`` itself imports only ``os`` and ``sys``); the one
-test that drives ``get_ext()`` end to end needs ``torch`` importable but never
-a GPU, an ``nvcc`` or a build -- ``load`` is monkeypatched.
-
-    python -m pytest tests/test_ext_symbols.py -q
+No extension is compiled. ``torch.utils.cpp_extension.load`` and device/CUTLASS
+discovery are replaced with stand-ins, while required symbol declarations are
+also checked against the packaged ``m.def`` bindings.
 """
+from __future__ import annotations
+
+import os
 import re
 import sys
 import types
@@ -20,69 +17,152 @@ cuda_ext = pytest.importorskip(
     "gridbook.cuda_ext", reason="gridbook not importable")
 
 
-def _stub(name, symbols):
-    """A stand-in for a torch-JIT extension module exporting ``symbols``."""
+def _stub(name, symbols, *, path=None):
     mod = types.ModuleType(name)
-    for s in symbols:
-        setattr(mod, s, lambda *a, **k: None)
+    if path is not None:
+        mod.__file__ = os.fspath(path)
+    for symbol in symbols:
+        setattr(mod, symbol, lambda *args, **kwargs: None)
     return mod
 
 
-# --------------------------------------------------------------------------
-# _require_symbols
-# --------------------------------------------------------------------------
-
-def test_complete_module_is_returned_unchanged():
-    mod = _stub("prismaquant_cb_ext", cuda_ext._EXT_SYMBOLS)
-    got = cuda_ext._require_symbols(mod, cuda_ext._EXT_SYMBOLS,
-                                    build_dir="/opt/gridbook/ext-cache",
-                                    source="cb_gemv.cu")
-    assert got is mod
+_LOADER_STATE = (
+    ("_ext", "_tried"),
+    ("_ptc", "_ptc_tried"),
+    ("_fused", "_fused_tried"),
+    ("_fused_fp4", "_fused_fp4_tried"),
+)
 
 
-def test_extra_symbols_do_not_matter():
-    """The check is a lower bound, not an equality: an extension carrying the
-    optional bindings on top of the required set is the normal case."""
-    mod = _stub("prismaquant_cb_ext",
-                (*cuda_ext._EXT_SYMBOLS, "cb_expand_fp8_into", "l2_unpin"))
+@pytest.fixture(autouse=True)
+def fresh_loaders():
+    saved = {name: getattr(cuda_ext, name)
+             for pair in _LOADER_STATE for name in pair}
+    for value_name, tried_name in _LOADER_STATE:
+        setattr(cuda_ext, value_name, None)
+        setattr(cuda_ext, tried_name, False)
+    yield
+    for name, value in saved.items():
+        setattr(cuda_ext, name, value)
+
+
+def _patch_load(monkeypatch, result=None, *, error=None):
+    pytest.importorskip("torch")
+    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
+    calls = []
+
+    def fake_load(*args, **kwargs):
+        calls.append((args, kwargs))
+        if error is not None:
+            raise error
+        return result
+
+    monkeypatch.setattr(cpp_extension, "load", fake_load)
+    return calls
+
+
+def _prepare_cutlass(monkeypatch, tmp_path):
+    cutlass = tmp_path / "cutlass" / "include"
+    cutlass.mkdir(parents=True)
+    monkeypatch.setattr(cuda_ext, "_find_cutlass_include",
+                        lambda: str(cutlass))
+    return cutlass
+
+
+def _prepare_fp4_loader(monkeypatch, tmp_path):
+    import torch
+
+    cutlass = _prepare_cutlass(monkeypatch, tmp_path)
+    monkeypatch.setenv("PRISMAQUANT_CUTLASS_INCLUDE", str(cutlass))
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (12, 1))
+
+
+# ---------------------------------------------------------------------------
+# Symbol validation and diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_complete_module_is_returned_unchanged(tmp_path):
+    mod = _stub("main", cuda_ext._EXT_SYMBOLS)
     assert cuda_ext._require_symbols(
-        mod, cuda_ext._EXT_SYMBOLS, build_dir="/cache",
+        mod, cuda_ext._EXT_SYMBOLS, build_dir=str(tmp_path),
         source="cb_gemv.cu") is mod
 
 
-def test_missing_symbol_raises_and_names_it_and_the_directory():
-    """The whole point of the error: it must say WHAT is missing and WHICH
-    directory to delete. A bare AttributeError from a call site says
-    neither."""
-    present = [s for s in cuda_ext._EXT_SYMBOLS if s != "cb_moe_combine"]
-    mod = _stub("prismaquant_cb_ext", present)
-    with pytest.raises(cuda_ext.StaleExtensionError) as ei:
-        cuda_ext._require_symbols(mod, cuda_ext._EXT_SYMBOLS,
-                                  build_dir="/opt/gridbook/ext-cache",
-                                  source="cb_gemv.cu")
-    msg = str(ei.value)
-    assert "cb_moe_combine" in msg
-    assert "/opt/gridbook/ext-cache" in msg
-    assert "cb_gemv.cu" in msg
-    assert "PRISMAQUANT_CB_EXT_DIR" in msg
+def test_extra_symbols_do_not_matter(tmp_path):
+    mod = _stub("main", (*cuda_ext._EXT_SYMBOLS, "future_binding"))
+    assert cuda_ext._require_symbols(
+        mod, cuda_ext._EXT_SYMBOLS, build_dir=str(tmp_path),
+        source="cb_gemv.cu") is mod
 
 
-def test_every_missing_symbol_is_reported_not_just_the_first():
-    """A stale .so usually lags by more than one binding; reporting one at a
-    time would mean one restart per symbol to find out."""
-    mod = _stub("prismaquant_cb_ext", ("fp8_act_qdq",))
-    with pytest.raises(cuda_ext.StaleExtensionError) as ei:
-        cuda_ext._require_symbols(mod, cuda_ext._EXT_SYMBOLS,
-                                  build_dir="/cache", source="cb_gemv.cu")
-    msg = str(ei.value)
-    for s in cuda_ext._EXT_SYMBOLS:
-        if s != "fp8_act_qdq":
-            assert s in msg, f"{s} missing from the error message"
+def test_require_symbols_accepts_a_one_shot_iterable(tmp_path):
+    names = (name for name in ("first", "second"))
+    mod = _stub("generated", ("first",))
+    with pytest.raises(cuda_ext.StaleExtensionError) as exc_info:
+        cuda_ext._require_symbols(
+            mod, names, build_dir=str(tmp_path), source="generated.cu")
+    message = str(exc_info.value)
+    assert "second" in message
+    assert "['first', 'second']" in message
 
 
-def test_stale_extension_error_is_not_confused_with_the_other_two():
-    """cuda_ext reports three different defects three different ways; the
-    except arms rely on the classes being disjoint."""
+def test_missing_symbols_report_module_and_cache_diagnostics(tmp_path):
+    module_path = tmp_path / "unexpected" / "main.so"
+    mod = _stub("main", ("fp8_act_qdq",), path=module_path)
+    with pytest.raises(cuda_ext.StaleExtensionError) as exc_info:
+        cuda_ext._require_symbols(
+            mod, cuda_ext._EXT_SYMBOLS, build_dir=str(tmp_path),
+            source="cb_gemv.cu")
+    message = str(exc_info.value)
+    for symbol in cuda_ext._EXT_SYMBOLS[1:]:
+        assert symbol in message
+    assert str(module_path) in message
+    assert str(tmp_path) in message
+    assert "mode" in message and "owner uid:gid" in message
+    assert "lock/build time" in message
+    assert "PRISMAQUANT_CB_EXT_DIR" in message
+
+
+def test_cache_diagnostics_handles_a_missing_directory(tmp_path):
+    missing = tmp_path / "not-created"
+    diagnostic = cuda_ext._cache_diagnostics(str(missing))
+    assert str(missing) in diagnostic
+    assert "cannot be stat'ed" in diagnostic
+    assert "FileNotFoundError" in diagnostic
+
+
+def test_symbol_family_accepts_either_complete_family_and_partial_other(
+        tmp_path):
+    families = (("alpha", ("a", "b")), ("gamma", ("g",)))
+    gamma = _stub("gamma", ("a", "g"))
+    alpha = _stub("alpha", ("a", "b"))
+    for mod in (gamma, alpha):
+        assert cuda_ext._require_any_symbol_family(
+            mod, families, build_dir=str(tmp_path), source="fused.cu") is mod
+
+
+def test_symbol_family_rejects_module_with_no_complete_family(tmp_path):
+    families = (("alpha", ("a", "b")), ("gamma", ("g",)))
+    mod = _stub("partial", ("a", "unrelated"))
+    with pytest.raises(cuda_ext.StaleExtensionError) as exc_info:
+        cuda_ext._require_any_symbol_family(
+            mod, families, build_dir=str(tmp_path), source="fused.cu")
+    message = str(exc_info.value)
+    assert "no usable symbol family" in message
+    assert "alpha" in message and "gamma" in message
+    assert "b" in message and "g" in message
+
+
+@pytest.mark.parametrize("families", [(), (("empty", ()),)])
+def test_symbol_family_rejects_an_invalid_contract(tmp_path, families):
+    with pytest.raises(ValueError, match="non-empty"):
+        cuda_ext._require_any_symbol_family(
+            _stub("mod", ()), families, build_dir=str(tmp_path),
+            source="fused.cu")
+
+
+def test_error_classes_are_disjoint():
     assert issubclass(cuda_ext.StaleExtensionError, RuntimeError)
     assert not issubclass(cuda_ext.StaleExtensionError,
                           cuda_ext.IncompleteInstallError)
@@ -90,21 +170,20 @@ def test_stale_extension_error_is_not_confused_with_the_other_two():
                           cuda_ext.StaleExtensionError)
 
 
-# --------------------------------------------------------------------------
-# the required sets themselves
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Declared contracts agree with the packaged extensions and call-site policy
+# ---------------------------------------------------------------------------
+
 
 _M_DEF = re.compile(r'm\.def\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')
 
 
 def _exports(cu_name):
-    """Symbol names bound by ``m.def("...")`` in a packaged CUDA source."""
-    import os
     path = os.path.join(cuda_ext.csrc_dir(), cu_name)
     if not os.path.isfile(path):
         pytest.skip(f"{cu_name} not present in this install")
-    with open(path, encoding="utf-8") as fh:
-        return set(_M_DEF.findall(fh.read()))
+    with open(path, encoding="utf-8") as source:
+        return set(_M_DEF.findall(source.read()))
 
 
 @pytest.mark.parametrize("required,cu_name", [
@@ -112,106 +191,210 @@ def _exports(cu_name):
     (cuda_ext._PTC_SYMBOLS, "cb_persistent_tc.cu"),
     (cuda_ext._FUSED_SYMBOLS, "cb_fused_gemm.cu"),
 ])
-def test_required_symbols_exist_in_the_packaged_source(required, cu_name):
-    """The assertion lists must not drift from the kernels they describe. A
-    typo here would make a HEALTHY build fail to load on every host, which is a
-    worse outcome than the bug this check exists to catch -- so pin it."""
-    exported = _exports(cu_name)
-    missing = sorted(set(required) - exported)
-    assert not missing, (
-        f"{cu_name} does not m.def() {missing}; the required-symbol tuple in "
-        f"cuda_ext is stale or misspelled")
+def test_strict_symbols_exist_in_packaged_source(required, cu_name):
+    assert not (set(required) - _exports(cu_name))
 
 
-def test_optional_bindings_stay_optional():
-    """These have call-site probes that treat absence as 'an older build' and
-    degrade correctly. Promoting any of them to required would turn a working
-    degrade into a hard fallback to Triton for every older extension."""
-    for name in ("cb_expand_fp8_into",      # ops.cb_expand_fp8_into_available
-                 "l2_pin_region", "l2_reset_window", "l2_unpin",
-                 "l2_persisting_max_bytes", "l2_max_window_bytes"):
-        assert name not in cuda_ext._EXT_SYMBOLS, (
-            f"{name} is probed at its call site and must stay optional")
+def test_fp4_symbol_families_exist_in_packaged_source():
+    exported = _exports("cb_fused_fp4_gemm.cu")
+    for _label, required in cuda_ext._FUSED_FP4_SYMBOL_FAMILIES:
+        assert not (set(required) - exported)
+
+
+def test_main_optional_bindings_stay_optional():
+    for name in ("cb_expand_fp8_into", "l2_pin_region", "l2_reset_window",
+                 "l2_unpin", "l2_persisting_max_bytes",
+                 "l2_max_window_bytes"):
+        assert name not in cuda_ext._EXT_SYMBOLS
+
+
+def test_fp8_grouped_bindings_stay_optional_after_dense_prerequisite():
     for name in ("cb_fused_moe_grouped", "cb_fused_moe_tile_m",
                  "cb_fused_moe_tile_sizes",
                  "cb_fused_moe_tile_sizes_for_kbits"):
-        assert name not in cuda_ext._FUSED_SYMBOLS, (
-            f"{name} ships independently and must stay optional")
+        assert name not in cuda_ext._FUSED_SYMBOLS
 
 
-# --------------------------------------------------------------------------
-# end to end through get_ext(), with the build monkeypatched out
-# --------------------------------------------------------------------------
-
-@pytest.fixture
-def fresh_get_ext():
-    """Reset get_ext's one-shot memo around a test, and restore it after."""
-    saved = (cuda_ext._ext, cuda_ext._tried)
-    cuda_ext._ext, cuda_ext._tried = None, False
-    yield
-    cuda_ext._ext, cuda_ext._tried = saved
+# ---------------------------------------------------------------------------
+# Main decode extension
+# ---------------------------------------------------------------------------
 
 
-def _patch_load(monkeypatch, result):
-    torch = pytest.importorskip("torch")
-    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
-    assert torch is not None
-    calls = {}
-
-    def fake_load(*args, **kwargs):
-        calls["kwargs"] = kwargs
-        return result
-
-    monkeypatch.setattr(cpp_extension, "load", fake_load)
-    return calls
-
-
-def test_get_ext_refuses_a_stale_module(monkeypatch, capsys, tmp_path,
-                                        fresh_get_ext):
-    """The regression this PR is about: a module that loaded but lacks a symbol
-    ops.py dereferences unconditionally must NOT become get_ext()'s value."""
+def test_get_ext_accepts_complete_module(monkeypatch, tmp_path):
     monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
-    stale = _stub("prismaquant_cb_ext",
-                  [s for s in cuda_ext._EXT_SYMBOLS if s != "cb_gemv_fp4_v2"])
+    good = _stub("main", cuda_ext._EXT_SYMBOLS,
+                 path=tmp_path / "prismaquant_cb_ext.so")
+    calls = _patch_load(monkeypatch, good)
+    assert cuda_ext.get_ext() is good
+    assert calls[0][1]["build_directory"] == str(tmp_path)
+
+
+def test_get_ext_refuses_incompatible_module(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    stale = _stub("main", cuda_ext._EXT_SYMBOLS[:-1],
+                  path=tmp_path / "prismaquant_cb_ext.so")
     _patch_load(monkeypatch, stale)
-
     assert cuda_ext.get_ext() is None
-    err = capsys.readouterr().err
-    assert "stale" in err.lower()
-    assert "cb_gemv_fp4_v2" in err
-    assert str(tmp_path) in err
+    error = capsys.readouterr().err
+    assert "incompatible CUDA decode-GEMV" in error
+    assert "cb_moe_combine" in error
+    assert "prismaquant_cb_ext.so" in error
 
 
-def test_get_ext_accepts_a_complete_module(monkeypatch, tmp_path,
-                                           fresh_get_ext):
-    """...and the check does not reject a healthy build."""
+def test_get_ext_is_memoized(monkeypatch, tmp_path):
     monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
-    good = _stub("prismaquant_cb_ext", cuda_ext._EXT_SYMBOLS)
-    _patch_load(monkeypatch, good)
-
+    good = _stub("main", cuda_ext._EXT_SYMBOLS)
+    calls = _patch_load(monkeypatch, good)
     assert cuda_ext.get_ext() is good
+    assert cuda_ext.get_ext() is good
+    assert len(calls) == 1
 
 
-def test_get_ext_is_still_memoised(monkeypatch, tmp_path, fresh_get_ext):
-    """One build attempt per process, unchanged: the second call must not
-    re-enter load()."""
+def test_get_ext_reports_build_exception_separately(monkeypatch, capsys,
+                                                     tmp_path):
     monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
-    good = _stub("prismaquant_cb_ext", cuda_ext._EXT_SYMBOLS)
-    n = {"calls": 0}
-    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
-
-    def counting_load(*args, **kwargs):
-        n["calls"] += 1
-        return good
-
-    monkeypatch.setattr(cpp_extension, "load", counting_load)
-    assert cuda_ext.get_ext() is good
-    assert cuda_ext.get_ext() is good
-    assert n["calls"] == 1
+    _patch_load(monkeypatch, error=PermissionError("cannot create lock"))
+    assert cuda_ext.get_ext() is None
+    error = capsys.readouterr().err
+    assert "could not be built (PermissionError: cannot create lock)" in error
+    assert "incompatible" not in error
 
 
-def test_sys_modules_untouched():
-    """Guard against this file leaking stubs into a shared pytest process the
-    way tests/test_target_namespace_compat.py does (see
-    .github/scripts/run_cpu_tests.sh)."""
-    assert "prismaquant_cb_ext" not in sys.modules
+def test_get_ext_reports_incomplete_install_separately(monkeypatch, capsys):
+    _patch_load(monkeypatch, _stub("unused", ()))
+    monkeypatch.setattr(
+        cuda_ext, "_require_csrc",
+        lambda *_names: (_ for _ in ()).throw(
+            cuda_ext.IncompleteInstallError("missing cb_gemv.cu")))
+    assert cuda_ext.get_ext() is None
+    error = capsys.readouterr().err
+    assert "broken gridbook install" in error
+    assert "missing cb_gemv.cu" in error
+
+
+# ---------------------------------------------------------------------------
+# Persistent tensor-core extension
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_loader_is_opt_in_and_does_not_build(monkeypatch):
+    calls = _patch_load(monkeypatch, _stub("ptc", cuda_ext._PTC_SYMBOLS))
+    monkeypatch.delenv("PRISMAQUANT_ENABLE_PTC", raising=False)
+    assert cuda_ext.get_persistent_ext() is None
+    assert not calls
+
+
+def test_persistent_loader_accepts_complete_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_ENABLE_PTC", "1")
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_cutlass(monkeypatch, tmp_path)
+    good = _stub("ptc", cuda_ext._PTC_SYMBOLS)
+    calls = _patch_load(monkeypatch, good)
+    assert cuda_ext.get_persistent_ext() is good
+    assert calls[0][1]["build_directory"] == str(tmp_path / "ptc")
+
+
+def test_persistent_loader_refuses_missing_binding(monkeypatch, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_ENABLE_PTC", "1")
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_cutlass(monkeypatch, tmp_path)
+    _patch_load(monkeypatch, _stub("ptc", ()))
+    with pytest.warns(UserWarning, match="incompatible persistent-TC") as seen:
+        assert cuda_ext.get_persistent_ext() is None
+    assert "cb_prefill_persistent_tc" in str(seen[0].message)
+
+
+def test_persistent_loader_reports_build_exception(monkeypatch, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_ENABLE_PTC", "1")
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_cutlass(monkeypatch, tmp_path)
+    _patch_load(monkeypatch, error=RuntimeError("nvcc failed"))
+    with pytest.warns(UserWarning, match="persistent-TC ext unavailable"):
+        assert cuda_ext.get_persistent_ext() is None
+
+
+# ---------------------------------------------------------------------------
+# Fused FP4 extension: dense and grouped families are independent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("symbols", [
+    ("cb_fused_fp4_prefill_mm_scaled",),
+    ("cb_fused_fp4_moe_grouped",),
+    ("cb_fused_fp4_prefill_mm_scaled", "cb_fused_fp4_moe_grouped"),
+])
+def test_fused_fp4_accepts_each_useful_partial_module(
+        monkeypatch, tmp_path, symbols):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_fp4_loader(monkeypatch, tmp_path)
+    good = _stub("fused_fp4", symbols)
+    calls = _patch_load(monkeypatch, good)
+    assert cuda_ext.get_fused_fp4_ext() is good
+    kwargs = calls[0][1]
+    assert kwargs["build_directory"] == str(tmp_path / "fused_fp4")
+    assert "-gencode=arch=compute_121a,code=sm_121a" in \
+        kwargs["extra_cuda_cflags"]
+
+
+def test_fused_fp4_refuses_module_with_only_optional_symbols(
+        monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_fp4_loader(monkeypatch, tmp_path)
+    useless = _stub("fused_fp4", ("cb_fused_fp4_moe_tile_sizes",))
+    _patch_load(monkeypatch, useless)
+    assert cuda_ext.get_fused_fp4_ext() is None
+    error = capsys.readouterr().err
+    assert "incompatible fused fp4" in error
+    assert "dense prefill" in error and "grouped MoE prefill" in error
+
+
+def test_fused_fp4_reports_build_exception(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_fp4_loader(monkeypatch, tmp_path)
+    _patch_load(monkeypatch, error=RuntimeError("CUTLASS failed"))
+    assert cuda_ext.get_fused_fp4_ext() is None
+    error = capsys.readouterr().err
+    assert "unavailable (RuntimeError: CUTLASS failed)" in error
+    assert "incompatible" not in error
+
+
+# ---------------------------------------------------------------------------
+# Fused FP8 extension: scaled dense binding is the grouped prerequisite
+# ---------------------------------------------------------------------------
+
+
+def test_fused_fp8_accepts_dense_only_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_cutlass(monkeypatch, tmp_path)
+    dense = _stub("fused", cuda_ext._FUSED_SYMBOLS)
+    calls = _patch_load(monkeypatch, dense)
+    assert cuda_ext.get_fused_ext() is dense
+    assert calls[0][1]["build_directory"] == str(tmp_path / "fused")
+
+
+def test_fused_fp8_refuses_grouped_without_dense_prerequisite(
+        monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_cutlass(monkeypatch, tmp_path)
+    grouped = _stub(
+        "fused", ("cb_fused_moe_grouped", "cb_fused_moe_tile_m"))
+    _patch_load(monkeypatch, grouped)
+    assert cuda_ext.get_fused_ext() is None
+    error = capsys.readouterr().err
+    assert "incompatible fused prefill" in error
+    assert "cb_fused_prefill_mm_scaled" in error
+
+
+def test_fused_fp8_reports_build_exception(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _prepare_cutlass(monkeypatch, tmp_path)
+    _patch_load(monkeypatch, error=RuntimeError("CUTLASS failed"))
+    assert cuda_ext.get_fused_ext() is None
+    error = capsys.readouterr().err
+    assert "fused prefill extension unavailable" in error
+    assert "CUTLASS failed" in error
+
+
+def test_no_fake_extension_modules_leak_into_sys_modules():
+    for name in ("main", "ptc", "fused", "fused_fp4"):
+        assert name not in sys.modules

--- a/tests/test_ext_symbols.py
+++ b/tests/test_ext_symbols.py
@@ -1,0 +1,217 @@
+"""Loader-side symbol assertion for the JIT extensions (``gridbook.cuda_ext``).
+
+GPU-FREE and TOOLCHAIN-FREE: nothing here builds or loads a real extension.
+``_require_symbols`` is exercised against stand-in module objects, and the
+required-symbol tuples are cross-checked against the ``m.def(...)`` bindings in
+the packaged ``.cu`` sources so the two cannot drift apart. Runs anywhere the
+package imports (``cuda_ext`` itself imports only ``os`` and ``sys``); the one
+test that drives ``get_ext()`` end to end needs ``torch`` importable but never
+a GPU, an ``nvcc`` or a build -- ``load`` is monkeypatched.
+
+    python -m pytest tests/test_ext_symbols.py -q
+"""
+import re
+import sys
+import types
+
+import pytest
+
+cuda_ext = pytest.importorskip(
+    "gridbook.cuda_ext", reason="gridbook not importable")
+
+
+def _stub(name, symbols):
+    """A stand-in for a torch-JIT extension module exporting ``symbols``."""
+    mod = types.ModuleType(name)
+    for s in symbols:
+        setattr(mod, s, lambda *a, **k: None)
+    return mod
+
+
+# --------------------------------------------------------------------------
+# _require_symbols
+# --------------------------------------------------------------------------
+
+def test_complete_module_is_returned_unchanged():
+    mod = _stub("prismaquant_cb_ext", cuda_ext._EXT_SYMBOLS)
+    got = cuda_ext._require_symbols(mod, cuda_ext._EXT_SYMBOLS,
+                                    build_dir="/opt/gridbook/ext-cache",
+                                    source="cb_gemv.cu")
+    assert got is mod
+
+
+def test_extra_symbols_do_not_matter():
+    """The check is a lower bound, not an equality: an extension carrying the
+    optional bindings on top of the required set is the normal case."""
+    mod = _stub("prismaquant_cb_ext",
+                (*cuda_ext._EXT_SYMBOLS, "cb_expand_fp8_into", "l2_unpin"))
+    assert cuda_ext._require_symbols(
+        mod, cuda_ext._EXT_SYMBOLS, build_dir="/cache",
+        source="cb_gemv.cu") is mod
+
+
+def test_missing_symbol_raises_and_names_it_and_the_directory():
+    """The whole point of the error: it must say WHAT is missing and WHICH
+    directory to delete. A bare AttributeError from a call site says
+    neither."""
+    present = [s for s in cuda_ext._EXT_SYMBOLS if s != "cb_moe_combine"]
+    mod = _stub("prismaquant_cb_ext", present)
+    with pytest.raises(cuda_ext.StaleExtensionError) as ei:
+        cuda_ext._require_symbols(mod, cuda_ext._EXT_SYMBOLS,
+                                  build_dir="/opt/gridbook/ext-cache",
+                                  source="cb_gemv.cu")
+    msg = str(ei.value)
+    assert "cb_moe_combine" in msg
+    assert "/opt/gridbook/ext-cache" in msg
+    assert "cb_gemv.cu" in msg
+    assert "PRISMAQUANT_CB_EXT_DIR" in msg
+
+
+def test_every_missing_symbol_is_reported_not_just_the_first():
+    """A stale .so usually lags by more than one binding; reporting one at a
+    time would mean one restart per symbol to find out."""
+    mod = _stub("prismaquant_cb_ext", ("fp8_act_qdq",))
+    with pytest.raises(cuda_ext.StaleExtensionError) as ei:
+        cuda_ext._require_symbols(mod, cuda_ext._EXT_SYMBOLS,
+                                  build_dir="/cache", source="cb_gemv.cu")
+    msg = str(ei.value)
+    for s in cuda_ext._EXT_SYMBOLS:
+        if s != "fp8_act_qdq":
+            assert s in msg, f"{s} missing from the error message"
+
+
+def test_stale_extension_error_is_not_confused_with_the_other_two():
+    """cuda_ext reports three different defects three different ways; the
+    except arms rely on the classes being disjoint."""
+    assert issubclass(cuda_ext.StaleExtensionError, RuntimeError)
+    assert not issubclass(cuda_ext.StaleExtensionError,
+                          cuda_ext.IncompleteInstallError)
+    assert not issubclass(cuda_ext.IncompleteInstallError,
+                          cuda_ext.StaleExtensionError)
+
+
+# --------------------------------------------------------------------------
+# the required sets themselves
+# --------------------------------------------------------------------------
+
+_M_DEF = re.compile(r'm\.def\(\s*"([A-Za-z_][A-Za-z0-9_]*)"')
+
+
+def _exports(cu_name):
+    """Symbol names bound by ``m.def("...")`` in a packaged CUDA source."""
+    import os
+    path = os.path.join(cuda_ext.csrc_dir(), cu_name)
+    if not os.path.isfile(path):
+        pytest.skip(f"{cu_name} not present in this install")
+    with open(path, encoding="utf-8") as fh:
+        return set(_M_DEF.findall(fh.read()))
+
+
+@pytest.mark.parametrize("required,cu_name", [
+    (cuda_ext._EXT_SYMBOLS, "cb_gemv.cu"),
+    (cuda_ext._PTC_SYMBOLS, "cb_persistent_tc.cu"),
+    (cuda_ext._FUSED_SYMBOLS, "cb_fused_gemm.cu"),
+])
+def test_required_symbols_exist_in_the_packaged_source(required, cu_name):
+    """The assertion lists must not drift from the kernels they describe. A
+    typo here would make a HEALTHY build fail to load on every host, which is a
+    worse outcome than the bug this check exists to catch -- so pin it."""
+    exported = _exports(cu_name)
+    missing = sorted(set(required) - exported)
+    assert not missing, (
+        f"{cu_name} does not m.def() {missing}; the required-symbol tuple in "
+        f"cuda_ext is stale or misspelled")
+
+
+def test_optional_bindings_stay_optional():
+    """These have call-site probes that treat absence as 'an older build' and
+    degrade correctly. Promoting any of them to required would turn a working
+    degrade into a hard fallback to Triton for every older extension."""
+    for name in ("cb_expand_fp8_into",      # ops.cb_expand_fp8_into_available
+                 "l2_pin_region", "l2_reset_window", "l2_unpin",
+                 "l2_persisting_max_bytes", "l2_max_window_bytes"):
+        assert name not in cuda_ext._EXT_SYMBOLS, (
+            f"{name} is probed at its call site and must stay optional")
+    for name in ("cb_fused_moe_grouped", "cb_fused_moe_tile_m",
+                 "cb_fused_moe_tile_sizes",
+                 "cb_fused_moe_tile_sizes_for_kbits"):
+        assert name not in cuda_ext._FUSED_SYMBOLS, (
+            f"{name} ships independently and must stay optional")
+
+
+# --------------------------------------------------------------------------
+# end to end through get_ext(), with the build monkeypatched out
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def fresh_get_ext():
+    """Reset get_ext's one-shot memo around a test, and restore it after."""
+    saved = (cuda_ext._ext, cuda_ext._tried)
+    cuda_ext._ext, cuda_ext._tried = None, False
+    yield
+    cuda_ext._ext, cuda_ext._tried = saved
+
+
+def _patch_load(monkeypatch, result):
+    torch = pytest.importorskip("torch")
+    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
+    assert torch is not None
+    calls = {}
+
+    def fake_load(*args, **kwargs):
+        calls["kwargs"] = kwargs
+        return result
+
+    monkeypatch.setattr(cpp_extension, "load", fake_load)
+    return calls
+
+
+def test_get_ext_refuses_a_stale_module(monkeypatch, capsys, tmp_path,
+                                        fresh_get_ext):
+    """The regression this PR is about: a module that loaded but lacks a symbol
+    ops.py dereferences unconditionally must NOT become get_ext()'s value."""
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    stale = _stub("prismaquant_cb_ext",
+                  [s for s in cuda_ext._EXT_SYMBOLS if s != "cb_gemv_fp4_v2"])
+    _patch_load(monkeypatch, stale)
+
+    assert cuda_ext.get_ext() is None
+    err = capsys.readouterr().err
+    assert "stale" in err.lower()
+    assert "cb_gemv_fp4_v2" in err
+    assert str(tmp_path) in err
+
+
+def test_get_ext_accepts_a_complete_module(monkeypatch, tmp_path,
+                                           fresh_get_ext):
+    """...and the check does not reject a healthy build."""
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    good = _stub("prismaquant_cb_ext", cuda_ext._EXT_SYMBOLS)
+    _patch_load(monkeypatch, good)
+
+    assert cuda_ext.get_ext() is good
+
+
+def test_get_ext_is_still_memoised(monkeypatch, tmp_path, fresh_get_ext):
+    """One build attempt per process, unchanged: the second call must not
+    re-enter load()."""
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    good = _stub("prismaquant_cb_ext", cuda_ext._EXT_SYMBOLS)
+    n = {"calls": 0}
+    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
+
+    def counting_load(*args, **kwargs):
+        n["calls"] += 1
+        return good
+
+    monkeypatch.setattr(cpp_extension, "load", counting_load)
+    assert cuda_ext.get_ext() is good
+    assert cuda_ext.get_ext() is good
+    assert n["calls"] == 1
+
+
+def test_sys_modules_untouched():
+    """Guard against this file leaking stubs into a shared pytest process the
+    way tests/test_target_namespace_compat.py does (see
+    .github/scripts/run_cpu_tests.sh)."""
+    assert "prismaquant_cb_ext" not in sys.modules

--- a/tests/test_ext_symbols.py
+++ b/tests/test_ext_symbols.py
@@ -208,6 +208,26 @@ def test_main_optional_bindings_stay_optional():
         assert name not in cuda_ext._EXT_SYMBOLS
 
 
+def test_main_contract_rejects_pre_fp4_qdq_revision(monkeypatch, capsys,
+                                                     tmp_path):
+    """The activation binding arrived after the original decode extension.
+
+    A cached module from that earlier revision must be diagnosed as stale
+    instead of being accepted and silently dropping the single-launch QDQ.
+    """
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    old_symbols = tuple(name for name in cuda_ext._EXT_SYMBOLS
+                        if name != "fp4_act_qdq")
+    stale = _stub("main", old_symbols,
+                  path=tmp_path / "prismaquant_cb_ext.so")
+    _patch_load(monkeypatch, stale)
+
+    assert cuda_ext.get_ext() is None
+    error = capsys.readouterr().err
+    assert "incompatible CUDA decode-GEMV" in error
+    assert "fp4_act_qdq" in error
+
+
 def test_fp8_grouped_bindings_stay_optional_after_dense_prerequisite():
     for name in ("cb_fused_moe_grouped", "cb_fused_moe_tile_m",
                  "cb_fused_moe_tile_sizes",


### PR DESCRIPTION
Bundle 07 from the supplied archive, rebased and corrected for every current extension family.

Outcome:
- validates required exports for the main, persistent-TC, and fused-FP8 loaders
- treats fused-FP4 dense and grouped entrypoint families as independently optional, preserving intentional partial fallback
- distinguishes a loaded-module API mismatch from lock, permission, or build failures
- reports module path plus cache permissions, ownership, and writability diagnostics
- preserves memoization and existing fallback behavior

Review corrections:
The submitted explanation attributed stale modules to root-owned cache reuse, while fresh unwritable caches normally fail at lock or build time. It also did not cover current PTC and fused-FP4 loaders. The reviewed implementation uses per-loader contracts and does not reject valid partial fused-FP4 modules.

Validation:
- focused coverage expanded from 13 to 34 tests; all pass on host and in the vLLM/CUDA container
- a fresh real main extension compiled, loaded, and exposed every required symbol
- related host suites: 55 passed and 57 capability skips

Integration note:
Bundle 04 adds fp4_act_qdq to the main extension. If PR #6 lands first, this branch will be rebased to include that new required export before merge.

Attribution:
Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.