### PR TITLE
runtime: fail closed on unsupported serving contracts

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -82,7 +82,7 @@ it already fails soft.
 | **RTX 5090 `sm_120`** | ✅ CUDA | ✅ | ✅ (expected) | **USER-REPORTED** working on the 27B artifact. Note the arch flag differs (`sm_120` vs the measured `sm_121`); no speed numbers exist for this card. |
 | **H100 `sm_90`** | expected ✅ | expected ✅ | ❌ fails soft → expand path | **INFERRED, UNTESTED.** |
 | **RTX 4090 / L40S `sm_89`** | expected ✅ | expected ✅ | ❌ fails soft → expand path | **INFERRED, UNTESTED.** |
-| **A100 `sm_80`** | expected ✅ | ❌ **expected to error** — the fp8 GEMM it calls needs `sm_89+` and has no capability guard or fallback | n/a | **NOT RECOMMENDED.** The plugin declares a capability floor of 8.0 and will start, but any prompt longer than 16 tokens is expected to fail. INFERRED from code. |
+| **A100 `sm_80`** | expected ✅ for FP4-CB | ❌ FP8-CB requires `sm_89+` | n/a | **FAILS EARLY for FP8-CB.** Gridbook rejects the first FP8-CB target during model construction instead of loading a serve that will fail above 16 tokens. FP4-CB retains its BF16 fallback; untested on this card. |
 | **Older / no `nvcc` / non-NVIDIA** | Triton fallback | Triton fallback | n/a | Correct numerics, prototype speed. Not a serving target. |
 
 Per-artifact caveat: an artifact may contain non-CB groups served by stock

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -49,10 +49,15 @@ but several times slower and not a serving target.
   W4A16 group. **Consequence:** an artifact's hardware requirements are the union
   of gridbook's and those of its delegated groups.
 - **Single-GPU (`tp=1`) only** — there is no tensor-parallel handling for CB
-  weights. `--enforce-eager` is the published-model configuration; mode-0
+  weights, and a live TP size above one now fails during model construction.
+  `--enforce-eager` is the published-model configuration; mode-0
   `FULL_DECODE_ONLY` is also capture-correct with the default opaque dispatch
   and is being promoted through the model-size performance gates
   ([details](TROUBLESHOOTING.md#do-i-really-need---enforce-eager)).
+- **BF16 activations only** — the shipping CUDA dense and grouped-MoE bindings
+  require BF16. Gridbook no longer advertises FP16 to vLLM and therefore fails
+  at dtype validation instead of crashing or changing dtype at a dispatch
+  crossover.
 
 ## Layout / registration
 
@@ -155,7 +160,7 @@ tooling and model cards — see the README's naming section.)
 | `PRISMAQUANT_CB_EXT_DIR` | `~/.cache/prismaquant-cb-ext` | Where the JIT extensions are built and cached. Point it at a persistent, writable directory in containers to avoid a ~30 s rebuild per start. |
 | `PRISMAQUANT_CB_DECODE` | `cuda` | `triton` forces the Triton decode path (much slower; bisection only). |
 | `PRISMAQUANT_CB_GEMV` | `inherited` | Which grouped fp4-CB decode GEMV serves a layer: `inherited` \| `auto` \| `v2`. Unset/`inherited` reproduces the shipped dispatch and never attempts the experimental JIT build. Explicit `auto` or `v2` may use `cb_gemv_v2.cu` only on native Blackwell cc 12.0/12.1 devices with the required opt-in shared memory and where the compiled occupancy predicate says it wins; this PR's execution battery covers cc 12.1. FP8-only serves never build it. **Not** bit-exact against `inherited` (reassociation class). An unknown spelling raises; changing it mid-process raises. |
-| `PRISMAQUANT_CB_PREFILL` | `auto` (fp8-CB) / `loop` (fp4-CB) | MoE prefill path: `auto` \| `stock` \| `grouped_fused` \| `loop`. For fp4-CB, unset selects conservative `loop`; any explicit mode also bypasses the separate fused-FP4 opt-in attempt. `l2_pipeline` exists but is **diagnostic-only** — it wedged live serving three times. |
+| `PRISMAQUANT_CB_PREFILL` | `auto` (fp8-CB) / `loop` (fp4-CB) | MoE prefill path: `auto` \| `stock` \| `grouped_fused` \| `grouped_fused_r1` \| `loop` \| `batched` \| `l2_pipeline`. `batched`, `grouped_fused_r1`, and `l2_pipeline` are diagnostic/A-B modes; `l2_pipeline` wedged live serving three times. For fp4-CB, unset selects conservative `loop`; any explicit mode also bypasses the separate fused-FP4 opt-in attempt. Unknown spellings fail, and changing the value mid-process requires a restart. |
 | `PRISMAQUANT_CB_FUSED_FP4` | off | Dense fp4-CB native-FP4 prefill opt-in: `1` for every prefill shape or `midm` for 16 < M <= 128. Changes the activation-scale bucket (fp32 emulation to native ue4m3), so it remains off pending served KL/PPL. |
 | `PRISMAQUANT_CB_FUSED_FP4_MOE` | off | Grouped-MoE fp4-CB native-FP4 prefill opt-in: `1`/`128` selects TileM 128; `256` selects TileM 256. An ineligible attempt fails closed to `loop`. It has the same activation-contract and served-quality gate as the dense path. |
 | `PRISMAQUANT_CB_FUSED_MIDM` | `1` | `0` skips the CUTLASS mid-M fused prefill kernel — including its JIT build, which is worth doing on non-`sm_120` GPUs where the build is doomed anyway. |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -412,19 +412,18 @@ The rules and evidence limits are in
 
 ## Non-Blackwell GPU: what breaks
 
-The plugin declares a compute-capability floor of **8.0**, so it will start on
-an A100 — but that floor is more permissive than the shipped paths. See the
-[hardware matrix](INSTALL.md#hardware-matrix) for the per-path breakdown.
+The base FP4-CB path declares compute capability **8.0**, while FP8-CB's native
+prefill path requires **8.9** and is now checked during model construction. See
+the [hardware matrix](INSTALL.md#hardware-matrix) for the per-path breakdown.
 
 - **`sm_89` / `sm_90` (RTX 4090, L40S, H100)** — decode and dense prefill are
   *expected* to work (the decode kernel has no architecture guards); the mid-M
   fused kernel fails soft with the warning above. **Inferred from code, untested
   by the author.**
-- **`sm_80` (A100)** — expected to fail on the first prompt longer than 16
-  tokens. The dense FP8-CB prefill calls a CUTLASS fp8 GEMM that requires
-  `sm_89+`, with no capability guard and no fallback; the symptom is an error
-  from `cutlass_scaled_mm` or `scaled_fp8_quant` at the first prefill, after a
-  successful load and short decodes. **Not recommended.**
+- **`sm_80` (A100)** — an FP8-CB artifact is rejected early with a clear
+  `sm_89+` error. The former behavior loaded successfully and then failed at
+  `cutlass_scaled_mm` / `scaled_fp8_quant` on the first prompt longer than 16
+  tokens. FP4-CB retains its BF16 fallback, but is untested on this card.
 - Per-artifact groups matter too. The 27B's vision tower is stock NVFP4 W4A16 and
   needs a vLLM NVFP4 backend independently of gridbook.
 
@@ -435,10 +434,10 @@ your versions and numbers is genuinely useful — that table is how it gets wide
 
 ## Tensor parallel (`tp > 1`)
 
-Unsupported. The plugin contains no tensor-parallel handling at all — there is no
-sharding logic for the packed index stream, per-role codebook offsets or scale
-planes. Serve with `tp=1`. Multi-GPU support is not currently on the roadmap;
-if you need it, say so on an issue.
+Unsupported and rejected during model construction. The plugin contains no
+tensor-parallel handling for the packed index stream, per-role codebook offsets
+or scale planes. Serve with `tp=1`. Multi-GPU support is not currently on the
+roadmap; if you need it, say so on an issue.
 
 ---
 

--- a/gridbook/config.py
+++ b/gridbook/config.py
@@ -49,6 +49,28 @@ _FUSED_FALLBACK = {
 }
 
 
+def _initialized_tensor_parallel_world_size() -> int | None:
+    """Return vLLM's TP size once model parallelism exists.
+
+    Config/resolver unit tests intentionally run without a distributed vLLM
+    process.  Production calls ``get_quant_method`` while constructing the
+    worker model, after vLLM initializes its model-parallel groups; that is the
+    first point where the documented TP=1 restriction can be enforced against
+    the real serving state instead of an argument string.
+    """
+
+    try:
+        from vllm.distributed import (
+            get_tensor_model_parallel_world_size,
+            model_parallel_is_initialized,
+        )
+    except (ImportError, AttributeError):  # pragma: no cover - minimal stubs
+        return None
+    if not model_parallel_is_initialized():
+        return None
+    return int(get_tensor_model_parallel_world_size())
+
+
 def _canonical_prefix(prefix: str) -> str:
     """vLLM serving prefix -> canonical target namespace. Some model classes
     wrap the LM (`language_model.model.layers.*` on Qwen3.5-class VL) while
@@ -132,6 +154,42 @@ class PrismaQuantConfig(QuantizationConfig):
         self._cb_targets: set[str] = set()
         self.ct_config = None                        # stock CompressedTensorsConfig
         self._codebooks: dict[str, torch.Tensor] | None = None
+        self._tp_world_size: int | None = None
+
+    def _require_supported_tensor_parallel(self) -> None:
+        if self._tp_world_size == 1:
+            return
+        world_size = _initialized_tensor_parallel_world_size()
+        if world_size is None:
+            return
+        if world_size != 1:
+            raise ValueError(
+                "Gridbook currently supports tensor-parallel size 1 only; "
+                f"the live vLLM worker reports TP={world_size}"
+            )
+        self._tp_world_size = world_size
+
+    @staticmethod
+    def _require_cb_device_capability(scheme: dict, prefix: str) -> None:
+        """Reject an FP8-CB artifact before its first illegal prefill.
+
+        FP8-CB's shipping large-M path uses vLLM's native FP8 quantizer and
+        CUTLASS scaled GEMM, whose hardware floor is sm_89.  The main decode
+        extension itself can compile for sm_80, so a global capability floor
+        would otherwise let an A100 load successfully and fail only when the
+        first prompt crosses the 16-token decode boundary.  FP4-CB retains the
+        broader BF16 transient fallback and is not rejected here.
+        """
+
+        if scheme.get("grid") != "fp8" or not torch.cuda.is_available():
+            return
+        capability = tuple(torch.cuda.get_device_capability())
+        if capability < (8, 9):
+            raise ValueError(
+                f"FP8-CB target {prefix!r} requires compute capability sm_89+ "
+                "for its shipping prefill path; "
+                f"the current device reports sm_{capability[0]}{capability[1]}"
+            )
 
     # -- lazy resolution of the (possibly pointer) quant config --------------
     def _ensure_resolved(self) -> None:
@@ -222,7 +280,10 @@ class PrismaQuantConfig(QuantizationConfig):
         return "gridbook"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
-        return [torch.bfloat16, torch.float16]
+        # Shipping CUDA decode and grouped-MoE bindings require BF16 inputs.
+        # Advertising FP16 lets vLLM accept a model dtype that later fails at
+        # the native boundary (or changes dtype at a fallback/crossover).
+        return [torch.bfloat16]
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -363,6 +424,7 @@ class PrismaQuantConfig(QuantizationConfig):
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> "QuantizeMethodBase | None":
+        self._require_supported_tensor_parallel()
         self._ensure_resolved()
         from .linear import PrismaQuantCBLinearMethod
 
@@ -381,6 +443,7 @@ class PrismaQuantConfig(QuantizationConfig):
                       f"{'CB' if scheme is not None else 'no-scheme'}",
                       file=sys.stderr, flush=True)
             if scheme is not None:
+                self._require_cb_device_capability(scheme, prefix)
                 return PrismaQuantCBLinearMethod(self, scheme, prefix)
             # 2) explicitly-ignored -> BF16 passthrough.
             if self._is_ignored(prefix):
@@ -404,6 +467,7 @@ class PrismaQuantConfig(QuantizationConfig):
         if RoutedExperts is not None and isinstance(layer, RoutedExperts):
             scheme = self._moe_scheme_for_prefix(prefix)
             if scheme is not None:
+                self._require_cb_device_capability(scheme, prefix)
                 from .moe import PrismaQuantCBMoEMethod
                 return PrismaQuantCBMoEMethod(
                     self, layer.moe_config, scheme, prefix)

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -107,6 +107,41 @@ def _window_fits_superblock(k: int, type_size: int) -> bool:
 # reject degrades to segmented once, not per forward.
 _GROUPED_MM_OK: bool | None = None
 
+# Every accepted public/diagnostic prefill selector. Historically every unknown
+# spelling fell through to ``batched`` -- the high-transient experimental path
+# that has crashed a large serve. Pin the environment once per process and fail
+# on typos or mid-serve mutation so one model cannot split its layers across
+# different execution contracts.
+_PREFILL_MODES = frozenset({
+    "auto",
+    "batched",
+    "grouped_fused",
+    "grouped_fused_r1",
+    "l2_pipeline",
+    "loop",
+    "stock",
+})
+_PREFILL_MODE_STATE: list[str | None] = []
+
+
+def _requested_prefill_mode() -> str | None:
+    raw = os.environ.get("PRISMAQUANT_CB_PREFILL")
+    current = raw.strip() if raw is not None else None
+    if current == "" or (current is not None and current not in _PREFILL_MODES):
+        allowed = ", ".join(sorted(_PREFILL_MODES))
+        raise ValueError(
+            "invalid PRISMAQUANT_CB_PREFILL="
+            f"{raw!r}; expected one of: {allowed}, or leave it unset"
+        )
+    if not _PREFILL_MODE_STATE:
+        _PREFILL_MODE_STATE.append(current)
+    elif current != _PREFILL_MODE_STATE[0]:
+        raise RuntimeError(
+            "PRISMAQUANT_CB_PREFILL changed after Gridbook dispatch was fixed; "
+            "restart the process instead of mixing prefill contracts"
+        )
+    return _PREFILL_MODE_STATE[0]
+
 
 def _grouped_mm_available() -> bool:
     global _GROUPED_MM_OK
@@ -501,7 +536,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # measured shapes, but its padding cost has a sharp token-count cliff.
         # The same unvalidated-on-serving-metric caveat as the dense gate in
         # linear.py applies.
-        requested_mode = os.environ.get("PRISMAQUANT_CB_PREFILL")
+        requested_mode = _requested_prefill_mode()
         if requested_mode is None and self.is_fp4 and num_tokens > 16:
             gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "").strip()
             if gf4 in ("1", "128", "256"):
@@ -544,8 +579,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         if mode == "stock":
             return self._apply_prefill_stock(
                 layer, x, topk_weights, topk_ids, act)
-        return self._apply_prefill_batched(
-            layer, x, topk_weights, topk_ids, act)
+        if mode == "batched":
+            return self._apply_prefill_batched(
+                layer, x, topk_weights, topk_ids, act)
+        raise AssertionError(f"unhandled validated CB prefill mode: {mode}")
 
     # -- prefill: fp4 grouped FUSED (block-scaled decode-in-prologue) --------
     def _gf4_ok(self, layer) -> bool:

--- a/tests/test_moe_fp4_stock_prefill.py
+++ b/tests/test_moe_fp4_stock_prefill.py
@@ -88,6 +88,13 @@ def moe(request):
         sys.modules.update(before)
 
 
+@pytest.fixture(autouse=True)
+def _reset_prefill_mode_state(moe):
+    moe._PREFILL_MODE_STATE.clear()
+    yield
+    moe._PREFILL_MODE_STATE.clear()
+
+
 def _method(moe, *, grid, k, n_sub, type_size, is_v2=True):
     """A ``PrismaQuantCBMoEMethod`` with ``__init__`` bypassed (the fixture
     pattern the other MoE test files use) carrying just the format fields the
@@ -193,6 +200,22 @@ def test_explicit_fp4_mode_bypasses_fused_default(moe, monkeypatch, mode):
 def test_fp8_explicit_mode_still_overrides_auto(moe, monkeypatch):
     monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", "loop")
     assert _dispatch_mode(moe, monkeypatch, _fp8(moe)) == "loop"
+
+
+@pytest.mark.parametrize("value", ["", "stok", "AUTO", "unknown"])
+def test_invalid_prefill_mode_fails_instead_of_selecting_batched(
+        moe, monkeypatch, value):
+    monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", value)
+    with pytest.raises(ValueError, match="invalid PRISMAQUANT_CB_PREFILL"):
+        _dispatch_mode(moe, monkeypatch, _fp8(moe))
+
+
+def test_prefill_mode_cannot_change_mid_process(moe, monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", "loop")
+    assert _dispatch_mode(moe, monkeypatch, _fp8(moe)) == "loop"
+    monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", "stock")
+    with pytest.raises(RuntimeError, match="changed after Gridbook dispatch"):
+        _dispatch_mode(moe, monkeypatch, _fp8(moe))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_target_namespace_compat.py
+++ b/tests/test_target_namespace_compat.py
@@ -596,7 +596,8 @@ def test_live_tensor_parallel_size_above_one_fails_before_dispatch(monkeypatch):
     monkeypatch.setattr(config_mod, "_initialized_tensor_parallel_world_size",
                         lambda: 2)
     with pytest.raises(ValueError, match=r"TP=2"):
-        cfg._require_supported_tensor_parallel()
+        # The gate precedes config resolution and method/weight construction.
+        cfg.get_quant_method(object(), "model.layers.0.mlp.down_proj")
 
     monkeypatch.setattr(config_mod, "_initialized_tensor_parallel_world_size",
                         lambda: 1)

--- a/tests/test_target_namespace_compat.py
+++ b/tests/test_target_namespace_compat.py
@@ -581,6 +581,49 @@ def test_get_quant_method_delegates_gate_projection_not_router(monkeypatch):
         _Linear(), "model.layers.1.mlp.gate_proj") is delegated
 
 
+def test_config_advertises_only_the_bf16_runtime_contract():
+    import torch
+
+    cfg = PrismaQuantConfig(_config())
+    assert cfg.get_supported_act_dtypes() == [torch.bfloat16]
+    assert torch.float16 not in cfg.get_supported_act_dtypes()
+
+
+def test_live_tensor_parallel_size_above_one_fails_before_dispatch(monkeypatch):
+    import gridbook.config as config_mod
+
+    cfg = PrismaQuantConfig(_config())
+    monkeypatch.setattr(config_mod, "_initialized_tensor_parallel_world_size",
+                        lambda: 2)
+    with pytest.raises(ValueError, match=r"TP=2"):
+        cfg._require_supported_tensor_parallel()
+
+    monkeypatch.setattr(config_mod, "_initialized_tensor_parallel_world_size",
+                        lambda: 1)
+    cfg._require_supported_tensor_parallel()
+    assert cfg._tp_world_size == 1
+
+
+def test_fp8_cb_rejects_sm80_before_the_first_prefill(monkeypatch):
+    import gridbook.config as config_mod
+
+    cfg = PrismaQuantConfig(_config())
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(config_mod.torch.cuda, "get_device_capability",
+                        lambda: (8, 0))
+    with pytest.raises(ValueError, match=r"sm_89\+.*sm_80"):
+        cfg._require_cb_device_capability(_SCHEME, "model.layers.0.mlp.down_proj")
+
+    monkeypatch.setattr(config_mod.torch.cuda, "get_device_capability",
+                        lambda: (8, 9))
+    cfg._require_cb_device_capability(_SCHEME, "model.layers.0.mlp.down_proj")
+
+    fp4 = {**_SCHEME, "grid": "fp4"}
+    monkeypatch.setattr(config_mod.torch.cuda, "get_device_capability",
+                        lambda: (8, 0))
+    cfg._require_cb_device_capability(fp4, "model.layers.0.mlp.down_proj")
+
+
 _SUBSET_ENTRIES = ["model.layers.1.mlp.gate", "model.layers.1.mlp", "lm_head",
                    "mlp.down_proj", "model.layers.1"]
 _SUBSET_NAMES = ["model.layers.1.mlp.gate", "model.layers.1.mlp.gate_proj",


### PR DESCRIPTION
## Outcome

Turns four previously late or silent runtime hazards into early, explicit contract checks:

- advertise BF16 only, matching the shipping dense and grouped CUDA bindings
- reject FP8-CB on devices below sm_89 during model construction, before the first illegal native-FP8 prefill
- reject live tensor-parallel size above one before CB weight allocation
- whitelist and process-freeze `PRISMAQUANT_CB_PREFILL`; typos no longer fall through to the high-transient experimental `batched` path, and mid-process changes cannot split a serve across contracts

FP4-CB keeps its broader BF16 transient fallback. The explicit diagnostic/A-B modes remain available. Fused native-FP4 prefill remains opt-in and unchanged.

## Why this matters

The previous configuration accepted FP16 although the native kernels require BF16, allowed an A100 FP8-CB serve to load and fail only after a prompt crossed the decode boundary, documented TP=1 without enforcing it, and routed every unknown prefill spelling into a path that previously crashed a large serve with roughly 1.6 GiB of transient workspace.

## Validation

- focused CPU contract suites: 124 passed
- exact pinned vLLM/CUDA image (`sha256:d0840ff...5141`) with real vLLM classes: 124 passed
- canonical isolated CPU suite: all 31 files passed or capability-skipped
- diff and compile hygiene: clean

No Strix Halo, HIP, or ROCm work is included; that scope was cancelled.
