### PR TITLE
Release unloaded models from the compiled dispatch registry

### DIFF
--- a/gridbook/ops.py
+++ b/gridbook/ops.py
@@ -7,10 +7,12 @@ vLLM import here, so the op is usable from the standalone correctness tests too.
 """
 from __future__ import annotations
 
-import torch
-
+import itertools
 import os
 import sys
+import weakref
+
+import torch
 
 from .kernels import cb_decode_linear
 
@@ -378,7 +380,9 @@ def _cb_moe_combine_fake(y, pair_w, tok_start, T):
 # carries only (tensors..., layer_id) and the impl/fake consult the registry.
 # The id is a python int baked per call site — each layer module passes its
 # own — so the traced graph binds each site to its layer statically.
-_LAYER_REGISTRY: dict = {}
+_LAYER_REGISTRY: dict[int, tuple[weakref.ReferenceType,
+                                 weakref.ReferenceType]] = {}
+_LAYER_IDS = itertools.count()
 _DISPATCH_VIA_OP: list = []
 
 
@@ -390,20 +394,55 @@ def dispatch_via_op() -> bool:
 
 
 def register_cb_layer(method, layer) -> int:
-    layer_id = len(_LAYER_REGISTRY)
-    _LAYER_REGISTRY[layer_id] = (method, layer)
+    """Register one compiled-dispatch target without owning its model.
+
+    vLLM can load and unload several engines in one Python process.  Strong
+    references here used to pin every method, layer, parameter, and associated
+    GPU allocation until process exit.  The module/quant-method ownership graph
+    is authoritative; this registry is only an integer indirection for custom
+    ops, so both references must be weak.
+
+    IDs are monotonic rather than derived from ``len(_LAYER_REGISTRY)``.  A
+    captured graph containing an expired ID can therefore never alias a newly
+    loaded layer after the weakref callback removes its old entry.
+    """
+    layer_id = next(_LAYER_IDS)
+
+    def expire(_ref, *, expected_id=layer_id):
+        _LAYER_REGISTRY.pop(expected_id, None)
+
+    method_ref = weakref.ref(method, expire)
+    layer_ref = weakref.ref(layer, expire)
+    _LAYER_REGISTRY[layer_id] = (method_ref, layer_ref)
     return layer_id
+
+
+def _lookup_cb_layer(layer_id: int):
+    entry = _LAYER_REGISTRY.get(layer_id)
+    if entry is None:
+        raise RuntimeError(
+            f"CB dispatch layer id {layer_id} is stale or unknown; the model "
+            "may have been unloaded")
+    method = entry[0]()
+    layer = entry[1]()
+    if method is None or layer is None:
+        # A callback normally removes the entry first.  Keep this explicit for
+        # finalizer ordering and interpreter-shutdown edge cases.
+        _LAYER_REGISTRY.pop(layer_id, None)
+        raise RuntimeError(
+            f"CB dispatch layer id {layer_id} expired after model unload")
+    return method, layer
 
 
 @torch.library.custom_op("prismaquant::cb_linear_forward", mutates_args=())
 def cb_linear_forward(x: torch.Tensor, layer_id: int) -> torch.Tensor:
-    method, layer = _LAYER_REGISTRY[layer_id]
+    method, layer = _lookup_cb_layer(layer_id)
     return method._apply_inline(layer, x)
 
 
 @cb_linear_forward.register_fake
 def _cb_linear_forward_fake(x, layer_id):
-    _method, layer = _LAYER_REGISTRY[layer_id]
+    _method, layer = _lookup_cb_layer(layer_id)
     return torch.empty((*x.shape[:-1], layer._cb_N), dtype=x.dtype,
                        device=x.device)
 
@@ -411,7 +450,7 @@ def _cb_linear_forward_fake(x, layer_id):
 @torch.library.custom_op("prismaquant::cb_moe_forward", mutates_args=())
 def cb_moe_forward(x: torch.Tensor, topk_weights: torch.Tensor,
                    topk_ids: torch.Tensor, layer_id: int) -> torch.Tensor:
-    method, layer = _LAYER_REGISTRY[layer_id]
+    method, layer = _lookup_cb_layer(layer_id)
     return method._apply_inline(layer, x, topk_weights, topk_ids)
 
 

--- a/tests/test_layer_registry.py
+++ b/tests/test_layer_registry.py
@@ -1,0 +1,65 @@
+"""Lifecycle guarantees for the custom-op layer indirection registry."""
+from __future__ import annotations
+
+import gc
+import weakref
+
+import pytest
+import torch
+
+from gridbook import ops
+
+
+class _Layer:
+    _cb_N = 5
+
+
+class _Method:
+    def _apply_inline(self, layer, x, *args):
+        del args
+        return torch.zeros((*x.shape[:-1], layer._cb_N), dtype=x.dtype)
+
+
+def test_registry_does_not_retain_unloaded_model():
+    method = _Method()
+    layer = _Layer()
+    method_ref = weakref.ref(method)
+    layer_ref = weakref.ref(layer)
+    layer_id = ops.register_cb_layer(method, layer)
+
+    del method, layer
+    gc.collect()
+
+    assert method_ref() is None
+    assert layer_ref() is None
+    assert layer_id not in ops._LAYER_REGISTRY
+    with pytest.raises(RuntimeError, match="stale or unknown"):
+        ops._lookup_cb_layer(layer_id)
+
+
+def test_expired_id_is_never_reused_for_new_layer():
+    first_method = _Method()
+    first_layer = _Layer()
+    first_id = ops.register_cb_layer(first_method, first_layer)
+    del first_method, first_layer
+    gc.collect()
+
+    second_method = _Method()
+    second_layer = _Layer()
+    second_id = ops.register_cb_layer(second_method, second_layer)
+
+    assert second_id > first_id
+    with pytest.raises(RuntimeError, match="stale or unknown"):
+        ops._lookup_cb_layer(first_id)
+    assert ops._lookup_cb_layer(second_id) == (second_method, second_layer)
+
+
+def test_live_linear_dispatch_keeps_output_contract():
+    method = _Method()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+
+    out = ops.cb_linear_forward(torch.ones((2, 3)), layer_id)
+
+    assert out.shape == (2, layer._cb_N)
+    assert torch.equal(out, torch.zeros_like(out))

--- a/tests/test_layer_registry.py
+++ b/tests/test_layer_registry.py
@@ -20,6 +20,12 @@ class _Method:
         return torch.zeros((*x.shape[:-1], layer._cb_N), dtype=x.dtype)
 
 
+class _MoEMethod:
+    def _apply_inline(self, layer, x, topk_weights, topk_ids):
+        del layer, topk_weights, topk_ids
+        return torch.full_like(x, 2)
+
+
 def test_registry_does_not_retain_unloaded_model():
     method = _Method()
     layer = _Layer()
@@ -35,6 +41,27 @@ def test_registry_does_not_retain_unloaded_model():
     assert layer_id not in ops._LAYER_REGISTRY
     with pytest.raises(RuntimeError, match="stale or unknown"):
         ops._lookup_cb_layer(layer_id)
+
+
+def test_layer_ownership_keeps_method_live_until_model_unload():
+    method = _Method()
+    layer = _Layer()
+    # This mirrors vLLM's LinearBase.quant_method ownership.
+    layer.quant_method = method
+    method_ref = weakref.ref(method)
+    layer_ref = weakref.ref(layer)
+    layer_id = ops.register_cb_layer(method, layer)
+
+    del method
+    gc.collect()
+    assert method_ref() is not None
+    assert layer_id in ops._LAYER_REGISTRY
+
+    del layer
+    gc.collect()
+    assert method_ref() is None
+    assert layer_ref() is None
+    assert layer_id not in ops._LAYER_REGISTRY
 
 
 def test_expired_id_is_never_reused_for_new_layer():
@@ -60,6 +87,53 @@ def test_live_linear_dispatch_keeps_output_contract():
     layer_id = ops.register_cb_layer(method, layer)
 
     out = ops.cb_linear_forward(torch.ones((2, 3)), layer_id)
+
+    assert out.shape == (2, layer._cb_N)
+    assert torch.equal(out, torch.zeros_like(out))
+
+
+def test_live_moe_dispatch_keeps_output_contract():
+    method = _MoEMethod()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+    x = torch.ones((3, 7))
+
+    out = ops.cb_moe_forward(
+        x,
+        torch.ones((3, 2)),
+        torch.zeros((3, 2), dtype=torch.int64),
+        layer_id,
+    )
+
+    assert out.shape == x.shape
+    assert torch.equal(out, torch.full_like(x, 2))
+
+
+def test_linear_custom_op_fake_and_schema_contract():
+    method = _Method()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+    x = torch.ones((2, 3))
+
+    torch.library.opcheck(ops.cb_linear_forward, (x, layer_id))
+
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode() as mode:
+        fake_out = ops.cb_linear_forward(mode.from_tensor(x), layer_id)
+    assert fake_out.shape == (2, layer._cb_N)
+
+
+def test_linear_custom_op_compiles_with_static_layer_id():
+    method = _Method()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+
+    def forward(x):
+        return ops.cb_linear_forward(x, layer_id)
+
+    compiled = torch.compile(forward, backend="eager", fullgraph=True)
+    out = compiled(torch.ones((2, 3)))
 
     assert out.shape == (2, layer._cb_N)
     assert torch.equal(out, torch.zeros_like(out))


### PR DESCRIPTION
## Outcome

Compiled dispatch no longer pins every unloaded model and its GPU allocations until process exit. Registry entries now hold weak references and use monotonic IDs, so a captured graph can never alias an expired ID to a newly loaded layer.

## Changes

- Replace process-lifetime strong method/layer references with weak references.
- Remove entries automatically when either owner expires.
- Fail stale/unknown IDs loudly with an unload-specific error.
- Use monotonic IDs to prevent ABA reuse after cleanup.
- Add lifecycle, vLLM-like ownership, linear/MoE dispatch, FakeTensor/opcheck, and full-graph compile coverage.

## Validation

- Focused integration set: 51 passed, 17 skipped (CUDA-only).
- Wheel build passed.
- Independent review exercised eager, FakeTensor, opcheck, torch.compile, torch.export, stale calls, independent expiry, and concurrent registration with no blocker.
- The broader local suite's unrelated failures are from its older partial-vLLM stubs and unwritable Triton cache; the canonical CI run is the merge gate.

## Attribution

This lifecycle repair was developed during RobTand's native-parity audit; it does not modify Jason's contributed kernel algorithms.
