### PR TITLE
config/moe: resolve CB schemes per expert stack

### DIFF
--- a/gridbook/config.py
+++ b/gridbook/config.py
@@ -40,6 +40,35 @@ except Exception:  # pragma: no cover - older vLLM
 
 _MOE_LEAVES = ("gate_up_proj", "down_proj", "gate_proj", "up_proj")
 
+# MoE target leaf -> the PACKED STACK it lands in (w13 = the fused gate_up
+# buffer, w2 = down). Unfused ``gate_proj``/``up_proj`` targets fold into the
+# gate_up_proj stack and must therefore agree with each other
+# (``_moe_stack_schemes_for_prefix`` asserts it). The stack, not the layer, is
+# the unit a CB byte width is allocated for — see that method's docstring.
+_MOE_STACK_OF = {
+    "gate_up_proj": "gate_up_proj",
+    "gate_proj": "gate_up_proj",
+    "up_proj": "gate_up_proj",
+    "down_proj": "down_proj",
+}
+assert set(_MOE_STACK_OF) == set(_MOE_LEAVES)   # one list of MoE leaves
+
+def _scheme_signature(scheme: dict) -> tuple:
+    """Hashable, lossless signature of a resolved scheme.
+
+    Do not maintain a hand-picked field list here: exporter revisions may add a
+    format-bearing field, and treating two such schemes as interchangeable
+    would recreate the silent per-stack aliasing bug this resolver prevents.
+    """
+    def freeze(value):
+        if isinstance(value, dict):
+            return tuple(sorted((k, freeze(v)) for k, v in value.items()))
+        if isinstance(value, (list, tuple)):
+            return tuple(freeze(v) for v in value)
+        return value
+
+    return freeze(scheme)
+
 # vLLM fuses these siblings into one module; packed_modules_mapping is populated
 # by dispatch time, but we keep the standard mapping as a fallback.
 _FUSED_FALLBACK = {
@@ -364,46 +393,113 @@ class PrismaQuantConfig(QuantizationConfig):
         # FusedMoE expert stacks (RoutedExperts): a CB expert group -> our MoE
         # method; else delegate to the stock CT MoE path.
         if RoutedExperts is not None and isinstance(layer, RoutedExperts):
-            scheme = self._moe_scheme_for_prefix(prefix)
-            if scheme is not None:
+            # Per-STACK, not per-layer: the two packed expert buffers may sit
+            # on different rungs (see _moe_stack_schemes_for_prefix).
+            stacks = self._moe_stack_schemes_for_prefix(prefix)
+            if stacks is not None:
                 from .moe import PrismaQuantCBMoEMethod
                 return PrismaQuantCBMoEMethod(
-                    self, layer.moe_config, scheme, prefix)
+                    self, layer.moe_config, stacks, prefix)
             if self.ct_config is not None:
                 return self.ct_config.get_quant_method(layer, prefix)
             return None
         return None
 
-    def _moe_scheme_for_prefix(self, prefix: str) -> dict | None:
-        """A CB expert stack (targets like ``…experts.gate_up_proj`` /
-        ``…experts.down_proj``) under this FusedMoE prefix — return its scheme
-        (uniform per layer, so any matching target's scheme is the layer's)."""
-        # Canonicalise BOTH sides, exactly as ``_scheme_for_prefix`` does for
-        # Linears. Without this the multimodal wrapper breaks experts ONLY:
-        # vLLM hands us the serving prefix ``language_model.model.layers.N.mlp.
-        # experts`` while the checkpoint-namespace targets read
-        # ``model.language_model.layers.N.mlp.experts.gate_up_proj``, so a raw
-        # ``startswith`` misses, no CB MoE method is created, no
-        # ``w13_cb_qweight``/``w2_cb_qweight`` params exist, and the arch's own
-        # expert mapping then derives ``experts.w2_weight.cb_qweight`` and
-        # AttributeErrors (35B CB serve boot). Dense Linears were unaffected
-        # because their lookup already canonicalised — that asymmetry WAS the bug.
-        #
-        # Structurally different from the dense lookup (the TARGET is longer
-        # than the prefix here, so this is a ``startswith``, not a key lookup),
-        # but the namespace question is the same one — so it comes from the same
-        # ``_candidate_bases``, on BOTH sides. Cross-vintage matches are safe
-        # here: ``_canonical_prefix`` only rewrites the ``language_model``
-        # wrapper, i.e. it renames the SAME module; it can never move a match to
-        # a different layer index or leaf.
+    def _moe_stack_schemes_for_prefix(self, prefix: str) -> dict | None:
+        """The CB scheme of EACH packed expert stack under this FusedMoE
+        prefix: ``{"gate_up_proj": scheme, "down_proj": scheme}`` — or ``None``
+        when no CB expert target lives under the prefix at all.
+
+        RESOLUTION IS PER (LAYER, STACK), NOT PER LAYER.  A graded checkpoint
+        may place ``…experts.gate_up_proj`` on one rung and
+        ``…experts.down_proj`` on another (different ``k`` / ``n_sub`` /
+        ``type_size`` / ``codebook_ref``).  The two stacks are separately
+        allocated ``(E, out, row_bytes)`` byte buffers whose last dim is a
+        function of the stack's OWN ``type_size``, so collapsing the layer onto
+        one scheme mis-sizes the other buffer and the load dies in
+        ``_cb_load_weights`` with a shape mismatch — and, for two rungs that
+        happen to share a ``type_size``, would instead decode the whole stack
+        against the wrong codebook SILENTLY.
+
+        Unfused ``gate_proj``/``up_proj`` targets fold into the ``gate_up_proj``
+        stack (``_MOE_STACK_OF``) and must agree with each other, because they
+        land in the ONE ``w13`` buffer; disagreement is an exporter bug and is
+        raised, not resolved.
+
+        Namespace handling is ``_scheme_for_prefix``'s, unchanged: canonicalise
+        BOTH sides via ``_candidate_bases``.  Without it the multimodal wrapper
+        breaks experts ONLY: vLLM hands us the serving prefix
+        ``language_model.model.layers.N.mlp.experts`` while the
+        checkpoint-namespace targets read
+        ``model.language_model.layers.N.mlp.experts.gate_up_proj``, so a raw
+        ``startswith`` misses, no CB MoE method is created, no
+        ``w13_cb_qweight``/``w2_cb_qweight`` params exist, and the arch's own
+        expert mapping then derives ``experts.w2_weight.cb_qweight`` and
+        AttributeErrors (35B CB serve boot).  Dense Linears were unaffected
+        because their lookup already canonicalised — that asymmetry WAS the bug.
+
+        Structurally different from the dense lookup (the TARGET is longer than
+        the prefix here, so this is a ``startswith``, not a key lookup), but the
+        namespace question is the same one — so it comes from the same
+        ``_candidate_bases``, on BOTH sides.  Cross-vintage matches are safe
+        here: ``_canonical_prefix`` only rewrites the ``language_model``
+        wrapper, i.e. it renames the SAME module; it can never move a match to a
+        different layer index or leaf.
+        """
         bases = _candidate_bases(prefix)
+        out: dict[str, dict] = {}
+        claimed: dict[str, str] = {}
         for name, sch in self.target_scheme.items():
-            if name.split(".")[-1] not in _MOE_LEAVES:
+            stack = _MOE_STACK_OF.get(name.split(".")[-1])
+            if stack is None:
                 continue
             variants = _candidate_bases(name)
-            if any(v.startswith(b) for v in variants for b in bases):
-                return sch
-        return None
+            # A target must be a DIRECT dotted child of this expert prefix.
+            # Raw startswith also matches neighbouring modules such as
+            # ``experts2`` and ``experts_backup`` and can assign their rungs to
+            # the wrong live layer.
+            if not any(v.startswith(b.rstrip(".") + ".")
+                       for v in variants for b in bases):
+                continue
+            prev = out.get(stack)
+            if prev is None:
+                out[stack] = sch
+                claimed[stack] = name
+            elif prev is not sch and prev != sch:
+                raise ValueError(
+                    f"[prismaquant] FusedMoE {prefix}: targets "
+                    f"{claimed[stack]!r} and {name!r} both land in the "
+                    f"{stack} expert buffer but carry DIFFERENT CB schemes — "
+                    f"fix the exporter's config_groups (one scheme per "
+                    f"(layer, stack))")
+        return out or None
+
+    def _moe_scheme_for_prefix(self, prefix: str) -> dict | None:
+        """The single CB scheme of a UNIFORM FusedMoE layer under *prefix*, or
+        ``None`` when no CB expert target lives there.
+
+        Thin accessor over ``_moe_stack_schemes_for_prefix`` for callers that
+        want one subscriptable scheme.  A layer whose two stacks are on
+        DIFFERENT rungs has no such answer, so this raises rather than pick one
+        — picking one is exactly the bug the per-stack resolution fixes.  The
+        serving path does not use this: ``get_quant_method`` passes the
+        per-stack mapping straight to ``PrismaQuantCBMoEMethod``.
+        """
+        stacks = self._moe_stack_schemes_for_prefix(prefix)
+        if stacks is None:
+            return None
+        first = next(iter(stacks.values()))
+        sig = _scheme_signature(first)
+        for sch in stacks.values():
+            if _scheme_signature(sch) != sig:
+                rungs = ", ".join(
+                    "{}=k{}/ts{}".format(s, v.get("k"), v.get("type_size"))
+                    for s, v in sorted(stacks.items()))
+                raise ValueError(
+                    f"[prismaquant] FusedMoE {prefix}: expert stacks are on "
+                    f"different CB rungs ({rungs}) — there is no single layer "
+                    f"scheme; use _moe_stack_schemes_for_prefix")
+        return first
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper):
         self._ensure_resolved()

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -4,8 +4,10 @@
 Each expert stack ships as ONE tensor per role: ``<q>.cb_qweight`` uint8
 ``(E, out, (in/256)·type_size)`` (+ fp8 ``<q>.weight_scale`` ``(E, out)``), where
 ``cb_qweight[e]`` is exactly the dense §1 superblock layout. All experts of a
-stack share one format + one codebook (per-layer uniformity, union-find at
-export; asserted here). Serving mirrors ``GGUFMoEMethod``: register w13/w2 expert
+stack share one format + one codebook (per-STACK uniformity, union-find at
+export; asserted here) — but the two stacks of a layer may sit on DIFFERENT
+rungs, so every byte width, codebook and k_bits below is resolved per stack.
+Serving mirrors ``GGUFMoEMethod``: register w13/w2 expert
 buffers, then a per-expert **transient** decode (one expert's ``[out, in]`` bf16
 tile live at a time — INV-1, the dense transient pattern extended to experts).
 
@@ -72,6 +74,34 @@ def _row_bytes(in_features: int, type_size: int) -> int:
     return (in_features // codec.SUPERBLOCK) * type_size
 
 
+def _scale_coding_kind(scheme: dict):
+    """Normalise the two accepted ``scale_coding`` representations."""
+    sc = scheme.get("scale_coding")
+    return sc.get("kind") if isinstance(sc, dict) else sc
+
+
+def _scale_coding_table(scheme: dict):
+    """Return the two-tier compose sub-table for *scheme*, if applicable."""
+    if _scale_coding_kind(scheme) != codec.SCALE_CODING_TWO_TIER:
+        return None
+    sc = scheme.get("scale_coding")
+    if isinstance(sc, dict):
+        return sc.get("table") or codec.TWO_TIER_SUB_TABLE
+    return codec.TWO_TIER_SUB_TABLE
+
+
+def _scheme_signature(scheme: dict) -> tuple:
+    """Lossless signature used only to decide whether legacy aliases are safe."""
+    def freeze(value):
+        if isinstance(value, dict):
+            return tuple(sorted((k, freeze(v)) for k, v in value.items()))
+        if isinstance(value, (list, tuple)):
+            return tuple(freeze(v) for v in value)
+        return value
+
+    return freeze(scheme)
+
+
 # torch._grouped_mm — the single-launch ragged grouped GEMM (2d×3d: mat_a
 # [P,K] × mat_b [G,K,N] with cumulative-end offsets [G] -> [P,N]) that collapses
 # the batched-prefill per-expert-segment GEMMs into ONE kernel. Opt-in
@@ -100,31 +130,90 @@ def _disable_grouped_mm(exc) -> None:
 
 
 class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
-    """CB decode for RoutedExperts (FusedMoE) — one uniform CB format per layer."""
+    """CB decode for RoutedExperts — one CB format per (layer, stack).
+
+    A plain scheme remains accepted for uniform callers and fixtures.  The
+    serving resolver passes ``gate_up_proj`` and ``down_proj`` separately so
+    their rung, byte width and codebook may differ.  Grid and scale-coding kind
+    remain layer-wide because activation QDQ and kernel-family selection are
+    layer-wide decisions.
+    """
 
     def __init__(self, quant_config, moe: FusedMoEConfig, scheme: dict,
                  prefix: str) -> None:
         super().__init__(moe)
         self.quant_config = quant_config
-        self.scheme = scheme
         self.prefix = prefix
-        self.is_fp4 = scheme["grid"] == "fp4"
-        self.k = int(scheme["k"])
-        self.n_sub = int(scheme["n_sub"])
-        self.type_size = int(scheme["type_size"])
-        sc = scheme.get("scale_coding")
-        if isinstance(sc, dict):
-            self.is_v2 = sc.get("kind") == codec.SCALE_CODING_TWO_TIER
-            self._sub_table = sc.get("table") or codec.TWO_TIER_SUB_TABLE
-        else:
-            self.is_v2 = (sc == codec.SCALE_CODING_TWO_TIER)
-            self._sub_table = codec.TWO_TIER_SUB_TABLE if self.is_v2 else None
+        if "grid" in scheme:                  # single scheme -> both stacks
+            per = {"w13": scheme, "w2": scheme}
+        else:                                 # per-stack mapping
+            missing = {"gate_up_proj", "down_proj"} - set(scheme)
+            if missing:
+                raise ValueError(
+                    f"{prefix}: the CB config groups cover only "
+                    f"{sorted(scheme)} — a CB FusedMoE layer needs BOTH "
+                    f"gate_up_proj and down_proj (missing {sorted(missing)}); "
+                    f"a half-CB layer cannot serve, the other stack has no "
+                    f"owner")
+            per = {"w13": scheme["gate_up_proj"], "w2": scheme["down_proj"]}
+        self.stack_scheme = per
+        self.scheme = per["w13"]              # layer-level attrs read from w13
+        self._stack_formats_match = (
+            _scheme_signature(per["w13"]) == _scheme_signature(per["w2"]))
+        if (per["w13"]["grid"] != per["w2"]["grid"]
+                or _scale_coding_kind(per["w13"])
+                != _scale_coding_kind(per["w2"])):
+            raise NotImplementedError(
+                f"{prefix}: mixed GRID / scale-coding across the two expert "
+                f"stacks (gate_up={per['w13'].get('grid')}/"
+                f"{_scale_coding_kind(per['w13'])}, "
+                f"down={per['w2'].get('grid')}/"
+                f"{_scale_coding_kind(per['w2'])}) is not supported; only the "
+                f"RUNG (k / n_sub / type_size / codebook_ref) may differ")
+        self.is_fp4 = per["w13"]["grid"] == "fp4"
+        # PER-STACK rung constants. Dicts keyed 'w13'/'w2' — read them through
+        # ``_fmt``, never directly: that accessor also serves the plain-int
+        # attrs the GPU test fixtures set on a ``__new__``-built method.
+        self.k = {w: int(per[w]["k"]) for w in ("w13", "w2")}
+        self.n_sub = {w: int(per[w]["n_sub"]) for w in ("w13", "w2")}
+        self.type_size = {w: int(per[w]["type_size"]) for w in ("w13", "w2")}
+        self.is_v2 = (_scale_coding_kind(per["w13"])
+                      == codec.SCALE_CODING_TWO_TIER)
+        # Retained for back-compat readers; the compose tables are now built
+        # per stack from ``stack_scheme`` in process_weights_after_loading.
+        self._sub_table = _scale_coding_table(per["w13"])
         if self.is_fp4 and not self.is_v2:
             # fp4-v1 expert transient is a follow-up (no compose-during-expand);
             # export MoE experts as fp8-CB or fp4 two-tier v2.
             raise NotImplementedError(
                 f"{prefix}: fp4 MoE experts require two-tier v2 scale coding "
                 "(fp4-v1 expert transient not yet implemented)")
+
+    # -- per-stack accessors -------------------------------------------------
+    def _fmt(self, which: str) -> tuple[int, int, int]:
+        """``(k, n_sub, type_size)`` for stack *which* (``'w13'`` | ``'w2'``).
+
+        Falls back to the layer-uniform scalars when the attributes are plain
+        ints — GPU test fixtures build the method via ``__new__`` and set
+        ``m.k = 16`` etc., and those fixtures stay valid.
+        """
+        k, ns, ts = self.k, self.n_sub, self.type_size
+        if isinstance(k, dict):
+            return k[which], ns[which], ts[which]
+        return int(k), int(ns), int(ts)
+
+    @staticmethod
+    def _cb(layer, attr: str, which: str) -> torch.Tensor:
+        """Per-stack layer tensor ``_cb_<attr>_<which>`` (``flat`` /
+        ``compose``), falling back to the uniform ``_cb_<attr>`` that test
+        fixtures set directly on the layer."""
+        t = getattr(layer, f"_cb_{attr}_{which}", None)
+        if t is not None:
+            return t
+        if getattr(layer, "_cb_stack_uniform", True) is False:
+            raise AttributeError(
+                f"graded CB MoE layer is missing per-stack {attr!r} for {which}")
+        return getattr(layer, f"_cb_{attr}")
 
     # -- weight buffers (stacked experts) ------------------------------------
     def create_weights(self, layer: torch.nn.Module, num_experts: int,
@@ -140,8 +229,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # "Overwriting existing tensor attribute" assert — 35B first serve).
         attrs = dict(extra_weight_attrs)
         # w13 = gate_up: out=2*inter, in=hidden.  w2 = down: out=hidden, in=inter.
+        w13_ts = self._fmt("w13")[2]
+        w2_ts = self._fmt("w2")[2]
         w13 = torch.nn.Parameter(torch.empty(
-            E, 2 * inter, _row_bytes(hidden_size, self.type_size),
+            E, 2 * inter, _row_bytes(hidden_size, w13_ts),
             dtype=torch.uint8), requires_grad=False)
         set_weight_attrs(w13, {**attrs, "is_transposed": False})
         # Fill sentinel (cb_fill_guard): False until a fill path copies
@@ -153,7 +244,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w13_cb_qweight", w13)
 
         w2 = torch.nn.Parameter(torch.empty(
-            E, hidden_size, _row_bytes(inter, self.type_size),
+            E, hidden_size, _row_bytes(inter, w2_ts),
             dtype=torch.uint8), requires_grad=False)
         set_weight_attrs(w2, {**attrs, "is_transposed": False})
         mark_unfilled(w2)
@@ -223,25 +314,67 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         dev = layer.w13_cb_qweight.device
         E = layer.w13_cb_qweight.shape[0]
         codebooks = self.quant_config.get_codebooks()
-        ref = self.scheme["codebook_ref"]
-        names = ref if isinstance(ref, list) else [ref]
-        subs = [codebooks[n].to(dev) for n in names]
-        layer._cb_flat = codec.build_flat_codebook(subs)
+        stack_scheme = (getattr(self, "stack_scheme", None)
+                        or {"w13": self.scheme, "w2": self.scheme})
+        flats: dict[tuple, torch.Tensor] = {}
+        composes: dict[tuple, torch.Tensor] = {}
+        zero_compose = None
+        for which in ("w13", "w2"):
+            sch = stack_scheme[which]
+            ref = sch["codebook_ref"]
+            names = tuple(ref) if isinstance(ref, list) else (ref,)
+            if names not in flats:
+                flats[names] = codec.build_flat_codebook(
+                    [codebooks[n].to(dev) for n in names])
+            setattr(layer, f"_cb_flat_{which}", flats[names])
+
+            table = _scale_coding_table(sch)
+            if table is None:
+                if zero_compose is None:
+                    zero_compose = torch.zeros(
+                        1, dtype=torch.float32, device=dev)
+                compose = zero_compose
+            else:
+                table_key = tuple(table)
+                if table_key not in composes:
+                    composes[table_key] = codec.build_compose_table(
+                        list(table_key)).to(dev)
+                compose = composes[table_key]
+            setattr(layer, f"_cb_compose_{which}", compose)
+
+        # Legacy per-layer aliases are safe only when the COMPLETE resolved
+        # schemes match.  Equal codebook refs alone are insufficient: k/n_sub,
+        # row format or scale coding can still differ.  Delete aliases left by
+        # a reused/test layer so a stale consumer fails loudly on graded data.
+        uniform = (_scheme_signature(stack_scheme["w13"])
+                   == _scheme_signature(stack_scheme["w2"]))
+        layer._cb_stack_uniform = uniform
+        for attr in ("_cb_flat", "_cb_compose", "_cb_flat_fp8"):
+            if hasattr(layer, attr):
+                delattr(layer, attr)
+        if uniform:
+            layer._cb_flat = layer._cb_flat_w13
+            layer._cb_compose = layer._cb_compose_w13
+
         layer._cb_row0 = torch.zeros(1, dtype=torch.int32, device=dev)
-        if self.is_v2:
-            layer._cb_compose = codec.build_compose_table(
-                self._sub_table).to(dev)
-        else:
-            layer._cb_compose = torch.zeros(1, dtype=torch.float32, device=dev)
-        # Per-layer uniformity: one format for all experts (union-find at
-        # export). The stacked buffer is single-format by construction; assert
-        # the byte width matches the scheme so a mis-exported stack fails loudly.
-        exp_w13 = _row_bytes(layer._cb_hidden, self.type_size)
-        exp_w2 = _row_bytes(layer._cb_inter, self.type_size)
+        # Per-stack uniformity: each stacked buffer is single-format by
+        # construction.  Check it against that stack's own byte contract.
+        exp_w13 = _row_bytes(layer._cb_hidden, self._fmt("w13")[2])
+        exp_w2 = _row_bytes(layer._cb_inter, self._fmt("w2")[2])
         assert layer.w13_cb_qweight.shape[2] == exp_w13, (
             f"{self.prefix}: w13 byte width {layer.w13_cb_qweight.shape[2]} != "
-            f"{exp_w13} (type_size/uniformity mismatch)")
-        assert layer.w2_cb_qweight.shape[2] == exp_w2
+            f"{exp_w13} (type_size/per-stack-uniformity mismatch)")
+        assert layer.w2_cb_qweight.shape[2] == exp_w2, (
+            f"{self.prefix}: w2 byte width {layer.w2_cb_qweight.shape[2]} != "
+            f"{exp_w2} (type_size/per-stack-uniformity mismatch)")
+
+        # Warm all resident representations before a captured/compiled forward.
+        if self.is_fp4:
+            self._fp4_fused_tables(layer, "w13")
+            self._fp4_fused_tables(layer, "w2")
+        else:
+            self._flat_fp8(layer, "w13")
+            self._flat_fp8(layer, "w2")
         layer._cb_E = E
         from .ops import register_cb_layer
         layer._cb_layer_id = register_cb_layer(self, layer)
@@ -255,16 +388,18 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         out = qw.shape[0]
         # w13 in=hidden (gate_up), w2 in=inter (down).
         in_f = layer._cb_hidden if which == "w13" else layer._cb_inter
+        k, n_sub, type_size = self._fmt(which)                 # per-stack rung
         qwp = codec.pad_qweight(qw.contiguous())
         row0 = torch.zeros(out, dtype=torch.int32, device=qw.device)
         if self.is_fp4:                                        # fp4 v2
             W = expand_fp4_v2_to_weight(
-                qwp, layer._cb_flat, row0, layer._cb_compose,
-                out, in_f, self.k, self.n_sub, self.type_size)
+                qwp, self._cb(layer, "flat", which), row0,
+                self._cb(layer, "compose", which),
+                out, in_f, k, n_sub, type_size)
         else:                                                  # fp8
-            val = expand_cb_to_value(qwp, layer._cb_flat, row0,
-                                     out, in_f, self.k, self.n_sub,
-                                     self.type_size, is_fp4=False)
+            val = expand_cb_to_value(qwp, self._cb(layer, "flat", which), row0,
+                                     out, in_f, k, n_sub,
+                                     type_size, is_fp4=False)
             ws = getattr(layer, f"{which}_weight_scale")[e].to(torch.float32)
             W = (val.float() * ws[:, None]).to(torch.bfloat16)
         return W                                               # (out, in) bf16
@@ -487,15 +622,29 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         ok = getattr(layer, "_cb_gf4_ok", None)
         if ok is not None:
             return ok
+        def _rung_ok(which: str) -> bool:
+            k, n_sub, type_size = self._fmt(which)
+            if not (12 <= k <= 24 and n_sub in (1, 2)
+                    and type_size == 4 * k + 9):
+                return False
+            if n_sub == 2:
+                w0 = k - k // 2
+                return ((1 << w0) + (1 << (k // 2))) * 2 <= 16384
+            return True
+
         ok = (self.is_fp4 and self.is_v2
-              and 12 <= self.k <= 24
-              and self.n_sub in (1, 2)
-              and self.type_size == 4 * self.k + 9
+              and all(_rung_ok(which) for which in ("w13", "w2"))
               and layer._cb_hidden % codec.SUPERBLOCK == 0
               and layer._cb_inter % codec.SUPERBLOCK == 0)
-        if ok and self.n_sub == 2:
-            w0 = self.k - self.k // 2
-            ok = ((1 << w0) + (1 << (self.k // 2))) * 2 <= 16384
+        if ok:
+            for which, in_f in (("w13", layer._cb_hidden),
+                                ("w2", layer._cb_inter)):
+                qw = getattr(layer, f"{which}_cb_qweight")
+                row_bytes = _row_bytes(in_f, self._fmt(which)[2])
+                ok = ok and (qw.dim() == 3 and qw.stride(2) == 1
+                             and qw.stride(1) == row_bytes
+                             and qw.shape[2] == row_bytes
+                             and qw.stride(0) == qw.shape[1] * row_bytes)
         if ok:
             try:
                 import vllm._custom_ops as vops
@@ -508,6 +657,29 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             ok = fext is not None and hasattr(fext, "cb_fused_fp4_moe_grouped")
         layer._cb_gf4_ok = bool(ok)
         return layer._cb_gf4_ok
+
+    def _fp4_fused_tables(self, layer, which: str):
+        """Return the fp4 value LUT and compose bytes for one expert stack."""
+        attr = f"_cb_fp4_gf_{which}"
+        cached = getattr(layer, attr, None)
+        if cached is not None:
+            return cached
+        k, n_sub, _type_size = self._fmt(which)
+        scheme = (getattr(self, "stack_scheme", None)
+                  or {"w13": self.scheme, "w2": self.scheme})[which]
+        table = _scale_coding_table(scheme)
+        if table is None:
+            raise ValueError(
+                f"{self.prefix}.{which}: fp4 fused tables require two-tier "
+                "scale coding")
+        cached = (
+            codec.build_fp4_value_lut(
+                self._cb(layer, "flat", which), k, n_sub).to(
+                    layer.w13_cb_qweight.device),
+            codec.build_compose_u8(table).to(layer.w13_cb_qweight.device),
+        )
+        setattr(layer, attr, cached)
+        return cached
 
     def _fp4_quant(self, x2: torch.Tensor):
         """Native NVFP4 activation quant (packed e2m1 + swizzled ue4m3 SFA +
@@ -543,18 +715,16 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         inter = layer._cb_inter
         N1 = 2 * inter
         d = N1 // 2
-        kb = self.k
-
-        luts = getattr(layer, "_cb_fp4_gf", None)
-        if luts is None:
-            lut = codec.build_fp4_value_lut(
-                layer._cb_flat, kb, self.n_sub).to(dev)
-            compose = codec.build_compose_u8(self._sub_table).to(dev)
-            luts = (lut, compose,
-                    torch.ones(N1, dtype=torch.float32, device=dev),
+        k13, ns13, ts13 = self._fmt("w13")
+        k2, ns2, ts2 = self._fmt("w2")
+        lut13, compose13 = self._fp4_fused_tables(layer, "w13")
+        lut2, compose2 = self._fp4_fused_tables(layer, "w2")
+        ones = getattr(layer, "_cb_fp4_gf_ones", None)
+        if ones is None:
+            ones = (torch.ones(N1, dtype=torch.float32, device=dev),
                     torch.ones(Kh, dtype=torch.float32, device=dev))
-            layer._cb_fp4_gf = luts
-        lut, compose, ones_n1, ones_kh = luts
+            layer._cb_fp4_gf_ones = ones
+        ones_n1, ones_kh = ones
         w13 = layer.w13_cb_qweight.data
         w2 = layer.w2_cb_qweight.data
 
@@ -584,9 +754,9 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         aq1, sfa1, recip1 = self._fp4_quant(a_pad)
         del a_pad
         gate_up = fext.cb_fused_fp4_moe_grouped(
-            aq1, sfa1, w13, lut, compose,
+            aq1, sfa1, w13, lut13, compose13,
             recip1.expand(Mp).contiguous(), ones_n1, expert_ids,
-            N1, Kh, kb, self.n_sub, self.type_size, True, tile_m)   # [Mp, N1]
+            N1, Kh, k13, ns13, ts13, True, tile_m)       # [Mp, N1]
         del aq1, sfa1
         a = torch.empty((Mp, d), dtype=gate_up.dtype, device=dev)
         apply_moe_activation(act, a, gate_up)                       # silu(g)*u
@@ -596,9 +766,9 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         aq2, sfa2, recip2 = self._fp4_quant(a)
         del a
         y = fext.cb_fused_fp4_moe_grouped(
-            aq2, sfa2, w2, lut, compose,
+            aq2, sfa2, w2, lut2, compose2,
             recip2.expand(Mp).contiguous(), ones_kh, expert_ids,
-            Kh, inter, kb, self.n_sub, self.type_size, True, tile_m)
+            Kh, inter, k2, ns2, ts2, True, tile_m)
         del aq2, sfa2
 
         pw_pad = pw_sorted.index_select(0, row_src)
@@ -616,7 +786,8 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
           * fp8-CB only (the fused kernel's LUT is the 4-sub-table e4m3
             codebook; fp4 two-tier composes a scale the prologue can't);
           * k in {28,32,36,40,44,48} — the KBits template dispatch, uniform
-            per layer by the export union-find;
+            per STACK by the export union-find and checked per stack, since
+            the two projections are separate launches with their own k_bits;
           * both projection K's are multiples of 256 (SUPERBLOCK, and the
             kernel's K%256 check);
           * packed row stride == row_bytes == (K/256)*4*k, which satisfies
@@ -626,10 +797,14 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         ok = getattr(layer, "_cb_gf_ok", None)
         if ok is not None:
             return ok
+
+        def _rung_ok(which: str) -> bool:
+            k, n_sub, ts = self._fmt(which)
+            return (n_sub == 4 and k in (28, 32, 36, 40, 44, 48)
+                    and ts == 4 * k)
+
         ok = (not self.is_fp4
-              and self.n_sub == 4
-              and self.k in (28, 32, 36, 40, 44, 48)
-              and self.type_size == 4 * self.k
+              and all(_rung_ok(w) for w in ("w13", "w2"))
               and layer._cb_hidden % codec.SUPERBLOCK == 0
               and layer._cb_inter % codec.SUPERBLOCK == 0
               and hasattr(layer, "w13_weight_scale"))
@@ -644,7 +819,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             for which, in_f in (("w13", layer._cb_hidden),
                                 ("w2", layer._cb_inter)):
                 qw = getattr(layer, f"{which}_cb_qweight")
-                rb = _row_bytes(in_f, self.type_size)
+                rb = _row_bytes(in_f, self._fmt(which)[2])
                 # stride(0) matters only to R2, which hands the WHOLE stack to
                 # the kernel and TORCH_CHECKs the expert stride; checking it
                 # here keeps an exotic layout a silent fall-through rather than
@@ -716,8 +891,12 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         inter = layer._cb_inter
         N1 = 2 * inter                               # w13 out (gate_up)
         d = N1 // 2
-        lut = self._stock_cb_flat_fp8(layer)
-        kb = self.k
+        # Per-stack LUT + k_bits: each stage is its own launch, so the two may
+        # sit on different rungs (they are the same objects on a uniform layer).
+        lut13 = self._flat_fp8(layer, "w13")
+        lut2 = self._flat_fp8(layer, "w2")
+        kb13 = self._fmt("w13")[0]
+        kb2 = self._fmt("w2")[0]
         fp8_dtype = current_platform.fp8_dtype()
 
         out = torch.zeros_like(x)
@@ -753,9 +932,9 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
 
             # stage 1: gate_up = ae @ W13[e]^T (decode in prologue)
             gate_up = fext.cb_fused_prefill_mm_scaled(
-                ae, w13q[e], lut, ase,
+                ae, w13q[e], lut13, ase,
                 w13s[e].reshape(-1).to(torch.float32).contiguous(),
-                N1, Kh, kb)                                        # [m_e, N1]
+                N1, Kh, kb13)                                      # [m_e, N1]
             del ae, ase
             a = torch.empty((gate_up.shape[0], d), dtype=gate_up.dtype,
                             device=dev)
@@ -769,10 +948,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
 
             # stage 2: y = a2 @ W2[e]^T
             y = fext.cb_fused_prefill_mm_scaled(
-                a2.contiguous(), w2q[e], lut,
+                a2.contiguous(), w2q[e], lut2,
                 a2s.reshape(-1).to(torch.float32).contiguous(),
                 w2s[e].reshape(-1).to(torch.float32).contiguous(),
-                Kh, inter, kb)                                     # [m_e, Kh]
+                Kh, inter, kb2)                                    # [m_e, Kh]
             del a2, a2s
             y = y * pw_sorted[p0:p1, None].to(y.dtype)             # router w
             out.index_add_(0, rows, y.to(out.dtype))
@@ -804,33 +983,44 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         k_bits) pair can be uncompilable (shared-memory limit), so a hardcoded
         list would hand the kernel a tile it cannot serve.
 
-        Precedence: the per-rung query (the only one that knows this layer's
+        Precedence: the per-rung query (the only one that knows a stack's
         k_bits), then the general one, then the back-compat single default. An
         extension build predating the newer symbols therefore degrades to
         exactly the one tile it has always supported. Cached per layer (the
-        answer is a property of the build + the layer's rung)."""
+        answer is a property of the build + the layer's rungs).
+
+        BOTH STACKS, INTERSECTED. The padded row layout that TileM defines is a
+        property of the ROUTING (``cb_grouped_pad_routing``) and is shared by
+        the two stages, so a graded layer may only use a tile its w13 rung AND
+        its w2 rung are both compiled for. On a uniform layer the two queries
+        return the same set and the intersection is a no-op."""
         sizes = getattr(layer, "_cb_gf2_tiles", None)
         if sizes is not None:
             return sizes
         from .cuda_ext import get_fused_ext
         fext = get_fused_ext()
-        sizes = []
+        per_stack = []
         if fext is not None:
-            for getter, args in (
-                    ("cb_fused_moe_tile_sizes_for_kbits", (self.k,)),
-                    ("cb_fused_moe_tile_sizes", ()),
-                    ("cb_fused_moe_tile_m", ())):
-                fn = getattr(fext, getter, None)
-                if fn is None:
-                    continue
-                try:
-                    got = fn(*args)
-                except Exception:  # noqa: BLE001 — treat as "not offered"
-                    continue
-                got = [got] if isinstance(got, int) else list(got)
-                sizes = sorted({int(s) for s in got if int(s) > 0})
-                if sizes:
-                    break
+            for which in ("w13", "w2"):
+                got_sizes = []
+                for getter, args in (
+                        ("cb_fused_moe_tile_sizes_for_kbits",
+                         (self._fmt(which)[0],)),
+                        ("cb_fused_moe_tile_sizes", ()),
+                        ("cb_fused_moe_tile_m", ())):
+                    fn = getattr(fext, getter, None)
+                    if fn is None:
+                        continue
+                    try:
+                        got = fn(*args)
+                    except Exception:  # noqa: BLE001 — treat as "not offered"
+                        continue
+                    got = [got] if isinstance(got, int) else list(got)
+                    got_sizes = sorted({int(s) for s in got if int(s) > 0})
+                    if got_sizes:
+                        break
+                per_stack.append(set(got_sizes))
+        sizes = sorted(set.intersection(*per_stack)) if per_stack else []
         layer._cb_gf2_tiles = sizes
         return sizes
 
@@ -924,8 +1114,11 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         inter = layer._cb_inter
         N1 = 2 * inter                               # w13 out (gate_up)
         d = N1 // 2
-        lut = self._stock_cb_flat_fp8(layer)
-        kb = self.k
+        # Per-stack LUT + k_bits (one launch per stage — see R1).
+        lut13 = self._flat_fp8(layer, "w13")
+        lut2 = self._flat_fp8(layer, "w2")
+        kb13 = self._fmt("w13")[0]
+        kb2 = self._fmt("w2")[0]
         fp8_dtype = current_platform.fp8_dtype()
         # Never hardcode a tile: the kernel owns which TileM it compiled.
         tile_m = int(fext.cb_fused_moe_tile_m() if tile_m is None else tile_m)
@@ -974,8 +1167,8 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
 
         # stage 1: gate_up = a_pad @ W13[expert_of_tile]^T
         gate_up = self._grouped_call(
-            fext, (a_pad, layer.w13_cb_qweight.data, lut, as_pad, w13s,
-                   expert_ids, N1, Kh, kb), tile_m)                # [Mp, N1]
+            fext, (a_pad, layer.w13_cb_qweight.data, lut13, as_pad, w13s,
+                   expert_ids, N1, Kh, kb13), tile_m)              # [Mp, N1]
         del a_pad, as_pad
         if gate_up is None:                          # binding has no TileM knob
             return None
@@ -990,9 +1183,9 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # stage 2: y = a2 @ W2[expert_of_tile]^T — SAME expert_ids, the row
         # layout is a property of the routing, not of the projection.
         y = self._grouped_call(
-            fext, (a2.contiguous(), layer.w2_cb_qweight.data, lut,
+            fext, (a2.contiguous(), layer.w2_cb_qweight.data, lut2,
                    a2s.reshape(-1).to(torch.float32).contiguous(), w2s,
-                   expert_ids, Kh, inter, kb), tile_m)             # [Mp, Kh]
+                   expert_ids, Kh, inter, kb2), tile_m)            # [Mp, Kh]
         del a2, a2s
         if y is None:
             return None
@@ -1027,7 +1220,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         if ok is not None:
             return ok
         ok = (not self.is_fp4
-              and self.n_sub == 4
+              and all(self._fmt(w)[1] == 4 for w in ("w13", "w2"))
               and hasattr(layer, "w13_weight_scale")
               and layer._cb_hidden % codec.SUPERBLOCK == 0
               and layer._cb_inter % codec.SUPERBLOCK == 0)
@@ -1035,7 +1228,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             for which, in_f in (("w13", layer._cb_hidden),
                                 ("w2", layer._cb_inter)):
                 qw = getattr(layer, f"{which}_cb_qweight")
-                rb = _row_bytes(in_f, self.type_size)
+                rb = _row_bytes(in_f, self._fmt(which)[2])
                 ok = ok and (qw.dim() == 3 and qw.stride(2) == 1
                              and qw.stride(1) == rb and qw.shape[2] == rb
                              and qw.stride(0) == qw.shape[1] * rb)
@@ -1313,7 +1506,6 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         inter = layer._cb_inter
         N1 = 2 * inter
         d = N1 // 2
-        lut = self._stock_cb_flat_fp8(layer)
         fp8_dtype = current_platform.fp8_dtype()
 
         # ---- routing: R1's construction verbatim (ONE host sync) -----------
@@ -1370,9 +1562,13 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             in_f = Kh if which == "w13" else inter
             rows = n_e * out_f
             packed = getattr(layer, f"{which}_cb_qweight")[e0:e1]
+            # Per-stack LUT + rung: a unit decodes exactly one stack, and the
+            # two stacks may sit on different rungs.
+            k, n_sub, type_size = self._fmt(which)
             pq_ops.cb_expand_fp8_into(
-                halves[buf_idx], packed.reshape(rows, -1), lut,
-                row0[:rows], rows, in_f, self.k, self.n_sub, self.type_size)
+                halves[buf_idx], packed.reshape(rows, -1),
+                self._flat_fp8(layer, which),
+                row0[:rows], rows, in_f, k, n_sub, type_size)
 
         def _weights(unit, buf_idx):
             which, e0, e1, _p0, _p1 = unit
@@ -1590,7 +1786,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             record_autotune_timings(
                 best, timings,
                 layer_prefix=self.prefix,
-                fmt=("NVFP4_CB_K%d" if self.is_fp4 else "FP8_CB_K%d") % self.k,
+                fmt=self._autotune_format(),
                 regime=autotune_shape_regime(
                     num_tokens if num_tokens is not None else 0,
                     n_experts=getattr(layer, "_cb_E", None),
@@ -1601,6 +1797,16 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             )
         except Exception:                      # noqa: BLE001 — never fail a serve
             pass
+
+    def _autotune_format(self) -> str:
+        """Stable cost-table key that preserves both rungs on graded layers."""
+        family = "NVFP4_CB" if self.is_fp4 else "FP8_CB"
+        f13 = self._fmt("w13")
+        f2 = self._fmt("w2")
+        if f13 == f2:
+            return f"{family}_K{f13[0]}"
+        return (f"{family}[w13=K{f13[0]}/N{f13[1]}/T{f13[2]},"
+                f"w2=K{f2[0]}/N{f2[1]}/T{f2[2]}]")
 
     # -- prefill: per-expert loop (bisection reference) ---------------------
     def _apply_prefill_loop(self, layer, x, topk_weights, topk_ids, act):
@@ -1746,15 +1952,17 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         packed = getattr(layer, f"{which}_cb_qweight")[experts]   # [C,out,bytes]
         C, out_f = packed.shape[0], packed.shape[1]
         in_f = layer._cb_hidden if which == "w13" else layer._cb_inter
+        k, n_sub, type_size = self._fmt(which)                 # per-stack rung
         qwp = codec.pad_qweight(packed.reshape(C * out_f, -1).contiguous())
         row0 = torch.zeros(C * out_f, dtype=torch.int32, device=packed.device)
         if self.is_fp4:                                        # fp4 two-tier v2
             W = expand_fp4_v2_to_weight(
-                qwp, layer._cb_flat, row0, layer._cb_compose,
-                C * out_f, in_f, self.k, self.n_sub, self.type_size)
+                qwp, self._cb(layer, "flat", which), row0,
+                self._cb(layer, "compose", which),
+                C * out_f, in_f, k, n_sub, type_size)
         else:                                                  # fp8
-            val = expand_cb_to_value(qwp, layer._cb_flat, row0, C * out_f, in_f,
-                                     self.k, self.n_sub, self.type_size,
+            val = expand_cb_to_value(qwp, self._cb(layer, "flat", which), row0,
+                                     C * out_f, in_f, k, n_sub, type_size,
                                      is_fp4=False)
             ws = getattr(layer, f"{which}_weight_scale")[experts].reshape(
                 C * out_f).to(torch.float32)
@@ -2058,6 +2266,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         nE = c1 - c0
         out_f = packed.shape[1]
         in_f = layer._cb_hidden if which == "w13" else layer._cb_inter
+        k, n_sub, type_size = self._fmt(which)
         row0 = torch.zeros(nE * out_f, dtype=torch.int32, device=packed.device)
         if to_fp8:                                                # fp8 bytes
             # CUDA expander (2.1x the Triton one, byte-identical) on the RAW
@@ -2070,41 +2279,47 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
                 qwp = codec.pad_qweight(
                     packed.reshape(nE * out_f, -1).contiguous())
                 W = expand_cb_to_fp8(
-                    qwp, self._stock_cb_flat_fp8(layer), row0, nE * out_f,
-                    in_f, self.k, self.n_sub, self.type_size)
+                    qwp, self._flat_fp8(layer, which), row0, nE * out_f,
+                    in_f, k, n_sub, type_size)
             else:
                 from . import ops as pq_ops
                 W = pq_ops.cb_expand_fp8(
                     packed.reshape(nE * out_f, -1),
-                    self._stock_cb_flat_fp8(layer), row0, nE * out_f, in_f,
-                    self.k, self.n_sub, self.type_size)
+                    self._flat_fp8(layer, which), row0, nE * out_f, in_f,
+                    k, n_sub, type_size)
         elif self.is_fp4:                                         # fp4 two-tier v2
             qwp = codec.pad_qweight(
                 packed.reshape(nE * out_f, -1).contiguous())
             W = expand_fp4_v2_to_weight(
-                qwp, layer._cb_flat, row0, layer._cb_compose, nE * out_f, in_f,
-                self.k, self.n_sub, self.type_size)
+                qwp, self._cb(layer, "flat", which), row0,
+                self._cb(layer, "compose", which), nE * out_f, in_f,
+                k, n_sub, type_size)
         else:                                                     # fp8 -> bf16
             qwp = codec.pad_qweight(
                 packed.reshape(nE * out_f, -1).contiguous())
-            val = expand_cb_to_value(qwp, layer._cb_flat, row0, nE * out_f, in_f,
-                                     self.k, self.n_sub, self.type_size,
+            val = expand_cb_to_value(qwp, self._cb(layer, "flat", which), row0,
+                                     nE * out_f, in_f, k, n_sub, type_size,
                                      is_fp4=False)
             ws = getattr(layer, f"{which}_weight_scale")[c0:c1].reshape(
                 nE * out_f).to(torch.float32)
             W = (val.float() * ws[:, None]).to(torch.bfloat16)
         return W.view(nE, out_f, in_f)
 
-    @staticmethod
-    def _stock_cb_flat_fp8(layer) -> torch.Tensor:
-        """The per-layer codebook re-encoded to E4M3 bytes for the fp8-direct
-        expand (every CB value is on the e4m3 grid — lossless). Cached on the
-        layer (also built by the CUDA-decode gate); built once, before capture."""
-        cb = getattr(layer, "_cb_flat_fp8", None)
+    def _flat_fp8(self, layer, which: str) -> torch.Tensor:
+        """One stack's resident E4M3 LUT, with uniform-fixture compatibility."""
+        attr = f"_cb_flat_fp8_{which}"
+        cb = getattr(layer, attr, None)
         if cb is None:
-            cb = layer._cb_flat.to(torch.float8_e4m3fn).view(
-                torch.uint8).contiguous()
-            layer._cb_flat_fp8 = cb
+            legacy = getattr(layer, "_cb_flat_fp8", None)
+            specific = getattr(layer, f"_cb_flat_{which}", None)
+            if specific is None and legacy is not None:
+                cb = legacy
+            else:
+                cb = self._cb(layer, "flat", which).to(
+                    torch.float8_e4m3fn).view(torch.uint8).contiguous()
+            setattr(layer, attr, cb)
+            if getattr(layer, "_cb_stack_uniform", False):
+                layer._cb_flat_fp8 = cb
         return cb
 
     # -- grouped CUDA decode path -------------------------------------------
@@ -2114,18 +2329,20 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             # Grouped CUDA GEMV support: fp8-CB v1 (n_sub=4, per-(expert,out)
             # fp32 scale) and fp4-CB two-tier v2 (n_sub=2, scale composed
             # in-kernel from the packed 9-byte section). fp4-v1 (bare e4m3
-            # plane) has no grouped path yet.
-            fmt_ok = ((self.n_sub == 4 and not self.is_fp4)
-                      or (self.n_sub in (1, 2) and self.is_fp4
-                          and self.is_v2))
+            # plane) has no grouped path yet. BOTH stacks must qualify: they
+            # are separate launches on possibly different rungs.
+            def _ns_ok(ns: int) -> bool:
+                return ((ns == 4 and not self.is_fp4)
+                        or (ns in (1, 2) and self.is_fp4 and self.is_v2))
+            fmt_ok = all(_ns_ok(self._fmt(w)[1]) for w in ("w13", "w2"))
             ok = (fmt_ok and os.environ.get(
                 "PRISMAQUANT_CB_DECODE", "cuda") == "cuda")
             if ok:
                 from .cuda_ext import get_ext
                 ok = get_ext() is not None
-            if ok and not self.is_fp4 and not hasattr(layer, "_cb_flat_fp8"):
-                layer._cb_flat_fp8 = layer._cb_flat.to(
-                    torch.float8_e4m3fn).view(torch.uint8).contiguous()
+            if ok and not self.is_fp4:
+                for which in ("w13", "w2"):
+                    self._flat_fp8(layer, which)
             layer._cb_moe_cuda_ok = ok
         return ok
 
@@ -2154,6 +2371,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         pair_self = torch.arange(pair_expert.numel(), device=x.device,
                                  dtype=torch.int32)
 
+        k13, ns13, ts13 = self._fmt("w13")                # per-stack rung
         if self.is_fp4:                                  # fp4-CB two-tier v2
             # Activation QDQ (fp4 group-16 RTN) stays OUTSIDE the kernel,
             # bit-identical to the loop's codec.fp4_group16_act_qdq; the kernel
@@ -2161,31 +2379,35 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             # 9-byte section + the resident (256,16) compose table.
             xq = codec.fp4_group16_act_qdq(x).to(torch.bfloat16)
             gate_up = pq_ops.cb_moe_gemv_fp4_v2(
-                xq, layer.w13_cb_qweight.data, layer._cb_flat,
-                layer._cb_compose, pair_expert, pair_xrow,
-                self.k, self.n_sub, self.type_size)      # (P, 2*inter)
+                xq, layer.w13_cb_qweight.data,
+                self._cb(layer, "flat", "w13"),
+                self._cb(layer, "compose", "w13"), pair_expert, pair_xrow,
+                k13, ns13, ts13)                         # (P, 2*inter)
         else:                                            # fp8-CB v1
             xq = pq_ops.fp8_act_qdq(x.to(torch.bfloat16))
             gate_up = pq_ops.cb_moe_gemv_fp8(
-                xq, layer.w13_cb_qweight.data, layer._cb_flat_fp8,
+                xq, layer.w13_cb_qweight.data,
+                self._flat_fp8(layer, "w13"),
                 layer.w13_weight_scale.data, pair_expert, pair_xrow,
-                self.k, self.n_sub, self.type_size)      # (P, 2*inter)
+                k13, ns13, ts13)                         # (P, 2*inter)
 
         d = gate_up.shape[-1] // 2
         a = torch.empty(gate_up.shape[:-1] + (d,), dtype=gate_up.dtype,
                         device=gate_up.device)
         apply_moe_activation(act, a, gate_up)
 
+        k2, ns2, ts2 = self._fmt("w2")
         if self.is_fp4:
             aq = codec.fp4_group16_act_qdq(a).to(torch.bfloat16)
             y_down = pq_ops.cb_moe_gemv_fp4_v2(
-                aq, layer.w2_cb_qweight.data, layer._cb_flat,
-                layer._cb_compose, pair_expert, pair_self,
-                self.k, self.n_sub, self.type_size)      # (P, hidden)
+                aq, layer.w2_cb_qweight.data,
+                self._cb(layer, "flat", "w2"),
+                self._cb(layer, "compose", "w2"), pair_expert, pair_self,
+                k2, ns2, ts2)                            # (P, hidden)
         else:
             aq = pq_ops.fp8_act_qdq(a)
             y_down = pq_ops.cb_moe_gemv_fp8(
-                aq, layer.w2_cb_qweight.data, layer._cb_flat_fp8,
+                aq, layer.w2_cb_qweight.data, self._flat_fp8(layer, "w2"),
                 layer.w2_weight_scale.data, pair_expert, pair_self,
-                self.k, self.n_sub, self.type_size)      # (P, hidden)
+                k2, ns2, ts2)                            # (P, hidden)
         return pq_ops.cb_moe_combine(y_down, pair_w, tok_start, T)

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -349,6 +349,17 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         uniform = (_scheme_signature(stack_scheme["w13"])
                    == _scheme_signature(stack_scheme["w2"]))
         layer._cb_stack_uniform = uniform
+        # ``process_weights_after_loading`` is normally one-shot, but reload and
+        # test harnesses can reuse a module.  Resident encodings and eligibility
+        # answers are derived from the just-installed per-stack tables/formats;
+        # retaining any old one would silently undo the graded resolution.
+        for attr in (
+                "_cb_flat_fp8_w13", "_cb_flat_fp8_w2",
+                "_cb_fp4_gf_w13", "_cb_fp4_gf_w2", "_cb_fp4_gf_ones",
+                "_cb_gf4_ok", "_cb_gf_ok", "_cb_gf2_ok", "_cb_gf2_tiles",
+                "_cb_l2_ok"):
+            if hasattr(layer, attr):
+                delattr(layer, attr)
         for attr in ("_cb_flat", "_cb_compose", "_cb_flat_fp8"):
             if hasattr(layer, attr):
                 delattr(layer, attr)
@@ -664,6 +675,11 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         cached = getattr(layer, attr, None)
         if cached is not None:
             return cached
+        if which == "w2" and getattr(layer, "_cb_stack_uniform", False):
+            cached = getattr(layer, "_cb_fp4_gf_w13", None)
+            if cached is not None:
+                setattr(layer, attr, cached)
+                return cached
         k, n_sub, _type_size = self._fmt(which)
         scheme = (getattr(self, "stack_scheme", None)
                   or {"w13": self.scheme, "w2": self.scheme})[which]
@@ -2312,7 +2328,9 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         if cb is None:
             legacy = getattr(layer, "_cb_flat_fp8", None)
             specific = getattr(layer, f"_cb_flat_{which}", None)
-            if specific is None and legacy is not None:
+            if legacy is not None and (
+                    specific is None
+                    or getattr(layer, "_cb_stack_uniform", False)):
                 cb = legacy
             else:
                 cb = self._cb(layer, "flat", which).to(

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -569,22 +569,24 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # still wedges despite non-default-stream test battery green). The
         # L2-residency hypothesis remains unmeasured; do not add it to auto
         # candidates until a live serve survives a full prefill battery.
-        # fp4-MMA fused MoE prefill (OPT-IN, default OFF — the fp4 default
-        # below stays 'loop' and is byte-identical until
-        # PRISMAQUANT_CB_FUSED_FP4_MOE is set). One tile-indexed grouped
+        # fp4-MMA fused MoE prefill. One tile-indexed grouped
         # block-scaled launch per projection stage (OMMA.SF.16864, k=64),
         # the fp8 grouped_fused_v2 mechanism with the packed-CB decode in the
         # producer/prologue. Values: "1"/"128" tile_m=128, "256" tile_m=256.
         # NOTE the activation bucket changes on this path (native NVFP4 quant,
         # not codec.fp4_group16_act_qdq) — served-KL A/B required before any
         # promotion; any constraint miss falls through SILENTLY to the modes
-        # below (no behaviour change when the env is unset).
-        # DEFAULT-ON since 2026-07-31 (Robert's call); tile 128 is the measured
-        # best (5.2-5.6x the per-expert loop). PRISMAQUANT_CB_FUSED_FP4_MOE=0
-        # restores the per-expert loop. Same unvalidated-on-serving-metric
-        # caveat as the dense gate in linear.py applies.
+        # below. Uniform stacks remain DEFAULT-ON since 2026-07-31 (tile 128
+        # measured best at 5.2-5.6x the per-expert loop). Graded stacks are
+        # fail-closed by default: the per-stack argument wiring is implemented,
+        # but the current grouped extension fails CUTLASS initialization on
+        # GB10 even in its pre-existing uniform parity test. Explicitly setting
+        # PRISMAQUANT_CB_FUSED_FP4_MOE opts a graded stack into that experimental
+        # path; "0" restores the per-expert loop for every stack layout.
         if self.is_fp4 and num_tokens > 16:
-            gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "1").strip()
+            gf4_default = "1" if self._stack_formats_match else "0"
+            gf4 = os.environ.get(
+                "PRISMAQUANT_CB_FUSED_FP4_MOE", gf4_default).strip()
             if gf4 in ("1", "128", "256"):
                 out = self._apply_prefill_grouped_fused_fp4(
                     layer, x, topk_weights, topk_ids, act,

--- a/tests/test_moe_per_stack_rungs.py
+++ b/tests/test_moe_per_stack_rungs.py
@@ -1,0 +1,219 @@
+"""Per-(layer, STACK) CB scheme resolution for FusedMoE expert stacks.
+
+A graded checkpoint may put ``…experts.gate_up_proj`` on one rung and
+``…experts.down_proj`` on another.  The two stacks are separately allocated
+``(E, out, row_bytes)`` byte buffers whose last dimension is a function of the
+stack's OWN ``type_size``, so a resolver that returns ONE scheme per layer
+mis-sizes the other buffer (load-time shape error) — or, for two rungs that
+happen to share a ``type_size``, decodes it against the wrong codebook with no
+error at all.
+
+These tests are CPU-only and cover the config resolver
+(``_moe_stack_schemes_for_prefix``).  They deliberately re-assert the
+namespace-canonicalisation property that ``test_target_namespace_compat.py``
+owns for the single-scheme accessor: the per-stack resolver is a NEW entry
+point, and the multimodal wrapper regression (35B CB serve boot) must not be
+able to come back through it.
+
+vLLM symbols are stubbed when vLLM is unavailable, exactly as the namespace
+compat suite does — ``gridbook.config`` imports them at module scope.
+"""
+import sys
+import types
+
+import pytest
+
+if "vllm" not in sys.modules:
+    try:
+        import vllm  # noqa: F401
+    except Exception:
+        torch = pytest.importorskip("torch")
+
+        def _mod(name):
+            m = types.ModuleType(name)
+            sys.modules[name] = m
+            return m
+
+        _mod("vllm")
+        _mod("vllm.model_executor")
+        _mod("vllm.model_executor.layers")
+        _mod("vllm.model_executor.layers.quantization")
+        lin = _mod("vllm.model_executor.layers.linear")
+        lin.LinearBase = type("LinearBase", (), {})
+        lin.UnquantizedLinearMethod = type("UnquantizedLinearMethod", (), {})
+        lin.LinearMethodBase = type("LinearMethodBase", (), {})
+        lin.register_weight_loader_v2_supported_method = lambda cls: cls
+        par = _mod("vllm.model_executor.parameter")
+
+        class _StubParam(torch.nn.Parameter):
+            def __new__(cls, data, **kw):
+                return super().__new__(cls, data, requires_grad=False)
+
+            def __init__(self, data, **kw):
+                pass
+
+        par.ModelWeightParameter = _StubParam
+        par.ChannelQuantScaleParameter = _StubParam
+        bc = _mod("vllm.model_executor.layers.quantization.base_config")
+
+        class QuantizationConfig:
+            def __init__(self):
+                pass
+
+        bc.QuantizationConfig = QuantizationConfig
+        bc.QuantizeMethodBase = object
+        vpe = _mod("vllm.model_executor.layers.vocab_parallel_embedding")
+        vpe.UnquantizedEmbeddingMethod = type("UEM", (), {})
+        vpe.VocabParallelEmbedding = type("VPE", (), {})
+        fm = _mod("vllm.model_executor.layers.fused_moe")
+        fm.RoutedExperts = type("RoutedExperts", (), {})
+
+from gridbook.config import PrismaQuantConfig  # noqa: E402
+
+
+def _scheme(k, type_size, codebook_ref):
+    return {"grid": "fp8", "mode": "product", "k": k, "n_sub": 4,
+            "type_size": type_size, "group_size": 0, "vec_dim": 8,
+            "codebook_ref": [codebook_ref], "codebook_source": "learned"}
+
+
+# k44 -> type_size 4*44 = 176; k36 -> 144.  Two rungs, two byte widths.
+_RUNG_HI = _scheme(44, 176, "cb.k44")
+_RUNG_LO = _scheme(36, 144, "cb.k36")
+
+# The three namespace vintages a serving prefix can arrive in for layer 1's
+# expert stack (identical to the compat suite's list — the per-stack resolver
+# must answer the namespace question the same way the single-scheme one does).
+_MOE_EXPERT_PREFIXES = [
+    "language_model.model.layers.1.mlp.experts",   # wrapper-class serving form
+    "model.layers.1.mlp.experts",                  # canonical
+    "model.language_model.layers.1.mlp.experts",   # old checkpoint form
+]
+
+
+def _cfg(groups):
+    """``groups`` = list of (targets, scheme)."""
+    cfg = PrismaQuantConfig.from_config({
+        "quant_method": "prismaquant", "format": "fp8_cb",
+        "codebook_file": "cb_codebooks.pqcb",
+        "config_groups": {
+            f"g{i}": {"format": "FP8_CB", "targets": list(t),
+                      "scheme": dict(s)}
+            for i, (t, s) in enumerate(groups)
+        },
+        "ignore": ["lm_head"],
+    })
+    cfg._ensure_resolved()
+    return cfg
+
+
+def _graded(stored_ns="model.language_model."):
+    """Layer 1's experts: gate_up on k44/ts176, down on k36/ts144."""
+    base = stored_ns + "layers.1.mlp.experts."
+    return _cfg([([base + "gate_up_proj"], _RUNG_HI),
+                 ([base + "down_proj"], _RUNG_LO)])
+
+
+def _uniform(stored_ns="model.language_model."):
+    base = stored_ns + "layers.1.mlp.experts."
+    return _cfg([([base + "gate_up_proj", base + "down_proj"], _RUNG_HI)])
+
+
+# ---------------------------------------------------------------------------
+# 1. The namespace property, on the NEW entry point.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stored_ns", ["model.language_model.", "model."])
+@pytest.mark.parametrize("prefix", _MOE_EXPERT_PREFIXES)
+def test_per_stack_resolves_across_namespaces(stored_ns, prefix):
+    """Every (stored target namespace x serving prefix namespace) pair naming
+    layer 1's expert stack must resolve BOTH stacks. A raw ``startswith`` here
+    is the 35B CB serve-boot bug: the wrapper serving prefix
+    ``language_model.model.layers.N.mlp.experts`` matches no canonicalised
+    target, no CB MoE method is created, and the arch's expert mapping then
+    AttributeErrors on ``experts.w2_weight.cb_qweight``."""
+    stacks = _uniform(stored_ns)._moe_stack_schemes_for_prefix(prefix)
+    assert stacks is not None, (stored_ns, prefix)
+    assert set(stacks) == {"gate_up_proj", "down_proj"}
+    assert all(s["k"] == _RUNG_HI["k"] for s in stacks.values())
+
+
+def test_per_stack_does_not_overmatch():
+    """A layer with no CB expert group still resolves to None (stock CT MoE
+    path), and a dense sibling prefix must not pick the expert group up."""
+    cfg = _uniform()
+    assert cfg._moe_stack_schemes_for_prefix(
+        "language_model.model.layers.2.mlp.experts") is None
+    assert cfg._moe_stack_schemes_for_prefix(
+        "language_model.model.layers.1.mlp.shared_expert") is None
+
+
+@pytest.mark.parametrize("neighbour", ["experts2", "experts_backup"])
+def test_per_stack_requires_a_dotted_prefix_boundary(neighbour):
+    """A raw startswith(``...experts``) silently steals either neighbour's
+    schemes.  Only an actual ``...experts.<projection>`` child may match."""
+    base = f"model.layers.1.mlp.{neighbour}."
+    cfg = _cfg([([base + "gate_up_proj", base + "down_proj"], _RUNG_HI)])
+    assert cfg._moe_stack_schemes_for_prefix(
+        "model.layers.1.mlp.experts") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. The graded ladder: two stacks, two rungs, two byte widths.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("prefix", _MOE_EXPERT_PREFIXES)
+def test_mixed_rung_layer_resolves_two_type_sizes(prefix):
+    """THE regression this change exists for: the resolver must hand back BOTH
+    rungs, not collapse the layer onto the first target it matched."""
+    stacks = _graded()._moe_stack_schemes_for_prefix(prefix)
+    assert stacks is not None, prefix
+    assert stacks["gate_up_proj"]["type_size"] == 176
+    assert stacks["down_proj"]["type_size"] == 144
+    assert stacks["gate_up_proj"]["k"] == 44
+    assert stacks["down_proj"]["k"] == 36
+    assert (stacks["gate_up_proj"]["codebook_ref"]
+            != stacks["down_proj"]["codebook_ref"])
+
+
+def test_unfused_gate_and_up_fold_into_one_stack():
+    """Unfused ``gate_proj``/``up_proj`` targets land in the ONE w13 buffer, so
+    they fold into ``gate_up_proj`` — and, agreeing, resolve cleanly."""
+    base = "model.layers.1.mlp.experts."
+    cfg = _cfg([([base + "gate_proj", base + "up_proj"], _RUNG_HI),
+                ([base + "down_proj"], _RUNG_LO)])
+    stacks = cfg._moe_stack_schemes_for_prefix(base.rstrip("."))
+    assert set(stacks) == {"gate_up_proj", "down_proj"}
+    assert stacks["gate_up_proj"]["type_size"] == 176
+    assert stacks["down_proj"]["type_size"] == 144
+
+
+def test_disagreeing_members_of_one_stack_raise():
+    """gate_proj and up_proj share the w13 buffer; two schemes for it is an
+    exporter bug and must fail loudly rather than pick one."""
+    base = "model.layers.1.mlp.experts."
+    cfg = _cfg([([base + "gate_proj"], _RUNG_HI),
+                ([base + "up_proj"], _RUNG_LO),
+                ([base + "down_proj"], _RUNG_LO)])
+    with pytest.raises(ValueError, match="gate_up_proj"):
+        cfg._moe_stack_schemes_for_prefix(base.rstrip("."))
+
+
+# ---------------------------------------------------------------------------
+# 3. The single-scheme accessor keeps its shape for uniform layers.
+# ---------------------------------------------------------------------------
+
+def test_single_scheme_accessor_unchanged_for_uniform_layers():
+    """``_moe_scheme_for_prefix`` still returns ONE subscriptable scheme — the
+    shape ``test_target_namespace_compat.py`` asserts."""
+    sch = _uniform()._moe_scheme_for_prefix(
+        "language_model.model.layers.1.mlp.experts")
+    assert sch is not None and sch["k"] == _RUNG_HI["k"]
+
+
+def test_single_scheme_accessor_refuses_a_graded_layer():
+    """There IS no single scheme for a graded layer; returning one is exactly
+    the bug. Callers that need an answer use the per-stack entry point."""
+    with pytest.raises(ValueError, match="different CB rungs"):
+        _graded()._moe_scheme_for_prefix(
+            "language_model.model.layers.1.mlp.experts")

--- a/tests/test_moe_per_stack_runtime.py
+++ b/tests/test_moe_per_stack_runtime.py
@@ -176,7 +176,7 @@ def test_grouped_decode_passes_each_stack_its_own_lut_and_format(monkeypatch):
     assert calls[1][0] == layer._cb_flat_fp8_w2.data_ptr()
 
 
-def test_default_fused_fp4_launches_with_each_stack_format(monkeypatch):
+def test_graded_fused_fp4_launches_with_each_stack_format(monkeypatch):
     w13 = _scheme("fp4", 12, 2, 57, ("a", "b"))
     w2 = _scheme("fp4", 16, 2, 73, ("c", "d"))
     method = _method(w13, w2)
@@ -221,7 +221,7 @@ def test_default_fused_fp4_launches_with_each_stack_format(monkeypatch):
     assert calls[1][3] is lut2 and calls[1][4] is compose2
 
 
-def test_unset_fp4_prefill_selects_the_graded_fused_path(monkeypatch):
+def test_explicit_fp4_prefill_selects_the_graded_fused_path(monkeypatch):
     w13 = _scheme("fp4", 12, 2, 57, ("a", "b"))
     w2 = _scheme("fp4", 16, 2, 73, ("c", "d"))
     method = _method(w13, w2)
@@ -235,8 +235,8 @@ def test_unset_fp4_prefill_selects_the_graded_fused_path(monkeypatch):
 
     method._apply_prefill_grouped_fused_fp4 = fused
     method._apply_prefill_loop = lambda *_args: pytest.fail(
-        "unset mode should not fall through to loop when fused succeeds")
-    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4_MOE", raising=False)
+        "explicit fused mode should not fall through when it succeeds")
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4_MOE", "1")
     monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
     layer = types.SimpleNamespace(
         activation=types.SimpleNamespace(value="silu"),
@@ -246,6 +246,26 @@ def test_unset_fp4_prefill_selects_the_graded_fused_path(monkeypatch):
         torch.zeros(17, 1, dtype=torch.long))
     assert out is sentinel
     assert seen == {"tile_m": 128}
+
+
+def test_unset_fp4_prefill_keeps_graded_fused_fail_closed(monkeypatch):
+    w13 = _scheme("fp4", 12, 2, 57, ("a", "b"))
+    w2 = _scheme("fp4", 16, 2, 73, ("c", "d"))
+    method = _method(w13, w2)
+    method._cuda_moe_ok = lambda _layer: False
+    sentinel = torch.full((17, 256), 4.0)
+    method._apply_prefill_grouped_fused_fp4 = lambda *_args, **_kwargs: (
+        pytest.fail("unproven graded fused path must be off when env is unset"))
+    method._apply_prefill_loop = lambda *_args: sentinel
+    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4_MOE", raising=False)
+    monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    layer = types.SimpleNamespace(
+        activation=types.SimpleNamespace(value="silu"),
+        apply_router_weight_on_input=False)
+    out = method._apply_inline(
+        layer, torch.zeros(17, 256), torch.ones(17, 1),
+        torch.zeros(17, 1, dtype=torch.long))
+    assert out is sentinel
 
 
 def test_graded_autotune_sink_records_both_rungs(tmp_path, monkeypatch):

--- a/tests/test_moe_per_stack_runtime.py
+++ b/tests/test_moe_per_stack_runtime.py
@@ -1,0 +1,261 @@
+"""Runtime contracts for graded FusedMoE stacks (requires a live vLLM).
+
+The resolver-only suite is deliberately vLLM-free.  This file exercises the
+actual ``PrismaQuantCBMoEMethod`` imported against the installed serving API:
+allocation/fill/post-load state, per-stack decode arguments, default-on fused
+FP4 arguments, and durable auto-tune telemetry.
+"""
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+import torch
+
+moe_mod = pytest.importorskip("gridbook.moe")
+from gridbook import codec  # noqa: E402
+from gridbook.cb_fill_guard import mark_filled  # noqa: E402
+
+PrismaQuantCBMoEMethod = moe_mod.PrismaQuantCBMoEMethod
+
+
+def _scheme(grid, k, n_sub, type_size, refs, **extra):
+    out = {
+        "grid": grid,
+        "mode": "product",
+        "k": k,
+        "n_sub": n_sub,
+        "type_size": type_size,
+        "codebook_ref": list(refs),
+    }
+    if grid == "fp4":
+        out["scale_coding"] = codec.SCALE_CODING_TWO_TIER
+    out.update(extra)
+    return out
+
+
+def _method(w13, w2):
+    method = PrismaQuantCBMoEMethod.__new__(PrismaQuantCBMoEMethod)
+    method.quant_config = None
+    method.prefix = "model.layers.0.mlp.experts"
+    method.stack_scheme = {"w13": w13, "w2": w2}
+    method.scheme = w13
+    method._stack_formats_match = (w13 == w2)
+    method.is_fp4 = w13["grid"] == "fp4"
+    method.is_v2 = (w13.get("scale_coding")
+                    == codec.SCALE_CODING_TWO_TIER)
+    method._sub_table = (codec.TWO_TIER_SUB_TABLE if method.is_v2 else None)
+    method.k = {"w13": int(w13["k"]), "w2": int(w2["k"])}
+    method.n_sub = {"w13": int(w13["n_sub"]),
+                    "w2": int(w2["n_sub"])}
+    method.type_size = {"w13": int(w13["type_size"]),
+                        "w2": int(w2["type_size"])}
+    return method
+
+
+class _Layer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.deferred = []
+
+    def load_weights(self, weights):
+        for name, _weight in weights:
+            self.deferred.append(name)
+            yield name
+
+
+def _fp8_case():
+    refs13 = tuple(f"cb32.{i}" for i in range(4))
+    refs2 = tuple(f"cb28.{i}" for i in range(4))
+    w13 = _scheme("fp8", 32, 4, 128, refs13)
+    w2 = _scheme("fp8", 28, 4, 112, refs2)
+    method = _method(w13, w2)
+    codebooks = {}
+    # Product n_sub=4: each sub-vector has width 2.  K32 -> 2^8 entries;
+    # K28 -> 2^7.  Distinct values also make the two resident LUTs observable.
+    for ref in refs13:
+        codebooks[ref] = torch.zeros(1 << 8, 2)
+    for ref in refs2:
+        codebooks[ref] = torch.ones(1 << 7, 2)
+    method.quant_config = types.SimpleNamespace(
+        get_codebooks=lambda: codebooks)
+    layer = _Layer()
+    method.create_weights(
+        layer, num_experts=2, hidden_size=256,
+        intermediate_size_per_partition=256, params_dtype=torch.bfloat16,
+        weight_loader=None)
+    return method, layer
+
+
+def _fill_instance_stacks(layer):
+    loaded = list(layer.load_weights(iter([
+        ("gate_up_proj.cb_qweight",
+         torch.full_like(layer.w13_cb_qweight, 7)),
+        ("down_proj.cb_qweight", torch.full_like(layer.w2_cb_qweight, 9)),
+    ])))
+    assert loaded == ["w13_cb_qweight", "w2_cb_qweight"]
+
+
+def test_graded_create_fill_and_postload_remove_legacy_aliases():
+    method, layer = _fp8_case()
+    assert layer.w13_cb_qweight.shape == (2, 512, 128)
+    assert layer.w2_cb_qweight.shape == (2, 256, 112)
+    _fill_instance_stacks(layer)
+
+    # A reused layer carrying old uniform state must not retain it.
+    layer._cb_flat = torch.tensor([-1.0])
+    layer._cb_compose = torch.tensor([-1.0])
+    layer._cb_flat_fp8 = torch.tensor([255], dtype=torch.uint8)
+    stale_specific = torch.tensor([254], dtype=torch.uint8)
+    layer._cb_flat_fp8_w13 = stale_specific
+    method.process_weights_after_loading(layer)
+
+    assert not hasattr(layer, "_cb_flat")
+    assert not hasattr(layer, "_cb_compose")
+    assert not hasattr(layer, "_cb_flat_fp8")
+    assert layer._cb_stack_uniform is False
+    assert layer._cb_flat_w13.numel() == 4 * (1 << 8) * 2
+    assert layer._cb_flat_w2.numel() == 4 * (1 << 7) * 2
+    assert layer._cb_flat_fp8_w13.data_ptr() != \
+        layer._cb_flat_fp8_w2.data_ptr()
+    assert layer._cb_flat_fp8_w13 is not stale_specific
+    assert torch.all(layer.w13_cb_qweight == 7)
+    assert torch.all(layer.w2_cb_qweight == 9)
+
+
+def test_alias_requires_the_complete_scheme_signature():
+    refs = tuple(f"cb.{i}" for i in range(4))
+    w13 = _scheme("fp8", 28, 4, 112, refs, future_format_revision=1)
+    w2 = _scheme("fp8", 28, 4, 112, refs, future_format_revision=2)
+    method = _method(w13, w2)
+    method.quant_config = types.SimpleNamespace(get_codebooks=lambda: {
+        ref: torch.zeros(1 << 7, 2) for ref in refs
+    })
+    layer = _Layer()
+    method.create_weights(layer, 1, 256, 256, torch.bfloat16,
+                          weight_loader=None)
+    _fill_instance_stacks(layer)
+    method.process_weights_after_loading(layer)
+    # Same current rung + same tensors is still not proof that a future format
+    # field is interchangeable.  Per-stack tensors may dedupe; aliases may not.
+    assert layer._cb_flat_w13 is layer._cb_flat_w2
+    assert layer._cb_stack_uniform is False
+    assert not hasattr(layer, "_cb_flat")
+
+
+def test_grouped_decode_passes_each_stack_its_own_lut_and_format(monkeypatch):
+    method, layer = _fp8_case()
+    _fill_instance_stacks(layer)
+    method.process_weights_after_loading(layer)
+    calls = []
+
+    def gemv(xq, qw, lut, scale, pair_expert, pair_xrow,
+             k_bits, n_sub, type_size):
+        calls.append((lut.data_ptr(), k_bits, n_sub, type_size, qw.shape[1]))
+        return torch.zeros((pair_expert.numel(), qw.shape[1]), dtype=xq.dtype)
+
+    from gridbook import ops
+    monkeypatch.setattr(ops, "fp8_act_qdq", lambda x: x)
+    monkeypatch.setattr(ops, "cb_moe_gemv_fp8", gemv)
+    monkeypatch.setattr(
+        ops, "cb_moe_combine",
+        lambda y, pair_w, tok_start, tokens: torch.zeros(
+            (tokens, y.shape[1]), dtype=y.dtype))
+    monkeypatch.setattr(
+        moe_mod, "apply_moe_activation",
+        lambda _act, out, gate_up: out.zero_())
+
+    out = method._apply_grouped_decode(
+        layer, torch.zeros(2, 256, dtype=torch.bfloat16),
+        torch.ones(2, 1), torch.tensor([[0], [1]]), object())
+    assert out.shape == (2, 256)
+    assert [(k, ns, ts) for _ptr, k, ns, ts, _n in calls] == [
+        (32, 4, 128), (28, 4, 112)]
+    assert calls[0][0] == layer._cb_flat_fp8_w13.data_ptr()
+    assert calls[1][0] == layer._cb_flat_fp8_w2.data_ptr()
+
+
+def test_default_fused_fp4_launches_with_each_stack_format(monkeypatch):
+    w13 = _scheme("fp4", 12, 2, 57, ("a", "b"))
+    w2 = _scheme("fp4", 16, 2, 73, ("c", "d"))
+    method = _method(w13, w2)
+    layer = types.SimpleNamespace(
+        _cb_E=2, _cb_hidden=256, _cb_inter=256,
+        w13_cb_qweight=torch.zeros(2, 512, 57, dtype=torch.uint8),
+        w2_cb_qweight=torch.zeros(2, 256, 73, dtype=torch.uint8),
+    )
+    lut13 = torch.tensor([13], dtype=torch.uint8)
+    lut2 = torch.tensor([2], dtype=torch.uint8)
+    compose13 = torch.tensor([31], dtype=torch.uint8)
+    compose2 = torch.tensor([21], dtype=torch.uint8)
+    layer._cb_fp4_gf_w13 = (lut13, compose13)
+    layer._cb_fp4_gf_w2 = (lut2, compose2)
+    calls = []
+
+    class _Ext:
+        @staticmethod
+        def cb_fused_fp4_moe_grouped(*args):
+            calls.append(args)
+            return torch.zeros((args[0].shape[0], args[8]),
+                               dtype=torch.bfloat16)
+
+    from gridbook import cuda_ext
+    monkeypatch.setattr(cuda_ext, "get_fused_fp4_ext", lambda: _Ext())
+    monkeypatch.setattr(method, "_gf4_ok", lambda _layer: True)
+    monkeypatch.setattr(
+        method, "_fp4_quant",
+        lambda x: (x, torch.zeros(1, dtype=torch.uint8), torch.ones(1)))
+    monkeypatch.setattr(
+        moe_mod, "apply_moe_activation",
+        lambda _act, out, gate_up: out.zero_())
+
+    x = torch.zeros(17, 256, dtype=torch.bfloat16)
+    out = method._apply_prefill_grouped_fused_fp4(
+        layer, x, torch.ones(17, 1),
+        torch.tensor([[i % 2] for i in range(17)]), object(), tile_m=128)
+    assert out.shape == x.shape
+    assert [(call[10], call[11], call[12]) for call in calls] == [
+        (12, 2, 57), (16, 2, 73)]
+    assert calls[0][3] is lut13 and calls[0][4] is compose13
+    assert calls[1][3] is lut2 and calls[1][4] is compose2
+
+
+def test_unset_fp4_prefill_selects_the_graded_fused_path(monkeypatch):
+    w13 = _scheme("fp4", 12, 2, 57, ("a", "b"))
+    w2 = _scheme("fp4", 16, 2, 73, ("c", "d"))
+    method = _method(w13, w2)
+    method._cuda_moe_ok = lambda _layer: False
+    sentinel = torch.full((17, 256), 3.0)
+    seen = {}
+
+    def fused(_layer, _x, _weights, _ids, _act, *, tile_m):
+        seen["tile_m"] = tile_m
+        return sentinel
+
+    method._apply_prefill_grouped_fused_fp4 = fused
+    method._apply_prefill_loop = lambda *_args: pytest.fail(
+        "unset mode should not fall through to loop when fused succeeds")
+    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4_MOE", raising=False)
+    monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    layer = types.SimpleNamespace(
+        activation=types.SimpleNamespace(value="silu"),
+        apply_router_weight_on_input=False)
+    out = method._apply_inline(
+        layer, torch.zeros(17, 256), torch.ones(17, 1),
+        torch.zeros(17, 1, dtype=torch.long))
+    assert out is sentinel
+    assert seen == {"tile_m": 128}
+
+
+def test_graded_autotune_sink_records_both_rungs(tmp_path, monkeypatch):
+    method, _layer = _fp8_case()
+    path = tmp_path / "graded.jsonl"
+    monkeypatch.setenv("PRISMAQUANT_CB_AUTOTUNE_LOG", str(path))
+    context = types.SimpleNamespace(_cb_E=2, _cb_inter=256)
+    method._log_prefill_choice(
+        "stock", {"stock": 1.25}, layer=context, num_tokens=2048)
+    row = json.loads(path.read_text().strip())
+    assert row["format"] == \
+        "FP8_CB[w13=K32/N4/T128,w2=K28/N4/T112]"
+    assert row["regime"]["n_experts"] == 2

--- a/tests/test_moe_stacked.py
+++ b/tests/test_moe_stacked.py
@@ -103,3 +103,36 @@ def test_moe_method_buffer_shapes():
     assert layer.w2_cb_qweight.shape == (E, hidden, _row_bytes(inter, ts))
     assert layer.w13_weight_scale.shape == (E, 2 * inter)
     assert layer.w2_weight_scale.shape == (E, hidden)
+
+
+def test_moe_method_buffer_shapes_graded_rungs():
+    """vLLM-dependent: a GRADED layer — gate_up on k44 (type_size 176), down on
+    k36 (type_size 144) — must allocate each stacked buffer at ITS OWN byte
+    width. Resolving one scheme per layer sizes the second buffer with the
+    other stack's type_size, and the checkpoint tensor then fails the shape
+    check in the CB load hook."""
+    pytest.importorskip("vllm")
+    import types
+    from gridbook.moe import PrismaQuantCBMoEMethod, _row_bytes
+
+    E, hidden, inter = 8, 512, 1024
+    hi = {"grid": "fp8", "mode": "product", "k": 44, "n_sub": 4,
+          "type_size": 176, "codebook_ref": ["cb.k44"]}
+    lo = {"grid": "fp8", "mode": "product", "k": 36, "n_sub": 4,
+          "type_size": 144, "codebook_ref": ["cb.k36"]}
+    m = PrismaQuantCBMoEMethod.__new__(PrismaQuantCBMoEMethod)
+    # bypass FusedMoEMethodBase.__init__ (needs a real FusedMoEConfig); test the
+    # per-stack buffer-shape logic directly.
+    m.quant_config = None; m.prefix = "x"; m.is_fp4 = False; m.is_v2 = False
+    m.stack_scheme = {"w13": hi, "w2": lo}
+    m.scheme = hi
+    m.k = {"w13": 44, "w2": 36}
+    m.n_sub = {"w13": 4, "w2": 4}
+    m.type_size = {"w13": 176, "w2": 144}
+    layer = types.SimpleNamespace()
+    layer.register_parameter = lambda n, p: setattr(layer, n, p)
+    m.create_weights(layer, E, hidden, inter, torch.bfloat16, weight_loader=None)
+    assert layer.w13_cb_qweight.shape == (E, 2 * inter, _row_bytes(hidden, 176))
+    assert layer.w2_cb_qweight.shape == (E, hidden, _row_bytes(inter, 144))
+    # The two widths must actually differ, or the test proves nothing.
+    assert layer.w13_cb_qweight.shape[2] != _row_bytes(hidden, 144)

--- a/tests/test_toplevel_loader.py
+++ b/tests/test_toplevel_loader.py
@@ -18,6 +18,7 @@ import torch
 import types
 
 from gridbook import moe_toplevel_loader
+from gridbook.cb_fill_guard import mark_unfilled
 from gridbook.moe_toplevel_loader import (
     _build_reverse_fusion,
     _load_shared_cb,
@@ -127,6 +128,48 @@ def test_wrapper_routes_experts_and_delegates_rest():
         "model.layers.0.mlp.down_proj.cb_qweight",
         "model.embed_tokens.weight",
     }
+
+
+def test_wrapper_fills_graded_stacks_with_different_row_widths():
+    """The top-level fill path copies each stack independently; it must not
+    assume w13 and w2 share a last dimension, and both fill sentinels must land."""
+    E, hidden, inter = 2, 256, 128
+    width13, width2 = 128, 112
+    prefix = "model.layers.1.mlp.experts."
+
+    class _FakeCausalLM:
+        def __init__(self):
+            self._params = {
+                prefix + "w13_cb_qweight": torch.zeros(
+                    E, 2 * inter, width13, dtype=torch.uint8),
+                prefix + "w2_cb_qweight": torch.zeros(
+                    E, hidden, width2, dtype=torch.uint8),
+            }
+            for param in self._params.values():
+                mark_unfilled(param)
+
+        def named_parameters(self):
+            return list(self._params.items())
+
+        def modules(self):
+            return []
+
+        def load_weights(self, weights):
+            return {name for name, _weight in weights}
+
+    install_toplevel_cb_expert_loader(_FakeCausalLM)
+    model = _FakeCausalLM()
+    loaded = model.load_weights(iter([
+        (prefix + "gate_up_proj.cb_qweight",
+         torch.full((E, 2 * inter, width13), 7, dtype=torch.uint8)),
+        (prefix + "down_proj.cb_qweight",
+         torch.full((E, hidden, width2), 9, dtype=torch.uint8)),
+    ]))
+    assert loaded == {prefix + "w13_cb_qweight", prefix + "w2_cb_qweight"}
+    assert torch.all(model._params[prefix + "w13_cb_qweight"] == 7)
+    assert torch.all(model._params[prefix + "w2_cb_qweight"] == 9)
+    assert all(getattr(param, "_pq_cb_filled", False)
+               for param in model._params.values())
 
 
 def test_wrapper_defers_unmappable_expert_name():


### PR DESCRIPTION
## Summary

This draft ports the archive's per-stack graded-rung work onto Gridbook's local integration base. It resolves expert quantization schemes independently for the `gate_up` (`w13`) and `down` (`w2`) stacks instead of assuming one scheme for an entire MoE layer.

The change:

- resolves exact/dot-boundary expert targets without overmatching names such as `experts2` or `experts_backup`;
- rejects conflicting gate/up schemes while allowing different `w13` and `w2` rungs;
- allocates, loads, validates, and caches each expert stack using its own `k`, `n_sub`, `type_size`, LUT, compose table, and packed row width;
- updates decode, stock, batched, grouped, fused FP8, fused FP4, L2, gate, and TileM consumers to use the appropriate stack format;
- creates legacy aliases only when the complete scheme signatures match and removes stale aliases/caches from graded layers;
- records both stack rungs in durable autotune telemetry; and
- preserves the existing fill-guard lifecycle, including post-load validation and loader-fill sentinels.

## Reviewer fixes and safety policy

The per-stack fused FP4 launch wiring is implemented and contract-tested: `w13` and `w2` receive their own LUT, compose table, `k`, `n_sub`, and `type_size`.

However, graded FP4 fusion is deliberately fail-closed by default. Uniform FP4 stacks retain the existing default behavior. A genuinely graded FP4 stack uses the proven per-expert loop unless `PRISMAQUANT_CB_FUSED_FP4_MOE=1`, `128`, or `256` explicitly opts into the experimental grouped path. This avoids silently promoting an unproven CUDA path while keeping the implementation available for continued validation.

## Validation

Green checks on the review worktree:

- Python compilation and diff hygiene passed.
- Host resolver and loader suites: **39 passed** (`tests/test_moe_per_stack_rungs.py` and `tests/test_toplevel_loader.py`).
- Live vLLM/CUDA-import runtime suites: **12 passed** (`tests/test_moe_per_stack_runtime.py` and `tests/test_moe_stacked.py`).
- Coverage includes post-load state, loader filling, fill sentinels, full-signature aliasing, stale-cache invalidation, exact target boundaries, per-stack decode arguments, fused-FP4 argument wiring, explicit/default dispatch policy, and graded telemetry.

## Draft blocker: grouped FP4 CUDA initialization

The real mixed-rung CUDA smoke cannot currently be promoted to a passing gate on the available NVIDIA GB10 (SM 12.1) system.

This is reproducible in the pre-existing **uniform** grouped-FP4 parity test, independent of this PR's per-stack arguments:

```text
python3 -m pytest tests/test_fused_fp4_prefill.py -k moe_grouped_bitexact_vs_dense
3 failed
RuntimeError: Expected gemm.initialize(args, workspace.data_ptr()) == cutlass::Status::kSuccess
```

The dense FP4 test at the same 512-row shape passes. Temporary diagnostics used during review (not committed) narrowed the grouped failure to:

```text
CUTLASS status: kErrorInternal
cudaFuncSetAttribute: cudaErrorInvalidResourceHandle
dynamic shared storage: 59,392 bytes
workspace: 0 bytes
```

Until the grouped launch-stub/CUTLASS issue is repaired and a real mixed-rung forward passes, this PR must remain a draft and graded fusion must remain default-off.

## Integration status

This branch preserves the archive commit plus two reviewer commits. It is based on `4e824c5` and is currently **32 commits behind `origin/master`**. Integration with current `master` remains required before the PR can be considered merge-ready; that integration is intentionally not folded into this draft push so the contribution and reviewer changes remain reviewable as separate commits.

## Attribution

Original contribution by Jason Wong (@jsconsultancy), identified in the archive as JW2026. The archive commit email is not linked by GitHub, so this PR records the confirmed account explicitly.