### PR TITLE
perf: cut MoE prefill selection overhead

### DIFF
--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -65,7 +65,11 @@ from .moe_l2 import (
     cb_l2_pin_action,
     cb_l2_plan,
 )
-from .moe_routing import cb_grouped_pad_routing
+from .moe_routing import (
+    cb_cached_expert_map,
+    cb_cached_row_offsets,
+    cb_grouped_pad_routing,
+)
 from .ops import dispatch_via_op, fp4_act_qdq_or_codec
 
 
@@ -317,7 +321,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # w13 in=hidden (gate_up), w2 in=inter (down).
         in_f = layer._cb_hidden if which == "w13" else layer._cb_inter
         qwp = codec.pad_qweight(qw.contiguous())
-        row0 = torch.zeros(out, dtype=torch.int32, device=qw.device)
+        row0 = cb_cached_row_offsets(layer, out, qw.device)
         if self.is_fp4:                                        # fp4 v2
             W = expand_fp4_v2_to_weight(
                 qwp, layer._cb_flat, row0, layer._cb_compose,
@@ -633,6 +637,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         expert_ids, row_src, is_pad, n_blocks = cb_grouped_pad_routing(
             topk_ids, E, tile_m)
         if os.environ.get("PRISMAQUANT_CB_GROUPED_TRIM", "1") == "1":
+            # Kept intentionally: a host-read-free replacement must either
+            # launch the full static-capacity tail (a performance change) or
+            # teach the grouped kernel to consume n_blocks on device. A tensor
+            # slice bound still performs this same host conversion implicitly.
             nb = int(n_blocks.item())                # THE one sync (optional)
             expert_ids = expert_ids[:nb].contiguous()
             row_src = row_src[:nb * tile_m]
@@ -1008,6 +1016,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
             topk_ids, E, tile_m)
 
         if os.environ.get("PRISMAQUANT_CB_GROUPED_TRIM", "1") == "1":
+            # Kept intentionally: a host-read-free replacement must either
+            # launch the full static-capacity tail (a performance change) or
+            # teach the grouped kernel to consume n_blocks on device. A tensor
+            # slice bound still performs this same host conversion implicitly.
             nb = int(n_blocks.item())                # THE one sync (optional)
             expert_ids = expert_ids[:nb].contiguous()
             row_src = row_src[:nb * tile_m]
@@ -1811,6 +1823,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         C, out_f = packed.shape[0], packed.shape[1]
         in_f = layer._cb_hidden if which == "w13" else layer._cb_inter
         qwp = codec.pad_qweight(packed.reshape(C * out_f, -1).contiguous())
+        # ``C`` is routing-dependent on this legacy hit-expert path.  Do not
+        # retain an exact-size cache here: many request distributions could
+        # otherwise accumulate one buffer for every C in [1, E].  The stock
+        # path below has static chunk shapes and is safe to cache.
         row0 = torch.zeros(C * out_f, dtype=torch.int32, device=packed.device)
         if self.is_fp4:                                        # fp4 two-tier v2
             W = expand_fp4_v2_to_weight(
@@ -1994,7 +2010,8 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
 
         for c0 in range(0, E, chunk):                 # FIXED trip = ceil(E/chunk)
             c1 = min(E, c0 + chunk)
-            expert_map = self._stock_chunk_expert_map(c0, c1, E, dev)
+            expert_map = self._stock_chunk_expert_map(
+                layer, c0, c1, E, dev)
             # Device-side routing for THIS expert shard (local ids, out-of-chunk
             # pairs excluded). Shared verbatim by both projections.
             if _timing: _t0 = _time.time()
@@ -2168,14 +2185,13 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         return max(1, min(E, budget // max(1, per_expert)))
 
     @staticmethod
-    def _stock_chunk_expert_map(c0: int, c1: int, E: int,
+    def _stock_chunk_expert_map(layer, c0: int, c1: int, E: int,
                                 dev) -> torch.Tensor:
         """global->local expert_map for one chunk shard: experts [c0, c1) map to
-        [0, c1-c0), all others -1. Built from python ints only (no tensor read),
-        so it is a constant of the captured graph."""
-        m = torch.full((E,), -1, dtype=torch.int32, device=dev)
-        m[c0:c1] = torch.arange(c1 - c0, dtype=torch.int32, device=dev)
-        return m
+        [0, c1-c0), all others -1. Built from python ints only (no tensor read)
+        and cached by exact layer/device/bounds, so it is a persistent constant
+        of the captured graph."""
+        return cb_cached_expert_map(layer, c0, c1, E, dev)
 
     def _expand_stack_slice(self, layer, which: str, c0: int, c1: int, *,
                             to_fp8: bool) -> torch.Tensor:
@@ -2220,7 +2236,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         nE = c1 - c0
         out_f = packed.shape[1]
         in_f = layer._cb_hidden if which == "w13" else layer._cb_inter
-        row0 = torch.zeros(nE * out_f, dtype=torch.int32, device=packed.device)
+        row0 = cb_cached_row_offsets(layer, nE * out_f, packed.device)
         _expand_env = os.environ.get("PRISMAQUANT_CB_EXPAND")
         if to_fp8:                                                # fp8 bytes
             # CUDA expander (2.1x the Triton one, byte-identical) on the RAW

--- a/gridbook/moe_autotune.py
+++ b/gridbook/moe_autotune.py
@@ -131,12 +131,12 @@ def cb_time_candidate(fn):
     """Run ``fn`` ONCE and return ``(output, milliseconds)``, or ``None`` if the
     candidate is unavailable (returned ``None``) or raised.
 
-    ISOLATION. The candidate is bracketed by a full ``torch.cuda.synchronize()``
-    on both sides of a CUDA-event pair, so the number contains this candidate's
-    device work and nothing queued before or after it. Events (not the wall
-    clock) are what make it a device duration rather than a launch duration.
-    Without CUDA it falls back to a wall clock — meaningless as a real decision,
-    but it keeps the machinery runnable off-GPU.
+    ISOLATION. CUDA events are recorded on the stream that is current when the
+    candidate starts.  Synchronising ONLY the end event waits for that stream's
+    candidate work without draining unrelated streams or the whole device.
+    Events (not the wall clock) are what make it a device duration rather than a
+    launch duration.  Without CUDA it falls back to a wall clock — meaningless
+    as a real decision, but it keeps the machinery runnable off-GPU.
 
     A raising candidate is DISQUALIFIED rather than fatal: an extension build may
     not have compiled some (TileM, k_bits) pair (shared-memory limits), and that
@@ -144,13 +144,13 @@ def cb_time_candidate(fn):
     """
     try:
         if torch.cuda.is_available():
-            torch.cuda.synchronize()
+            stream = torch.cuda.current_stream()
             start = torch.cuda.Event(enable_timing=True)
             end = torch.cuda.Event(enable_timing=True)
-            start.record()
+            start.record(stream)
             out = fn()
-            end.record()
-            torch.cuda.synchronize()
+            end.record(stream)
+            end.synchronize()
             return None if out is None else (out, start.elapsed_time(end))
         t0 = time.perf_counter()
         out = fn()
@@ -173,9 +173,29 @@ def cb_autotune_prefill(candidates, keep: str = STOCK, timer=None):
     an ordinary call. Timing ties break on the candidate NAME, not on iteration
     order, for the same reason.
 
+    A singleton candidate is run directly, with NO timer events or
+    synchronisation: there is no ranking decision to measure.  It is still
+    cached by the caller, and a raising/``None`` singleton is disqualified just
+    like a timed candidate.
+
     ``(None, {}, None)`` means every candidate was disqualified; the caller runs
     its default path. ``timer`` is injectable for testing.
     """
+    candidates = list(candidates)
+
+    if len(candidates) == 1:
+        name, fn = candidates[0]
+        try:
+            out = fn()
+        except Exception as exc:  # noqa: BLE001 — same fallback as timed paths
+            print(f"[prismaquant-cb] prefill candidate disqualified "
+                  f"({type(exc).__name__}: {exc})",
+                  file=sys.stderr, flush=True)
+            return None, {}, None
+        if out is None:
+            return None, {}, None
+        return name, {}, out if name == keep else None
+
     timer = timer or cb_time_candidate
     timings: dict[str, float] = {}
     kept = None

--- a/gridbook/moe_routing.py
+++ b/gridbook/moe_routing.py
@@ -1,13 +1,99 @@
-"""Padded, block-aligned MoE routing for the ROUND-2 grouped-fused prefill.
+"""Torch-only MoE routing construction and immutable routing constants.
 
 Lives in its own module rather than in ``moe.py`` because ``moe.py`` imports
 vLLM at module scope: keeping this torch-only makes the routing construction —
 the part with all the index arithmetic and therefore all the risk — testable in
-the build venv on CPU, with no vLLM and no GPU. ``moe.py`` re-exports it.
+the build venv on CPU, with no vLLM and no GPU.  The cached tensors below are
+likewise pure routing/expander metadata: read-only after construction and keyed
+by exact shape and device. ``moe.py`` consumes them directly.
 """
 from __future__ import annotations
 
+import threading
+import weakref
+
 import torch
+
+
+# Deduplicate the much larger row-zero constants across identically shaped
+# layers without making this module their owner.  Each consuming layer keeps a
+# strong reference in its private cache (which is what stabilises pointers for
+# graph capture); this process-wide index is weak so unloading the last model
+# also releases the Tensor objects.  The lock covers the rare first creation so
+# concurrent layer initialisation cannot allocate duplicate GPU buffers.
+_ROW_OFFSET_POOL: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
+_ROW_OFFSET_POOL_LOCK = threading.Lock()
+_LAYER_CACHE_INIT_LOCK = threading.Lock()
+
+
+def _layer_tensor_cache(layer, attr: str) -> dict:
+    """Return a private per-layer tensor cache, creating it on first use."""
+    cache = getattr(layer, attr, None)
+    if cache is None:
+        # Layer warmup is normally serial, but make first use convergent even
+        # when two request threads reach a previously untouched layer together.
+        with _LAYER_CACHE_INIT_LOCK:
+            cache = getattr(layer, attr, None)
+            if cache is None:
+                cache = {}
+                setattr(layer, attr, cache)
+    if not isinstance(cache, dict):
+        raise TypeError(f"{attr} must be a dict, got {type(cache).__name__}")
+    return cache
+
+
+def cb_cached_expert_map(layer, c0: int, c1: int, E: int,
+                         device) -> torch.Tensor:
+    """Read-only global-to-local map for stock-prefill expert chunk ``[c0,c1)``.
+
+    The chunk loop's bounds and expert count are Python/config integers, and a
+    model layer does not change device while serving.  The exact tuple is the
+    cache key nevertheless: a changed chunk override, a moved layer, or two
+    same-sized but differently positioned chunks can never alias.  Retaining
+    every exact tensor (rather than growing/replacing one buffer) also keeps a
+    captured graph's pointer alive for the layer's lifetime.
+    """
+    c0, c1, E = int(c0), int(c1), int(E)
+    if not 0 <= c0 <= c1 <= E:
+        raise ValueError(f"invalid expert chunk [{c0}, {c1}) for E={E}")
+    dev = torch.device(device)
+    cache = _layer_tensor_cache(layer, "_cb_stock_expert_maps")
+    key = (dev, c0, c1, E)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    value = torch.full((E,), -1, dtype=torch.int32, device=dev)
+    value[c0:c1] = torch.arange(c1 - c0, dtype=torch.int32, device=dev)
+    # ``setdefault`` makes a concurrent first construction converge on one
+    # persistent object.  Either contender is byte-identical and read-only.
+    return cache.setdefault(key, value)
+
+
+def cb_cached_row_offsets(layer, rows: int, device) -> torch.Tensor:
+    """Return an exact-size, read-only int32 zero vector for CB expanders.
+
+    Every row in a stacked stock-prefill decode uses codebook row zero.  The old
+    path allocated and zero-filled this constant once per projection and chunk.
+    Exact-size/device keys avoid stride tricks, mutable slicing, cross-device
+    reuse, and pointer replacement under graph capture.  Layers retain strong
+    references, while a weak process-wide pool shares identical immutable
+    buffers across layers and stops owning them when the last model unloads.
+    """
+    rows = int(rows)
+    if rows < 0:
+        raise ValueError(f"rows must be non-negative, got {rows}")
+    dev = torch.device(device)
+    cache = _layer_tensor_cache(layer, "_cb_row_offset_cache")
+    key = (dev, rows)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    with _ROW_OFFSET_POOL_LOCK:
+        value = _ROW_OFFSET_POOL.get(key)
+        if value is None:
+            value = torch.zeros(rows, dtype=torch.int32, device=dev)
+            _ROW_OFFSET_POOL[key] = value
+    return cache.setdefault(key, value)
 
 
 def cb_grouped_pad_routing(topk_ids: torch.Tensor, E: int, tile_m: int):

--- a/tests/test_moe_prefill_overhead.py
+++ b/tests/test_moe_prefill_overhead.py
@@ -1,0 +1,281 @@
+"""Low-level gates for behavior-preserving MoE prefill overhead cuts.
+
+Torch-only: CUDA timing is exercised with event/stream stubs, and the immutable
+metadata caches run on CPU.  This makes the synchronization and cache-key
+contracts fail loudly in the ordinary build environment rather than only on a
+serving GPU.
+"""
+from __future__ import annotations
+
+import gc
+import types
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+from gridbook.moe_autotune import (
+    STOCK,
+    cb_autotune_prefill,
+    cb_prefill_auto,
+    cb_time_candidate,
+)
+from gridbook.moe_routing import (
+    cb_cached_expert_map,
+    cb_cached_row_offsets,
+)
+
+
+def test_singleton_candidate_runs_once_without_touching_timer_or_cuda(
+        monkeypatch):
+    """One candidate has no ranking decision and must allocate no timer events."""
+    marker = object()
+    calls = {"ran": 0}
+
+    def candidate():
+        calls["ran"] += 1
+        return marker
+
+    def forbidden_timer(_fn):
+        raise AssertionError("singleton candidate reached the timer")
+
+    monkeypatch.setattr(
+        torch.cuda, "is_available",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("singleton candidate queried CUDA timing")))
+    best, timings, kept = cb_autotune_prefill(
+        [(STOCK, candidate)], timer=forbidden_timer)
+
+    assert best == STOCK
+    assert timings == {}
+    assert kept is marker
+    assert calls == {"ran": 1}
+
+
+def test_singleton_auto_caches_direct_choice_and_preserves_output():
+    layer = types.SimpleNamespace()
+    marker = object()
+    seen = {"built": 0, "ran": 0, "stock_fallback": 0, "logs": []}
+
+    def build():
+        seen["built"] += 1
+
+        def stock():
+            seen["ran"] += 1
+            return marker
+
+        return [(STOCK, stock)]
+
+    def fallback():
+        seen["stock_fallback"] += 1
+        raise AssertionError("successful singleton invoked stock twice")
+
+    out = cb_prefill_auto(
+        layer, 4096, build, fallback,
+        timer=lambda _fn: (_ for _ in ()).throw(
+            AssertionError("singleton auto reached timer")),
+        log=lambda best, timings, forced: seen["logs"].append(
+            (best, dict(timings), forced)),
+    )
+
+    assert out is marker
+    assert layer._cb_prefill_choice == STOCK
+    assert seen == {
+        "built": 1,
+        "ran": 1,
+        "stock_fallback": 0,
+        "logs": [(STOCK, {}, False)],
+    }
+
+
+def test_non_stock_singleton_keeps_stock_output_on_tuning_call():
+    """Skipping timing must not weaken the tuner's determinism contract."""
+    layer = types.SimpleNamespace()
+    tuned = object()
+    stock = object()
+    seen = {"candidate": 0, "fallback": 0}
+
+    def candidate():
+        seen["candidate"] += 1
+        return tuned
+
+    def fallback():
+        seen["fallback"] += 1
+        return stock
+
+    out = cb_prefill_auto(
+        layer, 4096,
+        lambda: [("grouped_fused:tile_m=128", candidate)],
+        fallback,
+        timer=lambda _fn: (_ for _ in ()).throw(
+            AssertionError("non-stock singleton reached timer")),
+    )
+
+    assert out is stock
+    assert layer._cb_prefill_choice == "grouped_fused:tile_m=128"
+    assert seen == {"candidate": 1, "fallback": 1}
+
+
+@pytest.mark.parametrize("failure", ["none", "raise"])
+def test_singleton_disqualification_preserves_fallback_contract(failure,
+                                                                 capsys):
+    def candidate():
+        if failure == "raise":
+            raise RuntimeError("unavailable")
+        return None
+
+    best, timings, kept = cb_autotune_prefill(
+        [(STOCK, candidate)],
+        timer=lambda _fn: (_ for _ in ()).throw(
+            AssertionError("disqualified singleton reached timer")),
+    )
+    assert (best, timings, kept) == (None, {}, None)
+    if failure == "raise":
+        assert "candidate disqualified" in capsys.readouterr().err
+
+
+def test_cuda_timer_uses_current_stream_and_only_end_event_sync(monkeypatch):
+    trace = []
+    stream = object()
+    events = []
+
+    class FakeEvent:
+        def __init__(self, *, enable_timing):
+            self.index = len(events)
+            self.enable_timing = enable_timing
+            events.append(self)
+            trace.append(("event", self.index, enable_timing))
+
+        def record(self, recorded_stream=None):
+            trace.append(("record", self.index, recorded_stream))
+
+        def synchronize(self):
+            trace.append(("event_sync", self.index))
+
+        def elapsed_time(self, end):
+            trace.append(("elapsed", self.index, end.index))
+            return 7.25
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream",
+        lambda: (trace.append(("current_stream",)), stream)[1])
+    monkeypatch.setattr(torch.cuda, "Event", FakeEvent)
+    monkeypatch.setattr(
+        torch.cuda, "synchronize",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("device-wide synchronize is forbidden")))
+
+    marker = object()
+
+    def candidate():
+        trace.append(("candidate",))
+        return marker
+
+    out, elapsed = cb_time_candidate(candidate)
+    assert out is marker
+    assert elapsed == pytest.approx(7.25)
+    assert trace == [
+        ("current_stream",),
+        ("event", 0, True),
+        ("event", 1, True),
+        ("record", 0, stream),
+        ("candidate",),
+        ("record", 1, stream),
+        ("event_sync", 1),
+        ("elapsed", 0, 1),
+    ]
+
+
+def test_cached_expert_maps_key_exact_bounds_device_and_layer():
+    layer = types.SimpleNamespace()
+    same_alias = torch.device("cpu")
+
+    a = cb_cached_expert_map(layer, 2, 5, 8, "cpu")
+    a_again = cb_cached_expert_map(layer, 2, 5, 8, same_alias)
+    assert a_again is a
+    assert a.dtype == torch.int32 and a.device == same_alias
+    assert torch.equal(a, torch.tensor([-1, -1, 0, 1, 2, -1, -1, -1],
+                                       dtype=torch.int32))
+
+    # Same chunk width, different bounds: never alias by size alone.
+    shifted = cb_cached_expert_map(layer, 3, 6, 8, "cpu")
+    assert shifted is not a
+    assert torch.equal(
+        shifted,
+        torch.tensor([-1, -1, -1, 0, 1, 2, -1, -1], dtype=torch.int32),
+    )
+
+    # The cache is per layer, so two model layers cannot share tensor lifetime.
+    other = cb_cached_expert_map(
+        types.SimpleNamespace(), 2, 5, 8, "cpu")
+    assert other is not a
+    assert torch.equal(other, a)
+
+
+@pytest.mark.parametrize("bounds", [(-1, 2, 8), (4, 3, 8), (0, 9, 8)])
+def test_cached_expert_map_rejects_invalid_bounds(bounds):
+    with pytest.raises(ValueError, match="invalid expert chunk"):
+        cb_cached_expert_map(types.SimpleNamespace(), *bounds, "cpu")
+
+
+def test_cached_row_offsets_key_exact_size_device_and_share_immutables():
+    layer = types.SimpleNamespace()
+    row0 = cb_cached_row_offsets(layer, 17, "cpu")
+    row0_again = cb_cached_row_offsets(layer, 17, torch.device("cpu"))
+    assert row0_again is row0
+    assert row0.dtype == torch.int32 and row0.is_contiguous()
+    assert torch.equal(row0, torch.zeros(17, dtype=torch.int32))
+
+    other_size = cb_cached_row_offsets(layer, 18, "cpu")
+    assert other_size is not row0
+    assert other_size.shape == (18,)
+
+    other_layer = cb_cached_row_offsets(types.SimpleNamespace(), 17, "cpu")
+    assert other_layer is row0
+
+    empty = cb_cached_row_offsets(layer, 0, "cpu")
+    assert empty.shape == (0,)
+    with pytest.raises(ValueError, match="non-negative"):
+        cb_cached_row_offsets(layer, -1, "cpu")
+
+
+def test_cached_row_offset_pool_does_not_own_unloaded_layers():
+    layer = types.SimpleNamespace()
+    row0 = cb_cached_row_offsets(layer, 123_457, "cpu")
+    tensor_ref = weakref.ref(row0)
+
+    del row0
+    del layer
+    gc.collect()
+
+    assert tensor_ref() is None
+
+
+def test_concurrent_cache_warmup_converges_on_one_object():
+    layer = types.SimpleNamespace()
+
+    def get_constants(_):
+        return (
+            cb_cached_expert_map(layer, 1, 4, 8, "cpu"),
+            cb_cached_row_offsets(layer, 32_771, "cpu"),
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(get_constants, range(32)))
+
+    expert_maps, row_offsets = zip(*results)
+    assert all(value is expert_maps[0] for value in expert_maps)
+    assert all(value is row_offsets[0] for value in row_offsets)
+
+
+@pytest.mark.parametrize("attr", ["_cb_stock_expert_maps",
+                                  "_cb_row_offset_cache"])
+def test_cache_attribute_collision_fails_loudly(attr):
+    layer = types.SimpleNamespace(**{attr: object()})
+    with pytest.raises(TypeError, match="must be a dict"):
+        if attr == "_cb_stock_expert_maps":
+            cb_cached_expert_map(layer, 0, 1, 1, "cpu")
+        else:
+            cb_cached_row_offsets(layer, 1, "cpu")

--- a/tests/test_moe_stock_prefill.py
+++ b/tests/test_moe_stock_prefill.py
@@ -307,6 +307,29 @@ def test_stock_expand_matches_decode(cfg, which):
             f"{cfg}/{which}: sliced expand expert {e} != _decode_expert")
 
 
+def test_stock_prefill_constant_buffers_reuse_device_storage():
+    """The hot stock path reuses exact-device expert maps and row-zero vectors."""
+    _require_stack()
+    m, layer, _ = _build("fp8")
+
+    map_a = m._stock_chunk_expert_map(layer, 1, 5, layer._cb_E, DEV)
+    map_b = m._stock_chunk_expert_map(layer, 1, 5, layer._cb_E, DEV)
+    assert map_a.data_ptr() == map_b.data_ptr()
+
+    first = m._expand_stack_slice(layer, "w13", 1, 5, to_fp8=True)
+    cached_before = {
+        key: value.data_ptr()
+        for key, value in layer._cb_row_offset_cache.items()
+    }
+    second = m._expand_stack_slice(layer, "w13", 1, 5, to_fp8=True)
+    cached_after = {
+        key: value.data_ptr()
+        for key, value in layer._cb_row_offset_cache.items()
+    }
+    assert cached_after == cached_before
+    assert torch.equal(first, second)
+
+
 # --------------------------------------------------------------------------- #
 # 4 — loop vs stock parity across rungs and token distributions.                #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Outcome

Removes avoidable host/allocation overhead from the MoE prefill hot path without changing quantization, routing, or kernel arithmetic.

- singleton autotune selections run directly with zero CUDA timing events or synchronizations
- multi-candidate timing records on the caller's current stream and synchronizes only the end event, rather than draining the device
- immutable stock-prefill expert maps are cached per layer/device/exact chunk
- immutable row-zero expander buffers are shared across equal-shaped layers through a weak pool while each live layer retains graph-stable ownership
- the routing-dependent legacy buffer and grouped-trim host read remain unchanged and are documented instead of being given unsafe/unbounded caches

## Review notes

The change is deliberately behavior-preserving. It does not claim a served throughput win from the CPU construction microbenchmarks. Final GPU throughput and regression checks will use Jason's Laguna artifact after the parity harness lands.

## Validation

- focused suite: 79 passed, 69 skipped (host and pinned vLLM image)
- wheel build, compileall, py_compile, and diff checks pass
- CPU microbenchmarks from the same process:
  - singleton selection: 0.617 us -> 0.136 us (4.5x)
  - expert-map construction: 2.930 us -> 0.401 us (7.3x)
  - 131072-row zero buffer: 6.413 us -> 0.329 us (19.5x)
- GPU-specific timing/throughput remains a merge/release validation gate

## Attribution

This is Robert's follow-up performance/safety work after the reviewed @jsconsultancy contribution series.
