### PR TITLE
Keep fused NVFP4 prefill opt-in until quality validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Restore dense and MoE fused NVFP4 prefill to explicit opt-in while its
+  different activation bucket awaits a served quality A/B. This also avoids
+  the grouped MoE kernel's severe padding amplification immediately above its
+  16-token dispatch boundary.
+
 ## 0.3.0 — 2026-07-31
 
 This release incorporates reviewed contributions from Jason Wong

--- a/docs/KERNELS.md
+++ b/docs/KERNELS.md
@@ -66,15 +66,15 @@ the CUDA-graph section for why this host-side branch matters.
 
 ---
 
-## Prefill path (large M): transient-expand + native GEMM
+## Prefill path (large M): transient expansion
 
 The default prefill **expands one layer's weight tile transiently** into a scratch
-buffer — decode CB → native FP4/FP8 codes + the (composed) E4M3 scale plane — then
-runs the stock native tensor-core GEMM on it, and frees the buffer. Memory stays
-bounded (INV-1); the tensor cores do the matmul (INV-2). For FP4-CB the expander
-emits an FP4-packed tile plus the swizzled E4M3 scale layout the block-scaled MMA
-expects, then calls the native FP4 GEMM; for FP8-CB it expands **directly to FP8**
-(the codebook values are already on the E4M3 grid), skipping any BF16 intermediate.
+buffer, runs a GEMM, and frees the buffer. Memory stays bounded (INV-1). FP8-CB
+expands **directly to FP8** (the codebook values are already on the E4M3 grid)
+and calls the stock native tensor-core GEMM (INV-2). FP4-CB v2 currently expands
+to BF16 and calls cuBLAS; that is a correctness-first fallback which does not yet
+meet INV-2. The native-FP4 decode-in-prologue kernel described below is opt-in
+because it changes the served activation bucket and still needs a quality A/B.
 
 The honest limitation of transient-expand is **memory traffic**: the tile is
 written to HBM and then read back by the GEMM, so prefill moves roughly 2× the
@@ -158,9 +158,10 @@ at 8k** and **207 → 1,822 tok/s at 63k**. Chunked prefill re-expands per
 microbatch, so `--max-num-batched-tokens 16384` matters for this path.
 
 **fp4**-CB MoE prefill can explicitly ride the same chunked `stock` path. The
-current unset policy remains fused-FP4 first, with `loop` on a constraint miss;
-an explicit `PRISMAQUANT_CB_PREFILL` bypasses that fused default so the selector
-is a reliable bisection control. Stock's transient is a bf16 expand rather than
+unset policy is the conservative per-expert `loop`. The native-FP4 grouped path
+is enabled with `PRISMAQUANT_CB_FUSED_FP4_MOE=1` (or `128`/`256` to select its
+tile), while an explicit `PRISMAQUANT_CB_PREFILL` remains authoritative and is a
+reliable bisection control. Stock's transient is a bf16 expand rather than
 the fp8-direct CUDA one, at 2 B/elt, so its chunk is sized from a **byte budget**
 (`PRISMAQUANT_CB_PREFILL_CHUNK_BYTES`, default 1 GiB) instead of the fp8 lane's
 flat 256: on a 192-expert Hy3-class band that is 1,184 MiB of measured

--- a/gridbook/linear.py
+++ b/gridbook/linear.py
@@ -55,20 +55,18 @@ _FP4_FUSED_MODE: list = []
 
 
 def _fp4_fused_mode() -> str:
-    # DEFAULT-ON since 2026-07-31 (Robert's call). Set
-    # PRISMAQUANT_CB_FUSED_FP4=0 to restore the Triton decode path.
-    #
-    # What this changes for a served artifact: the fp4 activation bucket moves
+    # Explicit opt-in: what this changes for a served artifact is the fp4
+    # activation bucket moving
     # from the Triton path's fp32 emulation scales to the format's native
     # ue4m3 scale factors — measured ~7.5e-2 relative against Triton. The fused
     # kernel is bit-exact against the stock NVF4 collective, so this is
     # arguably the *more* faithful rendering of what NVFP4 hardware serving
     # does; but it is a change in served numerics that has NOT been validated
     # on the serving metric (no KL/PPL A/B). See
-    # docs/lanes/nvfp4-cb/fp4-fused-prefill.md.
+    # docs/KERNELS.md ("Fused decode-in-prologue").
     if not _FP4_FUSED_MODE:
         _FP4_FUSED_MODE.append(
-            os.environ.get("PRISMAQUANT_CB_FUSED_FP4", "1").strip())
+            os.environ.get("PRISMAQUANT_CB_FUSED_FP4", "").strip())
     return _FP4_FUSED_MODE[0]
 
 
@@ -490,7 +488,7 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
         # global x per-group-16 ue4m3 SF) instead of the Triton/transient
         # paths' fp32-group-scale QDQ — the hardware SF operand is ue4m3, an
         # fp32 group scale is unrepresentable. Promotion therefore requires a
-        # served KL A/B (docs/lanes/nvfp4-cb/fp4-fused-prefill.md), which is
+        # served KL A/B (docs/KERNELS.md), which is
         # why this lands opt-in. "1" = all prefill M; "midm" = only the fp8
         # kernel's proven 16<M<=128 niche.
         if (self.is_fp4 and bias is None and M > PREFILL_M_THRESHOLD

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -492,13 +492,14 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # not codec.fp4_group16_act_qdq). An explicit PRISMAQUANT_CB_PREFILL
         # is authoritative and bypasses this default, so stock/loop remain
         # real bisection controls rather than being silently preempted.
-        # DEFAULT-ON since 2026-07-31 (Robert's call); tile 128 is the measured
-        # best (5.2-5.6x the per-expert loop). PRISMAQUANT_CB_FUSED_FP4_MOE=0
-        # restores the per-expert loop. Same unvalidated-on-serving-metric
-        # caveat as the dense gate in linear.py applies.
+        # Explicit opt-in until a served quality gate and routing-shape ladder
+        # pass. Tile 128 is 5.2-5.6x faster than the per-expert loop on the
+        # measured shapes, but its padding cost has a sharp token-count cliff.
+        # The same unvalidated-on-serving-metric caveat as the dense gate in
+        # linear.py applies.
         requested_mode = os.environ.get("PRISMAQUANT_CB_PREFILL")
         if requested_mode is None and self.is_fp4 and num_tokens > 16:
-            gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "1").strip()
+            gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "").strip()
             if gf4 in ("1", "128", "256"):
                 out = self._apply_prefill_grouped_fused_fp4(
                     layer, x, topk_weights, topk_ids, act,

--- a/tests/test_moe_fp4_stock_prefill.py
+++ b/tests/test_moe_fp4_stock_prefill.py
@@ -2,8 +2,9 @@
 
 Three things are decidable on CPU from shapes and config ints alone:
 
-  1. ``_apply_inline``'s mode precedence — an explicit stock/loop request must
-     bypass the default fused-FP4 path; an unset request keeps current policy.
+  1. ``_apply_inline``'s mode precedence — fused FP4 is explicitly opted in;
+     an unset request takes the conservative loop, and an explicit stock/loop
+     request remains authoritative.
   2. ``_stock_chunk_default`` — the fp4 bf16 chunk transient is 2 B/elt, so the
      fp8 lane's flat 256 holds every expert of a large MoE live at once. The
      fp4 chunk is byte-budgeted instead; fp8 keeps its 256 verbatim.
@@ -63,19 +64,28 @@ def moe(request):
     """``gridbook.moe``, importable with or without a real vLLM install."""
     import importlib
 
-    before = set(sys.modules)
+    # Preserve complete module objects, not only names. Another CPU test may
+    # have installed a deliberately smaller vLLM stub first; ``import vllm``
+    # alone would then succeed even though the MoE submodules are absent.
+    before = {
+        name: module for name, module in sys.modules.items()
+        if name.startswith("vllm") or name.startswith("gridbook")
+    }
     stubbed = False
     try:
-        import vllm  # noqa: F401
+        from vllm.model_executor.layers.fused_moe.config import (  # noqa: F401
+            FusedMoEConfig,
+        )
     except Exception:
         _install_vllm_stubs()
         stubbed = True
     mod = importlib.import_module("gridbook.moe")
     yield mod
     if stubbed:
-        for name in set(sys.modules) - before:
+        for name in list(sys.modules):
             if name.startswith("vllm") or name.startswith("gridbook"):
                 sys.modules.pop(name, None)
+        sys.modules.update(before)
 
 
 def _method(moe, *, grid, k, n_sub, type_size, is_v2=True):
@@ -144,13 +154,22 @@ def _dispatch_mode(moe, monkeypatch, m, fused_fp4="fused_fp4"):
     return m._apply_inline(lay, x, w, ids)
 
 
-def test_unset_fp4_keeps_current_fused_default(moe, monkeypatch):
+def test_unset_fp4_uses_conservative_loop(moe, monkeypatch):
     monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4_MOE", raising=False)
+    assert _dispatch_mode(moe, monkeypatch, _fp4(moe)) == "loop"
+
+
+@pytest.mark.parametrize("value", ["1", "128", "256"])
+def test_fp4_fused_prefill_is_explicitly_opted_in(moe, monkeypatch, value):
+    monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4_MOE", value)
     assert _dispatch_mode(moe, monkeypatch, _fp4(moe)) == "fused_fp4"
 
 
-def test_unset_fp4_fused_miss_falls_back_to_loop(moe, monkeypatch):
+def test_opted_in_fp4_fused_miss_falls_back_to_loop(moe, monkeypatch):
     monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4_MOE", "1")
     assert _dispatch_mode(
         moe, monkeypatch, _fp4(moe), fused_fp4=None) == "loop"
 

--- a/tests/test_weight_residency.py
+++ b/tests/test_weight_residency.py
@@ -74,7 +74,27 @@ if "vllm" not in sys.modules:
 
 from gridbook import codec                                        # noqa: E402
 from gridbook.config import PrismaQuantConfig                      # noqa: E402
+from gridbook import linear as cb_linear                           # noqa: E402
 from gridbook.linear import PrismaQuantCBLinearMethod              # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_fp4_fused_mode_cache():
+    """Keep process-global dispatch policy independent between tests."""
+    cb_linear._FP4_FUSED_MODE.clear()
+    yield
+    cb_linear._FP4_FUSED_MODE.clear()
+
+
+def test_dense_fp4_fused_prefill_is_opt_in(monkeypatch):
+    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4", raising=False)
+    assert cb_linear._fp4_fused_mode() == ""
+
+
+@pytest.mark.parametrize("value", ["1", "midm"])
+def test_dense_fp4_fused_prefill_explicit_modes(monkeypatch, value):
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4", value)
+    assert cb_linear._fp4_fused_mode() == value
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Why

The dense and grouped-MoE native-FP4 prefill paths change the activation quantization bucket and have not passed a served KL/PPL A/B. The grouped MoE path also has a severe padding cliff immediately above 16 tokens. Shipping both as default-on could therefore trade correctness and latency for an unvalidated optimization.

## What changed

- Restore dense fused NVFP4 prefill to explicit PRISMAQUANT_CB_FUSED_FP4 opt-in.
- Restore grouped-MoE fused NVFP4 prefill to explicit PRISMAQUANT_CB_FUSED_FP4_MOE opt-in.
- Preserve all optimized kernels and explicit 128/256 tile selection.
- Correct the public kernel documentation: FP4 fallback expands to BF16 today; FP8 alone reaches native transient GEMM by default.
- Add dispatch-policy coverage and isolate vLLM test stubs between modules.

## Validation

- python3 -m pytest tests/test_weight_residency.py tests/test_moe_fp4_stock_prefill.py -q: 62 passed
- reverse file order: 62 passed
- git diff --check