### PR TITLE
config: require a dotted MoE target boundary

### DIFF
--- a/gridbook/config.py
+++ b/gridbook/config.py
@@ -439,7 +439,12 @@ class PrismaQuantConfig(QuantizationConfig):
             if name.split(".")[-1] not in _MOE_LEAVES:
                 continue
             variants = _candidate_bases(name)
-            if any(v.startswith(b) for v in variants for b in bases):
+            # A target must be a dotted child of this exact expert prefix.
+            # Raw ``startswith`` also accepts neighbouring module names such
+            # as ``experts2`` and ``experts_backup``, silently assigning their
+            # scheme to the live ``experts`` stack.
+            if any(v.startswith(b.rstrip(".") + ".")
+                   for v in variants for b in bases):
                 return sch
         return None
 

--- a/tests/test_target_namespace_compat.py
+++ b/tests/test_target_namespace_compat.py
@@ -271,6 +271,19 @@ def test_moe_scheme_does_not_overmatch():
         "language_model.model.layers.1.mlp.shared_expert") is None
 
 
+@pytest.mark.parametrize("neighbour", ["experts2", "experts_backup"])
+@pytest.mark.parametrize("prefix", _MOE_EXPERT_PREFIXES)
+def test_moe_scheme_requires_a_dotted_prefix_boundary(neighbour, prefix):
+    """A sibling whose name merely starts with ``experts`` is not that stack."""
+    cfg = PrismaQuantConfig.from_config(_moe_config([
+        f"model.layers.1.mlp.{neighbour}.gate_up_proj",
+        f"model.layers.1.mlp.{neighbour}.down_proj",
+    ]))
+    cfg._ensure_resolved()
+
+    assert cfg._moe_scheme_for_prefix(prefix) is None
+
+
 # ---------------------------------------------------------------------------
 # The FOURTH namespace vintage: post-``apply_vllm_mapper`` (issue #1,
 # RobTand/gridbook, 2026-07-25).


### PR DESCRIPTION
## Value

Extracts the one independently valid correctness fix from draft PR #12 without merging its unvalidated graded-rung runtime machinery.

The MoE resolver previously used a raw prefix comparison, so targets under sibling modules such as `experts2` or `experts_backup` could be mistaken for the live `experts` stack. This change requires an actual dotted child boundary and keeps unmatched layers on their intended delegated path.

## Validation

- namespace compatibility suite: 87 passed
- covers `experts2` and `experts_backup` across all three supported serving-prefix namespaces
- compile and diff hygiene passed

Original finding and patch design by Jason Wong (@jsconsultancy), carried forward from #12. Review and extraction by @RobTand.