### PR TITLE
docs: document delegated NVFP4 MoE backends on GB10

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ arithmetic band and the single-seed noise band.
 | [`docs/MOTIVATION.md`](docs/MOTIVATION.md) | Why the 2–4 bpp regime needs codebooks, why serving has been the blocker, and an honest comparison to GGUF k-quant/IQ. |
 | [`docs/KERNELS.md`](docs/KERNELS.md) | Serving kernel design: transient-expand prefill, fused act-QDQ decode GEMV, two-tier in-register scale compose, grouped MoE GEMV, Triton fallbacks, CUDA-graph rules. |
 | [`docs/PLUGIN.md`](docs/PLUGIN.md) | Operator reference for the plugin itself: dispatch, kernel set, environment switches. |
+| [`docs/DELEGATED-NVFP4-MOE.md`](docs/DELEGATED-NVFP4-MOE.md) | What a **non-CB** NVFP4 MoE group in a mixed container gets on GB10 (`sm_121`): the capability-family formula, which vLLM MoE backends survive it, and why `marlin` serves a W4A4 group as W4A16 with no log line. |
 | [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) | The measured results with full hardware/protocol context and caveats. |
 | [`ROADMAP.md`](ROADMAP.md) | What is done, what is open, and what was measured and rejected. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to run the tests, what a good bug report contains, and what is in scope. |

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ arithmetic band and the single-seed noise band.
 | [`docs/MOTIVATION.md`](docs/MOTIVATION.md) | Why the 2–4 bpp regime needs codebooks, why serving has been the blocker, and an honest comparison to GGUF k-quant/IQ. |
 | [`docs/KERNELS.md`](docs/KERNELS.md) | Serving kernel design: transient-expand prefill, fused act-QDQ decode GEMV, two-tier in-register scale compose, grouped MoE GEMV, Triton fallbacks, CUDA-graph rules. |
 | [`docs/PLUGIN.md`](docs/PLUGIN.md) | Operator reference for the plugin itself: dispatch, kernel set, environment switches. |
-| [`docs/DELEGATED-NVFP4-MOE.md`](docs/DELEGATED-NVFP4-MOE.md) | What a **non-CB** NVFP4 MoE group in a mixed container gets on GB10 (`sm_121`): the capability-family formula, which vLLM MoE backends survive it, and why `marlin` serves a W4A4 group as W4A16 with no log line. |
+| [`docs/DELEGATED-NVFP4-MOE.md`](docs/DELEGATED-NVFP4-MOE.md) | Version-scoped backend selection for a **non-CB** NVFP4 MoE group on GB10 (`sm_121`), including Marlin's generic weight-only warning and a fail/unknown preflight policy. |
 | [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) | The measured results with full hardware/protocol context and caveats. |
 | [`ROADMAP.md`](ROADMAP.md) | What is done, what is open, and what was measured and rejected. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to run the tests, what a good bug report contains, and what is in scope. |

--- a/docs/DELEGATED-NVFP4-MOE.md
+++ b/docs/DELEGATED-NVFP4-MOE.md
@@ -1,0 +1,382 @@
+# Delegated NVFP4 MoE groups on GB10 (`sm_121`)
+
+A gridbook artifact is a **mixed container**. Config groups that carry a
+`"scheme"` key are CB groups and are served by this plugin; groups without one
+use the stock `compressed-tensors` vocabulary and are **delegated** to a real
+`CompressedTensorsConfig` that the plugin constructs — see
+[`SPEC.md` §6](SPEC.md) ("prefix is a plain NVFP4 / FP8 layer of a mixed
+container → delegate to the runtime's stock `compressed-tensors` handling",
+`docs/SPEC.md:397-400`) and [`PLUGIN.md`](PLUGIN.md) (`docs/PLUGIN.md:43-50`).
+
+The consequence is already stated in two places and then dropped:
+
+- `docs/PLUGIN.md:49-50` — "an artifact's hardware requirements are the union of
+  gridbook's and those of its delegated groups."
+- `docs/INSTALL.md:86-88` — "Those groups carry **their own** hardware
+  requirements, independent of gridbook's kernels."
+
+This page is the missing half of that sentence for the case that actually bites
+on the reference target: **a delegated NVFP4 MoE group on GB10.** The failure it
+documents is not a crash — it is a *silent* numerics change.
+
+- [Scope: does this apply to me?](#scope-does-this-apply-to-me)
+- [1. The capability-family formula](#1-the-capability-family-formula)
+- [2. Which NVFP4 MoE backends run on GB10](#2-which-nvfp4-moe-backends-run-on-gb10)
+- [3. The silent one: MARLIN drops the activation scale](#3-the-silent-one-marlin-drops-the-activation-scale)
+- [4. Why relaxing the CUTEDSL / TRTLLM gate does not help](#4-why-relaxing-the-cutedsl--trtllm-gate-does-not-help)
+- [5. What `auto` picks, and the exact `--kernel-config` spellings](#5-what-auto-picks-and-the-exact---kernel-config-spellings)
+- [6. A gate you can run before you serve](#6-a-gate-you-can-run-before-you-serve)
+- [7. Provenance: what is code-read and what is measured](#7-provenance-what-is-code-read-and-what-is-measured)
+
+---
+
+## Scope: does this apply to me?
+
+**Only if a delegated (non-CB) group in your artifact is an NVFP4 *MoE* group.**
+
+| Situation | This page applies? |
+|---|---|
+| CB expert band served by the gridbook plugin | **No.** CB groups do not go through vLLM's NVFP4 MoE oracle at all, and gridbook artifacts do not use `--kernel-config` for them. Use `--quantization gridbook`. |
+| Delegated NVFP4 **MoE** group (`w13`/`w2` stacked experts) | **Yes** — all of it. |
+| Delegated NVFP4 **dense Linear** group (e.g. the 27B's vision tower) | **Partly.** §1 is what "Blackwell-class" means precisely; §2–§6 are MoE-path only. |
+| Delegated FP8 Linears (e.g. the 295B's 36 vanilla-FP8 Linears) | **No.** |
+
+**None of the three currently published artifacts contains a delegated NVFP4 MoE
+group** — the 295B's non-CB groups are FP8 Linears and the 27B's is an NVFP4
+W4A16 vision tower (`docs/PLUGIN.md:47-49`). This page is therefore forward-looking:
+it is for anyone producing a mixed container that leaves an MoE band to stock
+`compressed-tensors`, and for anyone reading `docs/INSTALL.md:86-88` and wondering
+what "their own hardware requirements" costs on this box.
+
+---
+
+## 1. The capability-family formula
+
+GB10 is `sm_121`. vLLM's family predicate is integer division by ten:
+
+```python
+return (current_capability.to_int() // 10) == (capability // 10)
+```
+
+— vLLM `vllm/platforms/interface.py:363-375` (`is_device_capability_family`).
+
+`sm_121` → `to_int()` = `121` → `121 // 10` = **12**. So GB10 matches
+`is_device_capability_family(120)` and **fails** `is_device_capability_family(100)`.
+
+This is the single fact that decides everything below, and it is easy to get
+wrong in the other direction: "Blackwell" is not one family here. `sm_100`
+(GB100/GB200) is family 10; `sm_120`/`sm_121` (RTX 50-series, GB10) is family 12.
+A backend that gates on `family(100)` and calls itself "Blackwell-only" is
+**not** available on a DGX Spark. The gate is correct; only its prose is
+misleading.
+
+### Two predicates, both spelled "100", opposite answers on GB10
+
+vLLM has a *second* capability predicate and the two are easy to confuse when
+skim-reading a gate, because both take the literal `100`:
+
+| Call | Meaning | On `sm_121` |
+|---|---|---|
+| `is_device_capability_family(100)` | **exact family**: `121 // 10 == 100 // 10` → `12 == 10` | **False** |
+| `has_device_capability(100)` | **floor**: `to_int() >= 100` → `121 >= 100` — `vllm/platforms/interface.py:315-336` | **True** |
+
+`FlashInferExperts` uses *both*: `family(120)` in its device gate and
+`has_device_capability(100)` — the floor — to admit the NVFP4 scheme pair
+(`experts/flashinfer_cutlass_moe.py:177-184`). That is why it is available on
+GB10 while CUTEDSL and TRTLLM, which use the family form, are not. Read the
+predicate name, not the number.
+
+---
+
+## 2. Which NVFP4 MoE backends run on GB10
+
+Every gate below is `_supports_current_device()` on the expert class, consumed by
+`is_supported_config()` (`modular_kernel.py:536-547`).
+Line numbers throughout this page are **vLLM v0.23.0**
+(see [§7](#7-provenance-what-is-code-read-and-what-is-measured)). A path that
+starts with `vllm/`, `csrc/` or `CMakeLists.txt` is relative to the vLLM source
+root; every other path (`experts/…`, `oracle/…`, `modular_kernel.py`,
+`config.py`) is relative to **`vllm/model_executor/layers/fused_moe/`**.
+
+| `moe_backend` | Device gate | On GB10 | Accepts a W4A16 checkpoint? |
+|---|---|---|---|
+| `flashinfer_cutlass` | `is_device_capability(90) or family(100) or family(120)`, plus `has_flashinfer_cutlass_fused_moe()` — `experts/flashinfer_cutlass_moe.py:131-143` | ✅ (admits the NVFP4 pair via the `has_device_capability(100)` **floor**, `experts/flashinfer_cutlass_moe.py:177-184`) | ❌ needs `(kNvfp4Static, kNvfp4Dynamic)` — `experts/flashinfer_cutlass_moe.py:149-185` |
+| `cutlass` (logs as `VLLM_CUTLASS`) | `family(100) or family(110) or family(120)` — `experts/cutlass_moe.py:692-699` | ✅ | ❌ `_supports_quant_scheme` is `== (kNvfp4Static, kNvfp4Dynamic)` — `experts/cutlass_moe.py:706-710` |
+| `flashinfer_cutedsl` | `family(100)` only — `experts/flashinfer_cutedsl_moe.py:68-75` | ❌ | ❌ |
+| `flashinfer_trtllm` | `family(100)` only — `experts/trtllm_nvfp4_moe.py:112-120` | ❌ | ❌ |
+| *(`FLASHINFER_CUTEDSL_BATCHED`, reached only via the batched activation format)* | `family(100)` only — `experts/flashinfer_cutedsl_batched_moe.py:61-68` | ❌ | ❌ |
+| `flashinfer_b12x` | `family(120)`, plus `has_flashinfer_b12x_moe()` — `experts/flashinfer_b12x_moe.py:133-140` | ✅ device-wise, but **excluded from `auto`** — `oracle/nvfp4.py:170-182` | ✅ accepts `(kNvfp4Static, None)` — `experts/flashinfer_b12x_moe.py:147-157` |
+| `marlin` | no family gate: `has_device_capability((7, 5))` — `experts/marlin_moe.py:590-593` | ✅ | ✅ — **and this is the trap, see [§3](#3-the-silent-one-marlin-drops-the-activation-scale)** |
+| `emulation` | no capability gate — inherits `TritonExperts`: `is_cuda_alike() or is_xpu()` (`experts/triton_moe.py:71-73`) | ✅ correctness only | ❌ raises if `a13_scale`/`a2_scale` are `None` — `oracle/nvfp4.py:430-434` |
+| `humming` | accepted by the config validator (`vllm/config/kernel.py:122-137`) but **absent from the NVFP4 oracle's `map_nvfp4_backend`** (`oracle/nvfp4.py:141-157`). The Humming expert classes are wired into the **MXFP4** oracle only (`oracle/mxfp4.py:160-165`) | ❌ raises `ValueError` at startup on v0.23.0 | n/a |
+
+**The two fused NVFP4 MoE backends that actually work on GB10 are
+`FLASHINFER_CUTLASS` and `VLLM_CUTLASS`.** Both require a W4A4 checkpoint.
+
+### `VLLM_CUTLASS` has a build-time precondition and a dtype restriction
+
+Passing the device gate is necessary, not sufficient. The grouped GEMM behind
+`CutlassExpertsFp4` dispatches to an SM120 code path that only exists if the
+vLLM wheel was compiled for a 12.x arch:
+
+- `CMakeLists.txt:927-932` picks `FP4_ARCHS` (`12.0f` under CUDA ≥ 13.0, else
+  `12.0a;12.1a`), and `CMakeLists.txt:948-950` then defines `ENABLE_NVFP4_SM120=1`
+  / `-DENABLE_CUTLASS_MOE_SM120=1`.
+- `csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu:612-618`
+  routes `version_num >= 120 && version_num < 130` to
+  `run_fp4_blockwise_scaled_group_mm_sm120` (`ArchTag = cutlass::arch::Sm120`,
+  `OpClassBlockScaledTensorOp` — same file `:439-440`).
+- **bf16 output only.** A non-bf16 output dtype on a 12.x device hits
+  `STD_TORCH_CHECK_NOT_IMPLEMENTED(false, "SM120 NVFP4 MOE only supports bfloat16
+  output, ...")` — same file `:699-707`. Serve `--dtype bfloat16`.
+
+A wheel built without those archs does not fail the *Python* gate; it fails
+inside the op with "No compiled `cutlass_fp4_group_mm` kernel for CUDA device
+capability: 121" (same file `:628-631`).
+
+---
+
+## 3. The silent one: MARLIN drops the activation scale
+
+This is the reason this page exists. **`marlin` is the only backend in the table
+that will load a W4A4 NVFP4 MoE group on GB10 and serve it with different
+numerics than the checkpoint declares — with no warning line.**
+
+Three steps in vLLM's own source, in order:
+
+**(a) MARLIN's scheme check ignores the activation half entirely.** Where the
+CUTLASS backends compare the *pair*, MARLIN compares only the weight key:
+
+```python
+    SUPPORTED_W = [ ... kNvfp4Static, ... ]
+    return weight_key in SUPPORTED_W
+```
+
+— `experts/marlin_moe.py:600-619`. `activation_key` is a parameter and is never
+read. So a `(kNvfp4Static, kNvfp4Dynamic)` W4A4 group is "supported".
+
+**(b) The activation scales are then set to `None`.**
+
+```python
+    elif nvfp4_backend == NvFp4MoeBackend.MARLIN:
+        a13_scale = None
+        a2_scale = None
+```
+
+— `oracle/nvfp4.py:405-407`, in `convert_to_nvfp4_moe_kernel_format`. The
+`prepare_nvfp4_moe_layer_for_marlin` call immediately below it takes no
+activation-scale argument at all.
+
+**(c) The quant config built for the kernel is the weight-only one.**
+
+```python
+    if backend == NvFp4MoeBackend.MARLIN:
+        return nvfp4_w4a16_moe_quant_config(...)
+```
+
+— `oracle/nvfp4.py:478-484`. The function name is the proof, and its signature
+(`config.py:855-860`) has **no** `a1_gscale`/`a2_gscale` parameter —
+there is nowhere for a calibrated activation scale to go.
+
+Contrast the fused path, same file, same function:
+
+```python
+    return nvfp4_moe_quant_config(
+        g1_alphas=w13_scale_2,
+        g2_alphas=w2_scale_2,
+        a1_gscale=(1.0 / a13_scale),
+        a2_gscale=(1.0 / a2_scale),
+        ...
+```
+
+— `oracle/nvfp4.py:500-505`. The reciprocal is the checkpoint's calibrated
+per-expert input global scale being handed to the kernel.
+
+**Net effect.** Weights load, the server starts, every request succeeds, and
+every token is computed with **W4A16** numerics from a **W4A4** checkpoint. The
+only externally visible symptom is a quality change. There is no `WARNING`,
+because from vLLM's point of view nothing went wrong — MARLIN is a weight-only
+kernel and it did exactly what it does.
+
+> **If you benchmark a W4A4 delegated group under `marlin`, you are not
+> benchmarking W4A4.** Do not quote such a run as an activation-quantization
+> comparison.
+
+The mirror-image case is loud and therefore harmless: a genuinely weight-only
+(W4A16) group whose `QuantKey` ends `xNone` is *rejected* by every fused backend
+at startup, because their `_supports_quant_scheme` requires the pair
+(`experts/cutlass_moe.py:706-710`, `experts/flashinfer_cutedsl_moe.py:82-89`,
+`experts/trtllm_nvfp4_moe.py:128-136`). You get a `ValueError` naming the
+scheme, not a silent degrade.
+
+---
+
+## 4. Why relaxing the CUTEDSL / TRTLLM gate does not help
+
+The obvious "fix" — patch `family(100)` to also accept `family(120)` in
+`experts/flashinfer_cutedsl_moe.py:68-75` and `experts/trtllm_nvfp4_moe.py:112-120`
+— does not produce a working backend on GB10. The device gate is not the thing
+protecting you.
+
+Each of those gates is an `and` of the family check with an availability probe:
+`has_flashinfer_cutedsl_moe_nvfp4()` (`experts/flashinfer_cutedsl_moe.py:74`)
+and `has_flashinfer_trtllm_fused_moe()` (`experts/trtllm_nvfp4_moe.py:119`). On
+GB10 **both probes return `True`** — the FlashInfer package is importable and
+reports the feature present. Removing the family check therefore lets selection
+succeed and moves the failure downstream, into code that has no fallback:
+
+- **CUTEDSL** dies in FlashInfer's JIT at `get_nvcc_flags_list(
+  supported_major_versions=[10])` — the compile flags for this kernel are
+  enumerated for major version 10 only.
+- **TRTLLM** dies inside a prebuilt cubin whose name ends `_sm100f`.
+
+`FLASHINFER_CUDA_ARCH_LIST` only relocates the failure again; it does not
+conjure an sm_12x cubin. **Leave those gates alone.** The two CUTLASS backends
+in §2 are the supported answer.
+
+*(FlashInfer is a separate package, not part of the vLLM tree, so those last two
+symbols are quoted from an observed GB10 run rather than from a vLLM file:line —
+see [§7](#7-provenance-what-is-code-read-and-what-is-measured).)*
+
+---
+
+## 5. What `auto` picks, and the exact `--kernel-config` spellings
+
+### The `auto` walk order
+
+`moe_backend="auto"` iterates this list and takes the first backend whose
+`is_supported_config()` returns `True` (`oracle/nvfp4.py:174-182`, loop at
+`oracle/nvfp4.py:315-329`):
+
+```
+FLASHINFER_TRTLLM → FLASHINFER_CUTEDSL → FLASHINFER_CUTEDSL_BATCHED
+                  → FLASHINFER_CUTLASS → VLLM_CUTLASS → MARLIN → EMULATION
+```
+
+`FLASHINFER_B12X` is deliberately **not** in that list — "intentionally excluded
+from auto-selection until the upstream CUTLASS SM121 MMA op guard is resolved"
+(`oracle/nvfp4.py:170-173`). It is opt-in only.
+
+Read that order against §2 and §3. On GB10 the first three are eliminated by the
+family gate, so a **W4A4** group lands on `FLASHINFER_CUTLASS` — the right
+answer. But a group that fails the fused backends' scheme check for any reason
+keeps walking, and the next stop that accepts it is **`MARLIN`**. That is the
+mechanism by which the silent W4A16 downgrade in §3 gets selected *by default*,
+without anyone typing `marlin`.
+
+**Pin the backend explicitly for any run you intend to quote.** `auto`'s answer
+is a property of your image and its device probes, not of your intent.
+
+### Canonical spellings
+
+`KernelConfig._normalize_moe_backend` lowercases and maps `-` → `_`
+(`vllm/config/kernel.py:211-216`), so case and dashes do not matter. These are
+the canonical forms:
+
+```bash
+# Fused W4A4 on GB10 — the recommended path for a delegated NVFP4 MoE group
+--kernel-config '{"moe_backend":"flashinfer_cutlass"}'
+
+# vLLM's own CUTLASS; also fused, also W4A4-only. Needs a wheel built with
+# ENABLE_NVFP4_SM120 and --dtype bfloat16 (see §2).
+--kernel-config '{"moe_backend":"cutlass"}'
+
+# Weight-only. Correct for a genuine W4A16 group; SILENTLY W4A16 for a W4A4 one.
+--kernel-config '{"moe_backend":"marlin"}'
+
+# Bisection only — proves a scheme is genuinely unsupported rather than
+# silently degraded, because it raises instead of dropping scales.
+--kernel-config '{"moe_backend":"emulation"}'
+```
+
+### Confirm it at startup
+
+vLLM logs the choice once, from `_make_log_backend` (`oracle/nvfp4.py:200-205`):
+
+```
+Using 'FLASHINFER_CUTLASS' NvFp4 MoE backend out of potential backends: [...]
+```
+
+For a W4A4 delegated group on GB10 that name must be `FLASHINFER_CUTLASS` or
+`VLLM_CUTLASS`. If it says `MARLIN`, you are on §3.
+
+**This does not apply to gridbook's own CB groups.** The CB expert band is
+claimed by the plugin, not by a vLLM NVFP4 MoE backend, and `--kernel-config` has
+no effect on it. See [`PLUGIN.md`](PLUGIN.md).
+
+---
+
+## 6. A gate you can run before you serve
+
+A note nobody reads is not a gate. The constructive form of §3 is a check that
+**fails the artifact** rather than describing the hazard:
+
+> Given (a) the artifact's declared activation scheme — does it ship
+> `input_scale` / `input_global_scale` tensors for its MoE band? — and (b) the
+> `moe_backend` you will actually serve with, refuse the combination when the
+> kernel would not honour the scheme the checkpoint declares.
+>
+> - `W4A4 checkpoint` + a **weight-only** backend — on v0.23.0 that is
+>   `marlin`, and in general any backend whose `_supports_quant_scheme`
+>   ignores `activation_key` → **FAIL**: activation scales dropped, server
+>   starts, numerics silently differ from `config.json`.
+> - `W4A16 checkpoint` + a **fused** backend (`flashinfer_cutlass`, `cutlass`,
+>   `flashinfer_cutedsl`, `flashinfer_trtllm`, `emulation`) → **FAIL**: startup
+>   raise (loud, but still worth catching before a queue slot is spent).
+> - anything else → pass.
+>
+> Keep that first list keyed to the *predicate*, not to a fixed backend name:
+> a future backend that ignores `activation_key` inherits the same hazard, and
+> `humming` is only excluded here because v0.23.0's NVFP4 oracle has no mapping
+> for it at all ([§2](#2-which-nvfp4-moe-backends-run-on-gb10)).
+>
+> The backend must be **supplied**, not inferred: with `auto` the tool cannot
+> know what the device probes will decide, so the honest result is
+> "not checked", not "pass".
+
+Closing this gap does not recover the numerics — under MARLIN they are
+unrecoverable by construction, the kernel is weight-only. It makes the mismatch
+**non-silent**, which is the entire failure mode.
+
+The natural home for this in gridbook is artifact-production time (see
+[`SPEC.md`](SPEC.md) on what a producer guarantees per group): if you delegate an
+MoE band to stock `compressed-tensors`, record in the artifact's card which
+`moe_backend` it was validated under, so a reader is not left to discover the
+downgrade from a quality delta.
+
+---
+
+## 7. Provenance: what is code-read and what is measured
+
+**vLLM line numbers.** Every `vllm/...`, `csrc/...` and `CMakeLists.txt`
+reference on this page was read from a **vLLM v0.23.0** source tree, and each
+cited file was checked to be byte-identical to that release (no local patch on
+any file quoted here). vLLM moves fast and this surface is
+not a stability contract — re-grep for the symbol name (`is_device_capability_family`,
+`_supports_current_device`, `nvfp4_w4a16_moe_quant_config`) rather than trusting
+a line number against a different build. `INSTALL.md`'s reference stack is
+`0.23.1rc1.dev764+g54b16d8a9`, which is a *different* build from the v0.23.0
+tree these numbers came from; the symbols were identical in both as of writing,
+the numbers were checked only against v0.23.0.
+
+**Code-read, not run:** the whole of §1–§3 and §5 is a source reading. It
+requires no GPU and you can reproduce it with `grep` on your own vLLM.
+
+**Observed on GB10 hardware:** that `FLASHINFER_CUTLASS` and `VLLM_CUTLASS` both
+serve an NVFP4 W4A4 MoE checkpoint on `sm_121`; and the two downstream failure
+sites in §4 (`get_nvcc_flags_list(supported_major_versions=[10])`, the `_sm100f`
+cubin) after locally relaxing the family gate. Those observations were made
+serving a **standalone NVFP4 checkpoint**, not a gridbook mixed container — the
+delegated-group path composes the same vLLM code, but no published gridbook
+artifact exercises it yet (see [Scope](#scope-does-this-apply-to-me)).
+
+**Not measured, deliberately absent:** any throughput or quality number for a
+delegated NVFP4 MoE group inside a gridbook artifact, and any claim about
+`flashinfer_b12x`, which is listed in §2 from its gate only and has not been run
+here.
+
+---
+
+**See also:** [`INSTALL.md` §Hardware matrix](INSTALL.md#hardware-matrix) ·
+[`PLUGIN.md`](PLUGIN.md) · [`SPEC.md`](SPEC.md) ·
+[`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)

--- a/docs/DELEGATED-NVFP4-MOE.md
+++ b/docs/DELEGATED-NVFP4-MOE.md
@@ -1,382 +1,208 @@
 # Delegated NVFP4 MoE groups on GB10 (`sm_121`)
 
-A gridbook artifact is a **mixed container**. Config groups that carry a
-`"scheme"` key are CB groups and are served by this plugin; groups without one
-use the stock `compressed-tensors` vocabulary and are **delegated** to a real
-`CompressedTensorsConfig` that the plugin constructs — see
-[`SPEC.md` §6](SPEC.md) ("prefix is a plain NVFP4 / FP8 layer of a mixed
-container → delegate to the runtime's stock `compressed-tensors` handling",
-`docs/SPEC.md:397-400`) and [`PLUGIN.md`](PLUGIN.md) (`docs/PLUGIN.md:43-50`).
+A gridbook artifact can mix CB groups, which this plugin serves, with ordinary
+`compressed-tensors` groups, which gridbook delegates back to vLLM. This page
+covers one narrow case: a delegated NVFP4 **MoE** group on GB10. It does not
+apply to gridbook's own CB expert stacks or to delegated dense Linears.
 
-The consequence is already stated in two places and then dropped:
+No currently published gridbook artifact has such a group. The page is an
+operator check for future mixed artifacts, not a claim about the three current
+model releases.
 
-- `docs/PLUGIN.md:49-50` — "an artifact's hardware requirements are the union of
-  gridbook's and those of its delegated groups."
-- `docs/INSTALL.md:86-88` — "Those groups carry **their own** hardware
-  requirements, independent of gridbook's kernels."
+## Version scope
 
-This page is the missing half of that sentence for the case that actually bites
-on the reference target: **a delegated NVFP4 MoE group on GB10.** The failure it
-documents is not a crash — it is a *silent* numerics change.
+The NVFP4 MoE oracle is an internal vLLM interface and changes quickly. The
+claims below were source-checked against both:
 
-- [Scope: does this apply to me?](#scope-does-this-apply-to-me)
-- [1. The capability-family formula](#1-the-capability-family-formula)
-- [2. Which NVFP4 MoE backends run on GB10](#2-which-nvfp4-moe-backends-run-on-gb10)
-- [3. The silent one: MARLIN drops the activation scale](#3-the-silent-one-marlin-drops-the-activation-scale)
-- [4. Why relaxing the CUTEDSL / TRTLLM gate does not help](#4-why-relaxing-the-cutedsl--trtllm-gate-does-not-help)
-- [5. What `auto` picks, and the exact `--kernel-config` spellings](#5-what-auto-picks-and-the-exact---kernel-config-spellings)
-- [6. A gate you can run before you serve](#6-a-gate-you-can-run-before-you-serve)
-- [7. Provenance: what is code-read and what is measured](#7-provenance-what-is-code-read-and-what-is-measured)
-
----
-
-## Scope: does this apply to me?
-
-**Only if a delegated (non-CB) group in your artifact is an NVFP4 *MoE* group.**
-
-| Situation | This page applies? |
+| Build | Role |
 |---|---|
-| CB expert band served by the gridbook plugin | **No.** CB groups do not go through vLLM's NVFP4 MoE oracle at all, and gridbook artifacts do not use `--kernel-config` for them. Use `--quantization gridbook`. |
-| Delegated NVFP4 **MoE** group (`w13`/`w2` stacked experts) | **Yes** — all of it. |
-| Delegated NVFP4 **dense Linear** group (e.g. the 27B's vision tower) | **Partly.** §1 is what "Blackwell-class" means precisely; §2–§6 are MoE-path only. |
-| Delegated FP8 Linears (e.g. the 295B's 36 vanilla-FP8 Linears) | **No.** |
+| `0.23.1rc1.dev764+g54b16d8a9.d20260703` | gridbook's measured reference image |
+| `0.24.0` | current review image |
 
-**None of the three currently published artifacts contains a delegated NVFP4 MoE
-group** — the 295B's non-CB groups are FP8 Linears and the 27B's is an NVFP4
-W4A16 vision tower (`docs/PLUGIN.md:47-49`). This page is therefore forward-looking:
-it is for anyone producing a mixed container that leaves an MoE band to stock
-`compressed-tensors`, and for anyone reading `docs/INSTALL.md:86-88` and wondering
-what "their own hardware requirements" costs on this box.
+The capability predicate, compressed-tensors scheme dispatch, automatic backend
+order, Marlin conversion, and Marlin warning described here are the same in
+both builds. Backend activation support differs in places, so treat the table
+as scoped to these builds and re-check it when changing vLLM or FlashInfer.
 
----
+## Identify the declared scheme
 
-## 1. The capability-family formula
+Read the resolved `compressed-tensors` config group that targets all three MoE
+projections (gate, up, and down):
 
-GB10 is `sm_121`. vLLM's family predicate is integer division by ten:
+- NVFP4 `weights` plus NVFP4 `input_activations` declares **W4A4**.
+- NVFP4 `weights` plus `input_activations: null` (or no activation entry)
+  declares **W4A16**.
+
+That is also how vLLM decides: `CompressedTensorsMoEMethod.get_moe_method` reads
+the resolved group's `weights` and `input_activations`, then constructs the
+NVFP4 method with `use_a16=(input_quant is None)`.
+
+Do not infer the scheme from whether a safetensors key such as
+`input_global_scale` happens to exist. Runtime parameter creation and conversion
+can allocate or synthesize scale tensors. The config declaration, after target
+and ignore resolution, is the contract.
+
+Groups with a gridbook `"scheme"` key are CB groups and never enter this vLLM
+oracle. See [the format specification](SPEC.md#6-runtime-registration-and-dispatch).
+
+## Why GB10 is family 120
+
+GB10 reports CUDA capability `sm_121`. In both audited builds,
+`is_device_capability_family` compares:
 
 ```python
-return (current_capability.to_int() // 10) == (capability // 10)
+(current_capability.to_int() // 10) == (capability // 10)
 ```
 
-— vLLM `vllm/platforms/interface.py:363-375` (`is_device_capability_family`).
+Therefore `121 // 10 == 120 // 10` and GB10 is in family 120, not family
+100. This differs from `has_device_capability(100)`, which is a minimum check
+and is true because `121 >= 100`.
 
-`sm_121` → `to_int()` = `121` → `121 // 10` = **12**. So GB10 matches
-`is_device_capability_family(120)` and **fails** `is_device_capability_family(100)`.
+This distinction explains why a backend gated by `family(100)` does not run on
+GB10 even though a separate `has_device_capability(100)` check passes.
 
-This is the single fact that decides everything below, and it is easy to get
-wrong in the other direction: "Blackwell" is not one family here. `sm_100`
-(GB100/GB200) is family 10; `sm_120`/`sm_121` (RTX 50-series, GB10) is family 12.
-A backend that gates on `family(100)` and calls itself "Blackwell-only" is
-**not** available on a DGX Spark. The gate is correct; only its prose is
-misleading.
+## Backend behavior on GB10
 
-### Two predicates, both spelled "100", opposite answers on GB10
+The table describes source eligibility, not a promise that a particular wheel,
+shape, activation, or parallel configuration will pass every runtime check.
 
-vLLM has a *second* capability predicate and the two are easy to confuse when
-skim-reading a gate, because both take the literal `100`:
-
-| Call | Meaning | On `sm_121` |
-|---|---|---|
-| `is_device_capability_family(100)` | **exact family**: `121 // 10 == 100 // 10` → `12 == 10` | **False** |
-| `has_device_capability(100)` | **floor**: `to_int() >= 100` → `121 >= 100` — `vllm/platforms/interface.py:315-336` | **True** |
-
-`FlashInferExperts` uses *both*: `family(120)` in its device gate and
-`has_device_capability(100)` — the floor — to admit the NVFP4 scheme pair
-(`experts/flashinfer_cutlass_moe.py:177-184`). That is why it is available on
-GB10 while CUTEDSL and TRTLLM, which use the family form, are not. Read the
-predicate name, not the number.
-
----
-
-## 2. Which NVFP4 MoE backends run on GB10
-
-Every gate below is `_supports_current_device()` on the expert class, consumed by
-`is_supported_config()` (`modular_kernel.py:536-547`).
-Line numbers throughout this page are **vLLM v0.23.0**
-(see [§7](#7-provenance-what-is-code-read-and-what-is-measured)). A path that
-starts with `vllm/`, `csrc/` or `CMakeLists.txt` is relative to the vLLM source
-root; every other path (`experts/…`, `oracle/…`, `modular_kernel.py`,
-`config.py`) is relative to **`vllm/model_executor/layers/fused_moe/`**.
-
-| `moe_backend` | Device gate | On GB10 | Accepts a W4A16 checkpoint? |
+| Backend | GB10 device gate | Declared NVFP4 schemes | Important behavior |
 |---|---|---|---|
-| `flashinfer_cutlass` | `is_device_capability(90) or family(100) or family(120)`, plus `has_flashinfer_cutlass_fused_moe()` — `experts/flashinfer_cutlass_moe.py:131-143` | ✅ (admits the NVFP4 pair via the `has_device_capability(100)` **floor**, `experts/flashinfer_cutlass_moe.py:177-184`) | ❌ needs `(kNvfp4Static, kNvfp4Dynamic)` — `experts/flashinfer_cutlass_moe.py:149-185` |
-| `cutlass` (logs as `VLLM_CUTLASS`) | `family(100) or family(110) or family(120)` — `experts/cutlass_moe.py:692-699` | ✅ | ❌ `_supports_quant_scheme` is `== (kNvfp4Static, kNvfp4Dynamic)` — `experts/cutlass_moe.py:706-710` |
-| `flashinfer_cutedsl` | `family(100)` only — `experts/flashinfer_cutedsl_moe.py:68-75` | ❌ | ❌ |
-| `flashinfer_trtllm` | `family(100)` only — `experts/trtllm_nvfp4_moe.py:112-120` | ❌ | ❌ |
-| *(`FLASHINFER_CUTEDSL_BATCHED`, reached only via the batched activation format)* | `family(100)` only — `experts/flashinfer_cutedsl_batched_moe.py:61-68` | ❌ | ❌ |
-| `flashinfer_b12x` | `family(120)`, plus `has_flashinfer_b12x_moe()` — `experts/flashinfer_b12x_moe.py:133-140` | ✅ device-wise, but **excluded from `auto`** — `oracle/nvfp4.py:170-182` | ✅ accepts `(kNvfp4Static, None)` — `experts/flashinfer_b12x_moe.py:147-157` |
-| `marlin` | no family gate: `has_device_capability((7, 5))` — `experts/marlin_moe.py:590-593` | ✅ | ✅ — **and this is the trap, see [§3](#3-the-silent-one-marlin-drops-the-activation-scale)** |
-| `emulation` | no capability gate — inherits `TritonExperts`: `is_cuda_alike() or is_xpu()` (`experts/triton_moe.py:71-73`) | ✅ correctness only | ❌ raises if `a13_scale`/`a2_scale` are `None` — `oracle/nvfp4.py:430-434` |
-| `humming` | accepted by the config validator (`vllm/config/kernel.py:122-137`) but **absent from the NVFP4 oracle's `map_nvfp4_backend`** (`oracle/nvfp4.py:141-157`). The Humming expert classes are wired into the **MXFP4** oracle only (`oracle/mxfp4.py:160-165`) | ❌ raises `ValueError` at startup on v0.23.0 | n/a |
+| `flashinfer_trtllm` | family 100 | W4A4 | Rejected by the device-family gate. |
+| `flashinfer_cutedsl` | family 100 | W4A4 | Rejected by the device-family gate. The batched variant has the same gate. |
+| `flashinfer_cutlass` | includes family 120 and requires its FlashInfer feature | W4A4 | First native W4A4 candidate in `auto` on GB10. |
+| `cutlass` (logged as `VLLM_CUTLASS`) | includes family 120 | W4A4 | Second native W4A4 candidate. The wheel must contain the SM12x op; the audited reference source restricts this path to BF16 output on SM12x. |
+| `marlin` | CUDA capability 7.5 or newer | W4A4 and W4A16 pass its selector | Always builds the NVFP4 **W4A16** quant config. For W4A4 input, activation scales are discarded. |
+| `emulation` | CUDA/Triton support | W4A4 | Slow correctness path; preserves activation QDQ. |
+| `flashinfer_b12x` | family 120 and its FlashInfer feature | W4A4 and W4A16 | Explicit opt-in only; excluded from `auto`. It dynamically quantizes BF16 activations to FP4 in-kernel, including for a W4A16 declaration. Do not describe that case as W4A16 compute. |
 
-**The two fused NVFP4 MoE backends that actually work on GB10 are
-`FLASHINFER_CUTLASS` and `VLLM_CUTLASS`.** Both require a W4A4 checkpoint.
+`flashinfer_b12x` is especially version-sensitive. In the audited builds it is
+excluded from automatic selection pending an SM121 MMA guard, and its accepted
+activations differ between the reference nightly and 0.24. It has not been
+validated by a published gridbook model. Pinning it is an explicit experiment,
+not a general W4A16 recommendation.
 
-### `VLLM_CUTLASS` has a build-time precondition and a dtype restriction
+Although `humming` is accepted by the general kernel-config validator in these
+builds, the NVFP4 oracle does not map it. An explicit NVFP4 request therefore
+fails at startup rather than selecting a Humming implementation.
 
-Passing the device gate is necessary, not sufficient. The grouped GEMM behind
-`CutlassExpertsFp4` dispatches to an SM120 code path that only exists if the
-vLLM wheel was compiled for a 12.x arch:
+## The Marlin mismatch is underdiagnosed, not log-silent
 
-- `CMakeLists.txt:927-932` picks `FP4_ARCHS` (`12.0f` under CUDA ≥ 13.0, else
-  `12.0a;12.1a`), and `CMakeLists.txt:948-950` then defines `ENABLE_NVFP4_SM120=1`
-  / `-DENABLE_CUTLASS_MOE_SM120=1`.
-- `csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu:612-618`
-  routes `version_num >= 120 && version_num < 130` to
-  `run_fp4_blockwise_scaled_group_mm_sm120` (`ArchTag = cutlass::arch::Sm120`,
-  `OpClassBlockScaledTensorOp` — same file `:439-440`).
-- **bf16 output only.** A non-bf16 output dtype on a 12.x device hits
-  `STD_TORCH_CHECK_NOT_IMPLEMENTED(false, "SM120 NVFP4 MOE only supports bfloat16
-  output, ...")` — same file `:699-707`. Serve `--dtype bfloat16`.
+Marlin's `_supports_quant_scheme` checks the NVFP4 weight key but does not use
+the activation key. A W4A4 pair consequently passes selection. The NVFP4
+conversion then:
 
-A wheel built without those archs does not fail the *Python* gate; it fails
-inside the op with "No compiled `cutlass_fp4_group_mm` kernel for CUDA device
-capability: 121" (same file `:628-631`).
+1. sets both activation-scale arguments to `None`;
+2. prepares the weights for Marlin; and
+3. builds `nvfp4_w4a16_moe_quant_config`, whose interface has no activation
+   scale.
 
----
+The result is weight-only W4A16 execution even when the resolved config group
+declared W4A4.
 
-## 3. The silent one: MARLIN drops the activation scale
+This is visible in logs, but not diagnosed precisely. Both audited builds emit:
 
-This is the reason this page exists. **`marlin` is the only backend in the table
-that will load a W4A4 NVFP4 MoE group on GB10 and serve it with different
-numerics than the checkpoint declares — with no warning line.**
+- an INFO line selecting the `MARLIN` NVFP4 MoE backend; and
+- a WARNING saying weight-only FP4 compression will use Marlin.
 
-Three steps in vLLM's own source, in order:
+The warning does **not** say that the selected group declared W4A4, name the
+activation scales being dropped, or distinguish intentional W4A16 from a W4A4
+fallback. That missing connection is the operational hazard. A Marlin run of a
+W4A4 group must not be reported as a W4A4 activation-quantization result.
 
-**(a) MARLIN's scheme check ignores the activation half entirely.** Where the
-CUTLASS backends compare the *pair*, MARLIN compares only the weight key:
+## What `auto` can select
 
-```python
-    SUPPORTED_W = [ ... kNvfp4Static, ... ]
-    return weight_key in SUPPORTED_W
+For NVFP4 MoE, both audited builds try:
+
+```text
+FLASHINFER_TRTLLM
+→ FLASHINFER_CUTEDSL
+→ FLASHINFER_CUTEDSL_BATCHED
+→ FLASHINFER_CUTLASS
+→ VLLM_CUTLASS
+→ MARLIN
+→ EMULATION
 ```
 
-— `experts/marlin_moe.py:600-619`. `activation_key` is a parameter and is never
-read. So a `(kNvfp4Static, kNvfp4Dynamic)` W4A4 group is "supported".
+`FLASHINFER_B12X` is not in that list.
 
-**(b) The activation scales are then set to `None`.**
+On GB10, the family check eliminates the first three. For a W4A4 declaration,
+`auto` next tries the two native W4A4 candidates, but either may still fail an
+extension, activation, shape, dtype, or deployment-config check. Marlin is the
+next candidate and accepts the NVFP4 weight key. Never assume that `auto` chose
+a native W4A4 path.
 
-```python
-    elif nvfp4_backend == NvFp4MoeBackend.MARLIN:
-        a13_scale = None
-        a2_scale = None
-```
-
-— `oracle/nvfp4.py:405-407`, in `convert_to_nvfp4_moe_kernel_format`. The
-`prepare_nvfp4_moe_layer_for_marlin` call immediately below it takes no
-activation-scale argument at all.
-
-**(c) The quant config built for the kernel is the weight-only one.**
-
-```python
-    if backend == NvFp4MoeBackend.MARLIN:
-        return nvfp4_w4a16_moe_quant_config(...)
-```
-
-— `oracle/nvfp4.py:478-484`. The function name is the proof, and its signature
-(`config.py:855-860`) has **no** `a1_gscale`/`a2_gscale` parameter —
-there is nowhere for a calibrated activation scale to go.
-
-Contrast the fused path, same file, same function:
-
-```python
-    return nvfp4_moe_quant_config(
-        g1_alphas=w13_scale_2,
-        g2_alphas=w2_scale_2,
-        a1_gscale=(1.0 / a13_scale),
-        a2_gscale=(1.0 / a2_scale),
-        ...
-```
-
-— `oracle/nvfp4.py:500-505`. The reciprocal is the checkpoint's calibrated
-per-expert input global scale being handed to the kernel.
-
-**Net effect.** Weights load, the server starts, every request succeeds, and
-every token is computed with **W4A16** numerics from a **W4A4** checkpoint. The
-only externally visible symptom is a quality change. There is no `WARNING`,
-because from vLLM's point of view nothing went wrong — MARLIN is a weight-only
-kernel and it did exactly what it does.
-
-> **If you benchmark a W4A4 delegated group under `marlin`, you are not
-> benchmarking W4A4.** Do not quote such a run as an activation-quantization
-> comparison.
-
-The mirror-image case is loud and therefore harmless: a genuinely weight-only
-(W4A16) group whose `QuantKey` ends `xNone` is *rejected* by every fused backend
-at startup, because their `_supports_quant_scheme` requires the pair
-(`experts/cutlass_moe.py:706-710`, `experts/flashinfer_cutedsl_moe.py:82-89`,
-`experts/trtllm_nvfp4_moe.py:128-136`). You get a `ValueError` naming the
-scheme, not a silent degrade.
-
----
-
-## 4. Why relaxing the CUTEDSL / TRTLLM gate does not help
-
-The obvious "fix" — patch `family(100)` to also accept `family(120)` in
-`experts/flashinfer_cutedsl_moe.py:68-75` and `experts/trtllm_nvfp4_moe.py:112-120`
-— does not produce a working backend on GB10. The device gate is not the thing
-protecting you.
-
-Each of those gates is an `and` of the family check with an availability probe:
-`has_flashinfer_cutedsl_moe_nvfp4()` (`experts/flashinfer_cutedsl_moe.py:74`)
-and `has_flashinfer_trtllm_fused_moe()` (`experts/trtllm_nvfp4_moe.py:119`). On
-GB10 **both probes return `True`** — the FlashInfer package is importable and
-reports the feature present. Removing the family check therefore lets selection
-succeed and moves the failure downstream, into code that has no fallback:
-
-- **CUTEDSL** dies in FlashInfer's JIT at `get_nvcc_flags_list(
-  supported_major_versions=[10])` — the compile flags for this kernel are
-  enumerated for major version 10 only.
-- **TRTLLM** dies inside a prebuilt cubin whose name ends `_sm100f`.
-
-`FLASHINFER_CUDA_ARCH_LIST` only relocates the failure again; it does not
-conjure an sm_12x cubin. **Leave those gates alone.** The two CUTLASS backends
-in §2 are the supported answer.
-
-*(FlashInfer is a separate package, not part of the vLLM tree, so those last two
-symbols are quoted from an observed GB10 run rather than from a vLLM file:line —
-see [§7](#7-provenance-what-is-code-read-and-what-is-measured).)*
-
----
-
-## 5. What `auto` picks, and the exact `--kernel-config` spellings
-
-### The `auto` walk order
-
-`moe_backend="auto"` iterates this list and takes the first backend whose
-`is_supported_config()` returns `True` (`oracle/nvfp4.py:174-182`, loop at
-`oracle/nvfp4.py:315-329`):
-
-```
-FLASHINFER_TRTLLM → FLASHINFER_CUTEDSL → FLASHINFER_CUTEDSL_BATCHED
-                  → FLASHINFER_CUTLASS → VLLM_CUTLASS → MARLIN → EMULATION
-```
-
-`FLASHINFER_B12X` is deliberately **not** in that list — "intentionally excluded
-from auto-selection until the upstream CUTLASS SM121 MMA op guard is resolved"
-(`oracle/nvfp4.py:170-173`). It is opt-in only.
-
-Read that order against §2 and §3. On GB10 the first three are eliminated by the
-family gate, so a **W4A4** group lands on `FLASHINFER_CUTLASS` — the right
-answer. But a group that fails the fused backends' scheme check for any reason
-keeps walking, and the next stop that accepts it is **`MARLIN`**. That is the
-mechanism by which the silent W4A16 downgrade in §3 gets selected *by default*,
-without anyone typing `marlin`.
-
-**Pin the backend explicitly for any run you intend to quote.** `auto`'s answer
-is a property of your image and its device probes, not of your intent.
-
-### Canonical spellings
-
-`KernelConfig._normalize_moe_backend` lowercases and maps `-` → `_`
-(`vllm/config/kernel.py:211-216`), so case and dashes do not matter. These are
-the canonical forms:
+Pin the backend for a run whose numerics you intend to compare:
 
 ```bash
-# Fused W4A4 on GB10 — the recommended path for a delegated NVFP4 MoE group
+# Delegated W4A4; startup fails if the requested native path is unavailable.
 --kernel-config '{"moe_backend":"flashinfer_cutlass"}'
 
-# vLLM's own CUTLASS; also fused, also W4A4-only. Needs a wheel built with
-# ENABLE_NVFP4_SM120 and --dtype bfloat16 (see §2).
+# vLLM's native CUTLASS alternative. Use BF16 on the audited SM12x build.
+--dtype bfloat16 \
 --kernel-config '{"moe_backend":"cutlass"}'
 
-# Weight-only. Correct for a genuine W4A16 group; SILENTLY W4A16 for a W4A4 one.
+# Intentional weight-only W4A16.
 --kernel-config '{"moe_backend":"marlin"}'
 
-# Bisection only — proves a scheme is genuinely unsupported rather than
-# silently degraded, because it raises instead of dropping scales.
+# Slow W4A4 correctness check.
 --kernel-config '{"moe_backend":"emulation"}'
 ```
 
-### Confirm it at startup
+At startup, inspect the `Using '<BACKEND>' NvFp4 MoE backend` INFO line. If a
+W4A4 group says `MARLIN`, the runtime is using weight-only numerics regardless
+of the generic warning's wording.
 
-vLLM logs the choice once, from `_make_log_backend` (`oracle/nvfp4.py:200-205`):
+## Preflight policy
 
-```
-Using 'FLASHINFER_CUTLASS' NvFp4 MoE backend out of potential backends: [...]
-```
+A useful preflight has three outcomes:
 
-For a W4A4 delegated group on GB10 that name must be `FLASHINFER_CUTLASS` or
-`VLLM_CUTLASS`. If it says `MARLIN`, you are on §3.
+| Declared scheme | Requested backend | Result |
+|---|---|---|
+| W4A4 | `flashinfer_cutlass`, `cutlass`, or `emulation` | **PASS** for scheme compatibility; startup must still prove device/config support. |
+| W4A4 | `marlin` | **FAIL**: known conversion to W4A16. |
+| W4A4 | `flashinfer_b12x` | **UNKNOWN** for project validation: the source accepts it, but it is version-sensitive, opt-in, and untested by a published gridbook artifact. |
+| W4A16 | `marlin` | **PASS** for scheme compatibility. |
+| W4A16 | the audited W4A4-only backends | **FAIL**: unsupported declaration. |
+| W4A16 | `flashinfer_b12x` | **FAIL by default** if preserving W4A16 activation semantics is required; this opt-in backend dynamically quantizes activations. |
+| Either | `auto` | **UNKNOWN** until the serving environment runs every device and config probe. |
+| Either | unknown backend or unaudited vLLM version | **UNKNOWN**; update the versioned allowlist before serving. |
 
-**This does not apply to gridbook's own CB groups.** The CB expert band is
-claimed by the plugin, not by a vLLM NVFP4 MoE backend, and `--kernel-config` has
-no effect on it. See [`PLUGIN.md`](PLUGIN.md).
+Here, PASS means only that the declared activation semantics and requested
+backend agree. It does not prove the kernel is compiled or supports the model's
+shape and activation.
 
----
+Implement this as an explicit, versioned backend table. Do not try to future-
+proof it by inspecting whether `_supports_quant_scheme` reads
+`activation_key`: that method is only a selection predicate, not a runtime
+semantics contract. A future backend can accept a pair and still transform its
+scales, as the opt-in B12x path demonstrates.
 
-## 6. A gate you can run before you serve
+The preflight must resolve the target's declared config group, not scan tensor
+names. It must also return UNKNOWN for `auto` rather than turning missing
+environment information into a false pass.
 
-A note nobody reads is not a gate. The constructive form of §3 is a check that
-**fails the artifact** rather than describing the hazard:
+## Provenance and limits
 
-> Given (a) the artifact's declared activation scheme — does it ship
-> `input_scale` / `input_global_scale` tensors for its MoE band? — and (b) the
-> `moe_backend` you will actually serve with, refuse the combination when the
-> kernel would not honour the scheme the checkpoint declares.
->
-> - `W4A4 checkpoint` + a **weight-only** backend — on v0.23.0 that is
->   `marlin`, and in general any backend whose `_supports_quant_scheme`
->   ignores `activation_key` → **FAIL**: activation scales dropped, server
->   starts, numerics silently differ from `config.json`.
-> - `W4A16 checkpoint` + a **fused** backend (`flashinfer_cutlass`, `cutlass`,
->   `flashinfer_cutedsl`, `flashinfer_trtllm`, `emulation`) → **FAIL**: startup
->   raise (loud, but still worth catching before a queue slot is spent).
-> - anything else → pass.
->
-> Keep that first list keyed to the *predicate*, not to a fixed backend name:
-> a future backend that ignores `activation_key` inherits the same hazard, and
-> `humming` is only excluded here because v0.23.0's NVFP4 oracle has no mapping
-> for it at all ([§2](#2-which-nvfp4-moe-backends-run-on-gb10)).
->
-> The backend must be **supplied**, not inferred: with `auto` the tool cannot
-> know what the device probes will decide, so the honest result is
-> "not checked", not "pass".
+The review checked these vLLM source contracts in both versioned images:
 
-Closing this gap does not recover the numerics — under MARLIN they are
-unrecoverable by construction, the kernel is weight-only. It makes the mismatch
-**non-silent**, which is the entire failure mode.
+- `vllm/platforms/interface.py`:
+  `has_device_capability` and `is_device_capability_family`;
+- `compressed_tensors_moe.py`:
+  `CompressedTensorsMoEMethod.get_moe_method`;
+- `oracle/nvfp4.py`:
+  `select_nvfp4_moe_backend`,
+  `convert_to_nvfp4_moe_kernel_format`, and
+  `make_nvfp4_moe_quant_config`;
+- the backend classes' `_supports_current_device` and
+  `_supports_quant_scheme` methods; and
+- `marlin_utils_fp4.py`:
+  `prepare_nvfp4_moe_layer_for_marlin` and its warning.
 
-The natural home for this in gridbook is artifact-production time (see
-[`SPEC.md`](SPEC.md) on what a producer guarantees per group): if you delegate an
-MoE band to stock `compressed-tensors`, record in the artifact's card which
-`moe_backend` it was validated under, so a reader is not left to discover the
-downgrade from a quality delta.
+No delegated NVFP4 MoE gridbook artifact was served as part of this docs review,
+and this page intentionally publishes no throughput or quality number. Runtime
+support remains a property of the exact vLLM wheel, FlashInfer package, model
+configuration, and GPU.
 
----
-
-## 7. Provenance: what is code-read and what is measured
-
-**vLLM line numbers.** Every `vllm/...`, `csrc/...` and `CMakeLists.txt`
-reference on this page was read from a **vLLM v0.23.0** source tree, and each
-cited file was checked to be byte-identical to that release (no local patch on
-any file quoted here). vLLM moves fast and this surface is
-not a stability contract — re-grep for the symbol name (`is_device_capability_family`,
-`_supports_current_device`, `nvfp4_w4a16_moe_quant_config`) rather than trusting
-a line number against a different build. `INSTALL.md`'s reference stack is
-`0.23.1rc1.dev764+g54b16d8a9`, which is a *different* build from the v0.23.0
-tree these numbers came from; the symbols were identical in both as of writing,
-the numbers were checked only against v0.23.0.
-
-**Code-read, not run:** the whole of §1–§3 and §5 is a source reading. It
-requires no GPU and you can reproduce it with `grep` on your own vLLM.
-
-**Observed on GB10 hardware:** that `FLASHINFER_CUTLASS` and `VLLM_CUTLASS` both
-serve an NVFP4 W4A4 MoE checkpoint on `sm_121`; and the two downstream failure
-sites in §4 (`get_nvcc_flags_list(supported_major_versions=[10])`, the `_sm100f`
-cubin) after locally relaxing the family gate. Those observations were made
-serving a **standalone NVFP4 checkpoint**, not a gridbook mixed container — the
-delegated-group path composes the same vLLM code, but no published gridbook
-artifact exercises it yet (see [Scope](#scope-does-this-apply-to-me)).
-
-**Not measured, deliberately absent:** any throughput or quality number for a
-delegated NVFP4 MoE group inside a gridbook artifact, and any claim about
-`flashinfer_b12x`, which is listed in §2 from its gate only and has not been run
-here.
-
----
-
-**See also:** [`INSTALL.md` §Hardware matrix](INSTALL.md#hardware-matrix) ·
-[`PLUGIN.md`](PLUGIN.md) · [`SPEC.md`](SPEC.md) ·
-[`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)
+See also [installation and hardware](INSTALL.md#hardware-matrix),
+[plugin dispatch](PLUGIN.md), and [the format specification](SPEC.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -85,7 +85,12 @@ it already fails soft.
 
 Per-artifact caveat: an artifact may contain non-CB groups served by stock
 `compressed-tensors` (the 27B's vision tower is NVFP4 W4A16). Those groups carry
-**their own** hardware requirements, independent of gridbook's kernels.
+**their own** hardware requirements, independent of gridbook's kernels. For a
+delegated NVFP4 **MoE** group those requirements are sharper than the table
+above and one of the failure modes is silent — see
+[**`DELEGATED-NVFP4-MOE.md`**](DELEGATED-NVFP4-MOE.md), which spells out which
+vLLM NVFP4 MoE backends pass GB10's `sm_121` capability-family check and why
+`marlin` will serve a W4A4 group as W4A16 without logging anything.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -87,10 +87,10 @@ Per-artifact caveat: an artifact may contain non-CB groups served by stock
 `compressed-tensors` (the 27B's vision tower is NVFP4 W4A16). Those groups carry
 **their own** hardware requirements, independent of gridbook's kernels. For a
 delegated NVFP4 **MoE** group those requirements are sharper than the table
-above and one of the failure modes is silent — see
-[**`DELEGATED-NVFP4-MOE.md`**](DELEGATED-NVFP4-MOE.md), which spells out which
-vLLM NVFP4 MoE backends pass GB10's `sm_121` capability-family check and why
-`marlin` will serve a W4A4 group as W4A16 without logging anything.
+above — see [**`DELEGATED-NVFP4-MOE.md`**](DELEGATED-NVFP4-MOE.md) for the
+version-scoped GB10 backend matrix. In particular, Marlin logs a generic
+weight-only fallback but does not say that a W4A4 group's activation scales
+were discarded.
 
 ---
 

--- a/docs/hf-cards/Qwen3.6-27B-prismaquant-gridbook-5.5bit-vllm.md
+++ b/docs/hf-cards/Qwen3.6-27B-prismaquant-gridbook-5.5bit-vllm.md
@@ -103,7 +103,7 @@ Notes for this model:
   "Blackwell-class" is not one family — `sm_100` is capability family 10 and
   `sm_120`/`sm_121` is family 12, and vLLM's gates test the family, not the
   vendor name:
-  [what a delegated NVFP4 group gets on GB10](https://github.com/RobTand/gridbook/blob/master/docs/DELEGATED-NVFP4-MOE.md#1-the-capability-family-formula).
+  [the GB10 capability-family rule](https://github.com/RobTand/gridbook/blob/master/docs/DELEGATED-NVFP4-MOE.md#why-gb10-is-family-120).
 - **MTP draft block ships in BF16** but no speculative-decoding invocation is
   published for this artifact — the command above serves drafter-free.
 

--- a/docs/hf-cards/Qwen3.6-27B-prismaquant-gridbook-5.5bit-vllm.md
+++ b/docs/hf-cards/Qwen3.6-27B-prismaquant-gridbook-5.5bit-vllm.md
@@ -100,6 +100,10 @@ Notes for this model:
   [`docs/KERNELS.md` §CUDA-graph safety rules](https://github.com/RobTand/gridbook/blob/master/docs/KERNELS.md#cuda-graph-safety-rules).
 - **Vision tower** is NVFP4 weight-only (W4A16) and verified on image inputs; it
   needs a Blackwell-class or Marlin-supported path. Not tested on Ada.
+  "Blackwell-class" is not one family — `sm_100` is capability family 10 and
+  `sm_120`/`sm_121` is family 12, and vLLM's gates test the family, not the
+  vendor name:
+  [what a delegated NVFP4 group gets on GB10](https://github.com/RobTand/gridbook/blob/master/docs/DELEGATED-NVFP4-MOE.md#1-the-capability-family-formula).
 - **MTP draft block ships in BF16** but no speculative-decoding invocation is
   published for this artifact — the command above serves drafter-free.
 


### PR DESCRIPTION
## Summary

Document the backend-selection and activation-semantics hazards for a delegated
(non-CB) NVFP4 MoE group on GB10 (`sm_121`).

This adds an operator-focused page and links it from the main documentation,
installation guide, and the 27B model card. It is deliberately scoped to
delegated stock `compressed-tensors` groups; gridbook CB expert stacks do not
enter vLLM's NVFP4 MoE oracle.

No currently published gridbook artifact contains a delegated NVFP4 MoE group.
This is forward-looking guidance for future mixed containers.

## Audited behavior

The final documentation was source-checked against:

- gridbook reference image: vLLM
  `0.23.1rc1.dev764+g54b16d8a9.d20260703`
- current review image: vLLM `0.24.0`

The page records the contracts that agree across both versions:

- GB10's `sm_121` capability matches vLLM family 120, not family 100.
- W4A4 versus W4A16 is derived from the resolved
  `config_groups[*].input_activations` declaration, not the presence of tensor
  names in a checkpoint.
- On GB10, `auto` tries the family-compatible native W4A4 backends before
  Marlin, but extension, activation, shape, dtype, and deployment checks can
  still move selection to Marlin.
- Marlin's selector accepts an NVFP4 weight key regardless of activation key;
  conversion then drops the activation scales and constructs the W4A16 quant
  config.
- `flashinfer_b12x` is opt-in and excluded from `auto` in these builds. It
  accepts W4A16 declarations but dynamically quantizes BF16 activations to FP4,
  so that case must not be described as W4A16 compute.

## Review corrections

The contributor patch correctly identified the Marlin W4A4-to-W4A16 semantic
conversion, but its original logging claim was too strong. Both audited vLLM
builds emit:

- an INFO line naming the selected `MARLIN` backend; and
- a generic WARNING that Marlin will use weight-only FP4 compression.

What is missing is a precise diagnostic connecting that fallback to a W4A4
declaration and naming the discarded activation scales. The revised page calls
the behavior underdiagnosed rather than log-silent.

The reviewer commit also:

- replaces an unsound future-backend predicate rule with an explicit,
  versioned compatibility table;
- makes `auto` and unaudited versions return **UNKNOWN** in preflight guidance
  instead of a false pass;
- qualifies the version-sensitive B12x path;
- removes unsupported downstream FlashInfer assertions;
- shortens the page from 382 to 208 lines; and
- repairs the model-card anchor after reorganizing the page.

## Preflight policy

The documented policy separates scheme compatibility from runtime availability:

- W4A4 + native W4A4 backend: **PASS** for semantics, then prove runtime support
  at startup.
- W4A4 + Marlin: **FAIL**, because conversion is known to use W4A16 numerics.
- W4A16 + Marlin: **PASS** for semantics.
- `auto`, B12x project validation, unknown backends, or unaudited vLLM
  versions: **UNKNOWN** until the relevant runtime/version checks exist.

A gridbook config-time guard was not added. Gridbook delegates the group before
vLLM's oracle selects the actual backend, while `auto` depends on runtime GPU
and deployment probes. A correct fail-loud guard therefore belongs in a
version-aware artifact preflight or upstream oracle rather than a broad
gridbook dispatch check.

## Validation

- Source-contract assertions passed in both audited vLLM images for:
  - capability predicates;
  - compressed-tensors MoE scheme resolution;
  - NVFP4 automatic backend order;
  - Marlin selection, conversion, and warning;
  - B12x W4A4/W4A16 acceptance.
- `tests/test_delegation.py` under vLLM 0.24: **5 passed**.
- Seven new or modified local links and anchors checked.
- `git diff --check`: clean.

## Limitations

- Documentation only; no serving behavior changes.
- No delegated NVFP4 MoE gridbook artifact was served during review.
- B12x has not been validated by a published gridbook model.
- vLLM's MoE oracle is internal and fast-moving; the page explicitly requires a
  new audit when the vLLM or FlashInfer version changes.
- No throughput or quality claim is introduced.

## Attribution

Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.

The original contributor commit is preserved, followed by a separate reviewer
correction commit.