### PR TITLE
bench: add fail-closed native-parity serving protocol

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,5 +1,11 @@
 # Benchmarks
 
+For new native-performance work, use the reproducible streaming
+[native-parity protocol](NATIVE-PARITY.md). It fixes request shapes and seeds,
+runs independent blocks through `vllm bench serve`, and records the artifact,
+image, dispatch, software, and server provenance alongside true TTFT/TPOT/ITL/
+E2EL metrics.
+
 All results are from a **single NVIDIA GB10 / DGX Spark** (Blackwell `sm_121`,
 128 GB unified memory, ~273 GB/s). Published-model rows use vLLM with
 `--enforce-eager`; the explicitly labelled CUDA-graph canary does not. Read the

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -51,12 +51,15 @@ and ten measured repetitions, not TTFT/TPOT measurements.
 
 ## What is being compared, and how
 
-- **Matched-bpp baseline.** Every quality comparison is against an artifact of the
-  **same model at the same bits-per-weight**, quantized to stock per-Linear
-  **NVFP4/FP8** and served natively by vLLM's `compressed-tensors` path. This
-  isolates the one variable that matters: the *same byte budget* spent on codebook
-  formats versus scalar formats. (It is **not** a comparison to BF16 or to a
-  smaller/larger model.)
+- **Matched-rate baseline.** Quality rows compare the same model family against a
+  stock per-Linear **NVFP4/FP8** assignment served by vLLM's
+  `compressed-tensors` path. Historical tables generally match quantizable-body
+  bpp or body bytes, not a canonical whole-artifact inventory. They also compare
+  complete execution contracts—often native W4A4 against CB W8A8—not weight
+  encoding alone. Treat each row according to its stated byte scope and W/A
+  contract; only an inventory-derived whole-artifact match can pass the formal
+  [native-parity gate](NATIVE-PARITY.md). The published “native” baselines are
+  generally mixed NVFP4/FP8 assignments, not pure-NVFP4 artifacts.
 - **KL-vs-BF16.** Exact full-vocab (top-20) KL divergence between the quantized
   model's next-token distribution and the BF16 model's, on held-out WikiText
   (8176 positions), against the *same* BF16 reference dump per model. Lower is
@@ -85,8 +88,9 @@ disk — noted per model below.
 
 A 27B hybrid model (attention + gated linear-attention, with a vision tower),
 quantized at **5.5 bpp**. The allocator placed the **entire quantizable body on
-FP8-CB codebook rungs** and **zero** stock NVFP4/FP8 — the codebook formats won
-every Linear on cost.
+FP8-CB codebook rungs** and **zero** stock NVFP4/FP8 under that run's
+accuracy-only allocation objective. The teacher-backed comparison below is the
+quality evidence; the zero-native assignment by itself is not a speed claim.
 
 > **Which build is this?** The A/B in this section is the **2026-07-18** run,
 > whose CB arm was allocated from a 4-rung menu (`FP8_CB_K36/K40/K44/K48`, 386 CB
@@ -99,7 +103,8 @@ every Linear on cost.
 
 **Matched-bpp denominator (from the safetensors headers):** the CB body is
 **16.713 GB**, the NVFP4/FP8 baseline body is **16.707 GB** — a 0.04% difference.
-This is a genuine matched-bytes comparison.
+This is a close quantized-body byte match for the quality comparison, not a
+canonical whole-artifact inventory match.
 
 | | confident-KL | ALL-KL | conf top-1 | ALL top-1 | PPL | NLL |
 |---|---|---|---|---|---|---|
@@ -123,8 +128,9 @@ body-byte difference cannot explain a 58% KL move.
 | NVFP4/FP8 baseline (native) | **0.746 s** | 10.26 |
 | **CB (ours)** | 1.075 s | **10.27-10.30** |
 
-- **Decode is at/above native parity** (10.3 vs 10.26). At matched body bytes,
-  parity is the ceiling for a bandwidth-bound decode — reached.
+- **Measured batch-1 decode is at/above the native row in this historical cell**
+  (10.3 vs 10.26). This does not establish parity for batched/speculative decode,
+  tail ITL, other prompt distributions, or a formal whole-artifact byte match.
 - **Prefill is ~1.44× the native baseline** (1.075 s vs 0.746 s). The residual is
   the transient-expand path's doubled memory traffic; closing it is the
   fused-prologue / persistent-N kernel work in [`KERNELS.md`](KERNELS.md). (The
@@ -274,10 +280,11 @@ FP8-CB K44 MTP draft).
   (which GGUF cannot carry) closes most of the gap on natural text: 16.1
   tok/s** with the FP8-CB K44 draft at k=1, and becomes a straight multiplier
   once vLLM captures drafter CUDA graphs.
-- The joint-menu allocation experiment is also worth citing: offered vanilla
-  NVFP4 and FP8 alongside the codebook rungs, the measured allocator gave 36
-  Linears to vanilla FP8 and **zero to vanilla NVFP4** — at matched bits the
-  codebook dominates the fixed grid on every unit of a 295B.
+- The joint-menu allocation experiment gave 36 Linears to vanilla FP8 and zero
+  to vanilla NVFP4. That is an accuracy-only allocator outcome, so zero NVFP4 is
+  circular evidence about that objective—not proof that CB dominates native on
+  latency or on every unit. This 295B result has fit/serve/TEB evidence and no
+  BF16-teacher quality claim.
 - **ToolEvalBench: the shipped joint-menu artifact scored 88/100 (130/148)** on
   the ship config, against the GGUF IQ build's 87 (129/148) and k-quant's 86
   (128/148), under the identical protocol below. Zero errors, all 74 scenarios
@@ -350,14 +357,16 @@ runs as the tables above.
 - **TEB is base-model-dominated at matched bytes.** Tool-use parity across
   quantizations of the same base model is the expected result; treat TEB as a "does
   not regress" gate, not a quantization-quality discriminator.
-- **Speed status is honest and uneven.** Decode is at/above native parity (dense
-  and MoE). Large-M dense **prefill is not yet at native parity**: ~1.44× on the
-  27B (traffic-bound transient expand). MoE prefill was the worst gap and is now
-  the default CUDA chunk-expander path (Laguna 117B: 293 → 1,821 tok/s at 8k) —
-  the 35B TTFT row above predates it. The GGUF prefill comparison (the 295B
-  ~2.6×) is against a *different* serving stack (llama.cpp CUDA-core IQ dequant),
-  and is the clean "why native tiles win" number; it is not a claim of parity
-  with vLLM's own native NVFP4/FP8 GEMM at large M.
+- **Speed status is honest and uneven.** Historical batch-1 cells reached or
+  exceeded their native decode rows, but batched/speculative decode, tail ITL,
+  and the formal exact-byte workload matrix remain open. Large-M dense
+  **prefill is not yet at native parity**: ~1.44× on the 27B (traffic-bound
+  transient expand). MoE prefill was the worst gap and is now the default CUDA
+  chunk-expander path (Laguna 117B: 293 → 1,821 tok/s at 8k)—the 35B TTFT row
+  above predates it. The GGUF prefill comparison (the 295B ~2.6×) is against a
+  *different* serving stack (llama.cpp CUDA-core IQ dequant), and is the clean
+  "why native tiles win" number; it is not a claim of parity with vLLM's own
+  native NVFP4/FP8 GEMM at large M.
 - **bpp vs disk size differ by the BF16 floor.** Reported bpp is over quantizable
   params; embeddings/`lm_head`/norms/non-CB Linears are excluded from bpp but
   resident on disk, so `bpp × params` understates the artifact size.

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -1,10 +1,12 @@
 # Native-parity serving protocol
 
-This is the reproducible performance gate for work intended to bring Gridbook
-to native vLLM parity. It compares the same model family, exact whole-artifact
-byte budget, serving image, and controlled request distribution while recording
-the complete quantization/backend/activation contract. It is a protocol, not a
-performance or quality claim.
+This is the reproducible single-arm measurement protocol for work intended to
+bring Gridbook to native vLLM parity. It records one serving arm under an exact
+whole-artifact byte budget and controlled request distribution, including the
+complete quantization/backend/activation contract. A successful JSON report is
+measurement-valid for that arm; it is never by itself a parity decision,
+release acceptance, or quality claim. Pairing and release decisions happen
+outside the runner after both arms and all quality evidence exist.
 
 The runner is `gridbook-bench-serve` (or
 `python -m gridbook.bench_serve` from a checkout).  It delegates every request
@@ -18,13 +20,14 @@ to the streaming client in **`vllm bench serve`**.  Consequently:
 Do not replace TPOT with `whole request wall time / output tokens`.  That folds
 prefill into decode and can make a faster prefill path look like a faster decode
 kernel. The report retains vLLM's detailed metric evidence as well as
-block-level summaries, but deliberately omits generated completions and
-redacts non-empty server error bodies.
+block-level summaries, but deliberately omits generated completions and the
+entire `errors` field regardless of its runtime type.
 
 The command surface in this protocol is parser-validated against vLLM
-`0.23.1rc1.dev764+g54b16d8a9.d20260703`.  The report records the client version;
-an older client missing a required streaming, warmup, detailed-result, or
-sampling flag fails rather than silently changing the protocol.
+`0.23.1rc1.dev764+g54b16d8a9.d20260703`. `--client-runtime-id` must be the exact
+successful output of the selected `vllm --version` probe. A missing or different
+probe, or an older client missing a required streaming, warmup, detailed-result,
+or sampling flag, fails rather than silently changing the protocol.
 
 ## What must match
 
@@ -75,13 +78,31 @@ not the formal whole-shipped-artifact gate.
 
 The runner requires opaque `--image-id` and `--model-id` values and records them
 verbatim.  Prefer an image digest and a model repository plus immutable commit,
-not mutable tags such as `latest` or `main`.  `--server-arg` records the exact
-server command line; it is metadata only and never starts or changes a server.
+not mutable tags such as `latest` or `main`. `--git-commit`, when supplied, is
+an exact 40- or 64-hex commit. Without it, provenance is detected only when
+`gridbook/bench_serve.py` and `pyproject.toml` are in a real source root and
+`git rev-parse --show-toplevel` resolves to exactly that root; an installed
+wheel cannot accidentally inherit a parent repository. A dirty auto-detected
+checkout fails by default. `--allow-dirty` is explicitly research-only and
+forces `release_eligible: false` even when the measurement otherwise succeeds.
+
+`--server-arg` records the exact server command line; it is metadata only and
+never starts or changes a server. `--prefix-caching off` requires the recorded
+`--no-enable-prefix-caching` server flag, while `on` requires
+`--enable-prefix-caching`; missing or conflicting declarations fail before any
+request. Each run also requires at least one dispatch/startup attachment via
+paired, repeatable `--server-evidence PATH` and
+`--server-evidence-sha256 SHA256`. The runner hashes and records those external
+bytes but does not parse them or certify that a backend claim inside is true;
+reviewers must still inspect the bound log.
 The runner and server may be different containers or hosts, so their
 environments are never conflated.  `PRISMAQUANT_*` values visible to the
 benchmark process are labelled **runner environment**; add other runner values
-with `--runner-env`.  Record the actual separately managed server environment
-explicitly with repeatable `--server-env NAME=VALUE`.  Credentials, URL user
+with `--runner-env`. Extra `--runner-env-prefix` values must be specific
+environment-name prefixes of at least three characters, start with a letter,
+and end in `_`; empty or broad catch-all prefixes are rejected. Record the
+actual separately managed server environment explicitly with repeatable
+`--server-env NAME=VALUE`. Credentials, URL user
 info, sensitive URL query values, every nonempty URL fragment, authorization
 headers, and secret-like arguments/environment keys are redacted from metadata
 and recorded commands.
@@ -92,24 +113,31 @@ contract (`W4A4`, `W8A8`, and so on), concrete kernel/backend, tensor-parallel
 size, fallback state, exact server vLLM/runtime build, GPU identifier, driver,
 and accelerator runtime (for example CUDA or ROCm). Client and server runtime
 identifiers are separate required fields because the benchmark may run outside
-the serving container.  Attach
-server log lines proving the backend and fallback state; `--server-arg` and a
-filename containing “native” do not prove dispatch.
+the serving container. Attach server log lines proving the backend and fallback
+state; `--server-arg`, an attachment digest, and a filename containing “native”
+identify evidence but do not themselves prove dispatch semantics.
 
 Every report also requires a SHA-256-bound
 `gridbook.execution-manifest.v1`. Its `assignments` enumerate serving units and
 their format/rung, layout, scale coding, W/A contract, concrete backend, and
 fallback state, and it is bound to the artifact-inventory digest and TP size.
 It must declare `coverage: "all_serving_units"`; a sampled-layer manifest is
-not release evidence.
+not release evidence. Each assignment must name one concrete, unique serving
+unit: wildcard, duplicate, hierarchical-overlap, and literal `mixed` values are
+rejected, as are non-integer or boolean TP sizes. The harness can validate that
+syntax and internal binding, but cannot infer the model's complete serving-unit
+set. Generate the manifest from the complete exported/serving configuration and
+review that generation step; a hand-written coverage claim is not proof of
+completeness.
 Uniform runs must repeat the manifest's one value on the corresponding CLI
 identity fields. If an assignment uses more than one value, that CLI field must
-say `mixed`. The manifest is the authoritative identity for mixed menus; a
+say `mixed`. Only these aggregate CLI fields may say `mixed`; per-unit assignment
+fields may not. The manifest is the authoritative identity for mixed menus; a
 single average bpp or headline format is not.
 
-Minimal manifests look like this (real inventories enumerate every shipped
-file, and real mixed menus enumerate every serving unit or an auditable complete
-set of non-overlapping unit groups):
+Minimal syntax examples look like this (real inventories enumerate every
+shipped file, and production execution manifests must be generated from and
+enumerate the complete concrete serving-unit set):
 
 ```json
 {"schema":"gridbook.artifact-inventory.v1","total_bytes":123,"files":[{"path":"config.json","bytes":123,"sha256":"<64 hex>"}]}
@@ -119,8 +147,11 @@ For a new PrismaQuant export, pass its existing `quant_config.json` instead of
 translating the embedded inventory into the standalone form.
 
 ```json
-{"schema":"gridbook.execution-manifest.v1","coverage":"all_serving_units","artifact_inventory_sha256":"<inventory JSON SHA-256>","tensor_parallel_size":1,"assignments":[{"unit":"model.*","format_rung":"FP8_CB_K36","serialized_layout":"product-codebook-indices-v1","scale_coding":"e4m3-per-block","quant_contract":"W8A8","kernel_backend":"gridbook-cuda-cb-gemv-v2","fallback_state":"none-observed"}]}
+{"schema":"gridbook.execution-manifest.v1","coverage":"all_serving_units","artifact_inventory_sha256":"<inventory JSON SHA-256>","tensor_parallel_size":1,"assignments":[{"unit":"model.layers.0.self_attn.q_proj","format_rung":"FP8_CB_K36","serialized_layout":"product-codebook-indices-v1","scale_coding":"e4m3-per-block","quant_contract":"W8A8","kernel_backend":"gridbook-cuda-cb-gemv-v2","fallback_state":"none-observed"}]}
 ```
+
+That one-assignment object demonstrates the accepted shape only; it is not a
+valid completeness claim for a multi-unit model.
 
 The digest arguments are the SHA-256 of the exact JSON file bytes, not a digest
 of a reserialized in-memory object.
@@ -190,15 +221,24 @@ special tokens and decode/re-encode correction make the exact observed endpoints
 tokenizer-specific. Determine them from the pinned client/tokenizer and declare
 the inclusive contract with `--observed-input-len-min` and
 `--observed-input-len-max`. The harness requires every detailed input length to
-fall within that declared range and their sum to equal `total_input_tokens`; it
-does not relabel the requested `--input-len` as an observed bound. The exact
-per-request equality contract remains exclusive to `R=0`.
+fall within that declared range and their sum to equal `total_input_tokens`, but
+bounds alone are not sufficient evidence that paired arms received the same
+prompts. Before either measured arm, generate the expected vector for every
+block with the pinned client/tokenizer/seed. Canonicalize it as a compact JSON
+array of integers with no whitespace (for example `[24,26,28]`), hash those
+ASCII/UTF-8 bytes with SHA-256, and pass one repeatable
+`--expected-input-lens-sha256` in block order. The runner hashes the exact saved
+`input_lens` vector and requires the block-specific digest. Fixed `R=0` cells
+remain simple and instead forbid these vector digests because
+`--observed-input-len` already defines every element exactly.
 
-Keep prefix caching off for this primary matrix.  vLLM's readiness probe and
-warmups deliberately reuse the first request, so an enabled prefix cache would
-turn that measured request into a cache-hit benchmark.  Prefix-cached serving
-is valuable, but it belongs in a separately labelled workload with an explicit
-hit-rate distribution.
+Keep prefix caching off for this primary matrix by supplying both
+`--prefix-caching off` and recorded server arg
+`--no-enable-prefix-caching`. vLLM's readiness probe and warmups deliberately
+reuse the first request, so an enabled prefix cache would turn that measured
+request into a cache-hit benchmark. Prefix-cached serving is valuable, but it
+belongs in a separately labelled workload with `--prefix-caching on`, recorded
+server arg `--enable-prefix-caching`, and an explicit hit-rate distribution.
 
 Three blocks are the minimum smoke-quality measurement, not permission to
 overstate a small delta.  Use five or more blocks near parity or when variance
@@ -214,7 +254,7 @@ and covers the serving scheduler, not just one batch-1 kernel point:
 
 | Lane | Required sweep/evidence |
 |---|---|
-| Prompt distribution | Fixed rows plus at least one declared nonzero input-range ratio using identical seeds |
+| Prompt distribution | Fixed rows plus at least one nonzero input-range ratio using identical seeds and block-specific canonical `input_lens` digests |
 | Concurrency | Ladder `1, 2, 4, 8` plus the shipped maximum if higher; report every block and tail ITL |
 | Chunked prefill | Matched runs with chunked prefill off and on, recording chunk size/scheduler flags |
 | Plain decode | Non-speculative, batch-1 `M=1`; report TPOT/ITL and output throughput |
@@ -271,6 +311,9 @@ gridbook-bench-serve \
   --model "$TOKENIZER_ID" \
   --tokenizer "$TOKENIZER_ID" \
   --served-model-name "$SERVED_MODEL_NAME" \
+  --prefix-caching off \
+  --server-evidence "$SERVER_STARTUP_LOG" \
+  --server-evidence-sha256 "$SERVER_STARTUP_LOG_SHA256" \
   --model-id "$MODEL_ID_AT_REVISION" \
   --image-id "$VLLM_IMAGE_DIGEST" \
   --git-commit "$GRIDBOOK_COMMIT" \
@@ -294,6 +337,7 @@ gridbook-bench-serve \
   --execution-manifest "$EXECUTION_MANIFEST_JSON" \
   --execution-manifest-sha256 "$EXECUTION_MANIFEST_SHA256" \
   --speculative-mode off \
+  --server-arg=--no-enable-prefix-caching \
   --server-arg=--enforce-eager \
   --server-arg="--max-model-len=$MAX_MODEL_LEN" \
   --runner-env CUDA_VISIBLE_DEVICES \
@@ -314,13 +358,15 @@ gridbook-bench-serve \
 
 Use the same template with the prefill and mixed-online values from the table.
 `--served-model-name` is the API alias; `--model-id` is the immutable artifact
-identity.  They are deliberately separate because production servers often use
+identity. They are deliberately separate because production servers often use
 a short alias for a long Hub revision.  `--git-commit` may be omitted when the
 runner is invoked from a Git checkout; an installed wheel has no repository
-metadata, so supply the exact commit used to build it. The byte inventory, its
-digest, the execution manifest, and its digest are required. The runner verifies
-their bindings and refuses an artifact larger than the declared budget before
-issuing a request. For a speculative cell use `--speculative-mode on
+metadata, so supply the exact 40/64-hex commit used to build it. Set
+`BENCH_CLIENT_VLLM_RUNTIME_ID` to the exact output of the selected
+`vllm --version`. The byte inventory, its digest, the execution manifest, its
+digest, and paired server-evidence attachment/digest are required. The runner
+verifies their byte bindings and refuses an artifact larger than the declared
+budget before issuing a request. For a speculative cell use `--speculative-mode on
 --speculative-config '{"method":"...","num_speculative_tokens":K,...}'`; the
 JSON must describe the exact server configuration, not merely say “enabled,”
 and the same strict-JSON object must appear in the recorded
@@ -334,13 +380,15 @@ the recorded, matched arguments, wait until model loading and JIT compilation
 finish, then point the runner at the active arm.  Never serve both large arms on
 the same accelerator during a comparison.
 
-## Structured report and acceptance
+## Structured single-arm report
 
 Each JSON report has schema `gridbook.vllm-bench-serve.v2` and contains:
 
+- an explicit `single-arm-serving-measurement` scope, measurement-valid status,
+  and hard-false parity/release-acceptance fields;
 - UTC start/end timestamps and wall duration;
-- Gridbook git commit/dirty state and package, vLLM, Python, platform and host
-  versions;
+- Gridbook git commit/dirty/release-eligibility state and package, exact verified
+  client vLLM, Python, platform and host versions;
 - supplied image, artifact, tokenizer, endpoint and served-model identities;
 - exact inventory-derived whole-artifact bytes, inventory digest/reference,
   budget, headroom, and byte-scope definition, plus separately scoped optional
@@ -350,13 +398,19 @@ Each JSON report has schema `gridbook.vllm-bench-serve.v2` and contains:
   accelerator runtime, plus the digest-bound per-serving-unit execution
   manifest;
 - recorded server flags and dispatch environment;
+- the explicit prefix-caching state and digest-bound external server-evidence
+  attachments, with no claim that the harness parsed their semantics;
 - runner environment and explicitly supplied server environment in separate
   fields;
 - the exact workload controls, structured speculation mode/config, block seeds,
   and full vLLM command for each block;
-- the input-length ratio, validation envelope, and observed per-request lengths;
+- the input-length ratio, validation envelope, observed per-request lengths, and
+  for ranged cells the expected and observed canonical vector digests by block;
+- exact reconciliation of pinned vLLM's saved `backend`, `endpoint_type`,
+  `label`, `model_id`, `tokenizer_id`, `num_prompts`, `request_rate`, and
+  `max_concurrency` invocation fields before metrics are accepted;
 - sanitized vLLM detailed metric output for each block (generated text omitted,
-  non-empty server error bodies redacted); and
+  the complete `errors` field omitted regardless of type); and
 - mean, median, min, max, NumPy-linear block p05/p95, and sample standard
   deviation across block metrics.
 
@@ -374,12 +428,20 @@ The CLI enforces at least four warmups, at least three independent blocks, and a
 percentile set containing p95; a report cannot quietly weaken the minimum
 TTFT/ITL gates.
 
+`measurement_valid: true` means only that every block satisfied this one-arm
+contract. `parity_acceptance` and `release_acceptance` are always false because
+the runner has no paired arm or quality evidence. `release_eligible` additionally
+requires clean/explicit Gridbook provenance and is forced false by
+`--allow-dirty`; it still is not a release decision.
+
 Detailed ITL entries are streamed **chunk** intervals, not a promise of one
 entry per generated token: one chunk can carry several regular or
 speculatively accepted tokens.  The harness therefore never requires
 `len(itls) == output_len - 1`. It reconstructs mean, median, population standard
 deviation, and every requested percentile for TTFT and flattened ITL with
-NumPy-linear percentile semantics. It reconstructs per-request E2EL as
+NumPy-linear percentile semantics. Percentile result labels exactly match the
+pinned client rule (`95` for integral floats, otherwise Python's round-trip
+float string), and normalization collisions are rejected. It reconstructs per-request E2EL as
 `ttft + sum(itls)` and TPOT as `sum(itls) / (fixed output_len - 1)`, checking the
 same complete aggregate set with a small declared terminal-event allowance.
 Request, output-token, and total-token throughput are independently recomputed
@@ -387,8 +449,9 @@ from the finite positive raw duration and exact detailed totals. These checks
 reject contradictory summary data without inventing one ITL per token.
 
 Reports are created with mode `0600`. The runner strips `generated_texts` and
-replaces non-empty values in `errors` before the first result checkpoint, then
-recursively applies the same metadata redaction to the remaining result. Treat
+the entire `errors` field before the first result checkpoint, regardless of
+their types, then recursively applies the same metadata redaction to the
+remaining result. Treat
 reports as potentially sensitive anyway: no generic redactor can certify every
 future field a vLLM version may add. Review a report before publishing it.
 

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -34,12 +34,12 @@ experiment, not another sample of the same experiment.
 |---|---|
 | Base model | Same architecture, tokenizer, revision, and non-quantized tensors |
 | Byte budget | Exact whole served artifact is at or below the predeclared byte budget `B` |
-| Software | Same immutable vLLM image digest, CUDA/driver, Gridbook commit, and package version |
+| Software | Same immutable vLLM image digest, accelerator runtime/driver, Gridbook commit, and package version |
 | Server | Same model length, KV dtype, eager/graph mode, memory utilization, batching and scheduler flags |
 | Execution | Explicit format/rung, serialized layout, scale coding, W/A contract, concrete backend, TP size, and fallback state |
 | Features | Prefix caching off; speculative decode, LoRA, request logging, and observability identically configured or off |
 | Hardware | Same GPU, power/clock policy, thermals, and no competing workload |
-| Client | Same input/output lengths, prompts, dataset seed, arrival rate, concurrency, warmups, and blocks |
+| Client | Same requested/observed input contract, output length, prompts, dataset seed, arrival rate, concurrency, warmups, and blocks |
 
 Use a native quantized artifact made from the same base model. The formal size
 gate is integer arithmetic: **`whole_served_artifact_bytes <= B`**.  “Whole
@@ -81,15 +81,17 @@ environments are never conflated.  `PRISMAQUANT_*` values visible to the
 benchmark process are labelled **runner environment**; add other runner values
 with `--runner-env`.  Record the actual separately managed server environment
 explicitly with repeatable `--server-env NAME=VALUE`.  Credentials, URL user
-info, sensitive URL query values, authorization headers, and secret-like
-arguments/environment keys are redacted from metadata and recorded commands.
+info, sensitive URL query values, every nonempty URL fragment, authorization
+headers, and secret-like arguments/environment keys are redacted from metadata
+and recorded commands.
 
 Format labels are not execution evidence. Every report requires the
 format/rung, serialized weight layout, scale coding, full weight/activation
 contract (`W4A4`, `W8A8`, and so on), concrete kernel/backend, tensor-parallel
 size, fallback state, exact server vLLM/runtime build, GPU identifier, driver,
-and CUDA runtime.  Client and server runtime identifiers are separate required
-fields because the benchmark may run outside the serving container.  Attach
+and accelerator runtime (for example CUDA or ROCm). Client and server runtime
+identifiers are separate required fields because the benchmark may run outside
+the serving container.  Attach
 server log lines proving the backend and fallback state; `--server-arg` and a
 filename containing “native” do not prove dispatch.
 
@@ -171,19 +173,25 @@ blocks**.  The runner derives a distinct prompt-dataset seed for each block
 Gridbook arms so every block is paired.
 This seed controls prompt construction, not generation.  Server sampling is
 separately and unconditionally pinned to greedy decoding with `--temperature
-0`.  Fixed lengths are enforced with vLLM's random dataset at range ratio zero
-plus `ignore_eos`; the runner rejects a block if completed prompts, per-request
-lengths, or total input/output tokens differ from the requested values.
+0`. `--input-len` is the value sent to vLLM as `--random-input-len`; it is a
+dataset-generation request, not an observed-token assertion. The pinned random
+dataset subtracts tokenizer special tokens, so a requested length of 64 can
+legitimately appear as 63 in `input_lens`. For every range-ratio-zero cell,
+determine that tokenizer-specific value in a dry run and provide it separately
+as `--observed-input-len`. The runner records both values and rejects a block
+unless every detailed input length and `total_input_tokens` match the declared
+observed value exactly. Output length remains exact through `ignore_eos`.
 
 For a prompt-length distribution, set `--input-range-ratio R` with
 `0 <= R < 1`.  The pinned vLLM client receives
-`{"input": R, "output": 0}`, so output length remains exact.  vLLM samples
-integer input lengths up through `ceil(input_len * (1 + R))`; its lower endpoint
-also depends on tokenizer-added special tokens and decode/re-encode correction,
-neither of which is emitted in result JSON.  The harness therefore uses the safe
-conservative envelope `[1, ceil(input_len * (1 + R))]`, requires integer positive
-per-request lengths, and requires their sum to equal `total_input_tokens`.  The
-exact per-request equality check remains exclusive to `R=0`.
+`{"input": R, "output": 0}`, so output length remains exact. Tokenizer-added
+special tokens and decode/re-encode correction make the exact observed endpoints
+tokenizer-specific. Determine them from the pinned client/tokenizer and declare
+the inclusive contract with `--observed-input-len-min` and
+`--observed-input-len-max`. The harness requires every detailed input length to
+fall within that declared range and their sum to equal `total_input_tokens`; it
+does not relabel the requested `--input-len` as an observed bound. The exact
+per-request equality contract remains exclusive to `R=0`.
 
 Keep prefix caching off for this primary matrix.  vLLM's readiness probe and
 warmups deliberately reuse the first request, so an enabled prefix cache would
@@ -280,8 +288,8 @@ gridbook-bench-serve \
   --client-runtime-id "$BENCH_CLIENT_VLLM_RUNTIME_ID" \
   --server-runtime-id "$SERVER_VLLM_RUNTIME_ID" \
   --gpu-id "$GPU_ID" \
-  --driver-version "$NVIDIA_DRIVER_VERSION" \
-  --cuda-version "$SERVER_CUDA_VERSION" \
+  --driver-version "$SERVER_DRIVER_VERSION" \
+  --accelerator-runtime "$SERVER_ACCELERATOR_RUNTIME" \
   --execution-manifest "$EXECUTION_MANIFEST_JSON" \
   --execution-manifest-sha256 "$EXECUTION_MANIFEST_SHA256" \
   --speculative-mode off \
@@ -291,6 +299,7 @@ gridbook-bench-serve \
   --server-env "CUDA_VISIBLE_DEVICES=$SERVER_CUDA_DEVICE" \
   --server-env PRISMAQUANT_CB_DECODE=cuda \
   --input-len 32 \
+  --observed-input-len "$OBSERVED_INPUT_LEN" \
   --output-len 256 \
   --num-prompts 16 \
   --max-concurrency 1 \
@@ -337,7 +346,8 @@ Each JSON report has schema `gridbook.vllm-bench-serve.v2` and contains:
   payload bytes;
 - structured format/rung, serialized layout/scale coding, W/A contract,
   concrete backend/fallback, TP size, client/server runtimes, GPU, driver, and
-  CUDA, plus the digest-bound per-serving-unit execution manifest;
+  accelerator runtime, plus the digest-bound per-serving-unit execution
+  manifest;
 - recorded server flags and dispatch environment;
 - runner environment and explicitly supplied server environment in separate
   fields;

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -1,0 +1,158 @@
+# Native-parity serving protocol
+
+This is the reproducible performance gate for work intended to bring Gridbook
+to native vLLM parity.  It compares the same model family, byte budget, serving
+image, and fixed request stream while changing only the weight format/plugin
+dispatch under test.  It is a protocol, not a performance claim.
+
+The runner is `gridbook-bench-serve` (or
+`python -m gridbook.bench_serve` from a checkout).  It delegates every request
+to the streaming client in **`vllm bench serve`**.  Consequently:
+
+- TTFT is measured from request issue to the first streamed token;
+- TPOT is `(E2EL - TTFT) / (output tokens - 1)` for multi-token responses;
+- ITL is measured between streamed token arrivals; and
+- E2EL is measured from request issue through the final stream event.
+
+Do not replace TPOT with `whole request wall time / output tokens`.  That folds
+prefill into decode and can make a faster prefill path look like a faster decode
+kernel.  The report retains vLLM's raw detailed results as well as block-level
+summaries.
+
+## What must match
+
+Before running either arm, record this checklist.  A row that differs is a new
+experiment, not another sample of the same experiment.
+
+| Dimension | Required match |
+|---|---|
+| Base model | Same architecture, tokenizer, revision, and non-quantized tensors |
+| Byte budget | Same target bpp and quantizable-body bytes; report the actual byte difference |
+| Software | Same immutable vLLM image digest, CUDA/driver, Gridbook commit, and package version |
+| Server | Same model length, KV dtype, eager/graph mode, memory utilization, batching and scheduler flags |
+| Features | Prefix caching off; speculative decode, LoRA, request logging, and observability identically configured or off |
+| Hardware | Same GPU, power/clock policy, thermals, and no competing workload |
+| Client | Same input/output lengths, prompts, seed, arrival rate, concurrency, warmups, and number of blocks |
+
+Use a native quantized artifact made from the same base model and matched body
+bytes.  BF16 is a useful ceiling, but it is not the native denominator for this
+test.  A 27B Gridbook result must not be compared with a differently sized
+native model.
+
+The runner requires opaque `--image-id` and `--model-id` values and records them
+verbatim.  Prefer an image digest and a model repository plus immutable commit,
+not mutable tags such as `latest` or `main`.  `--server-arg` records the exact
+server command line; it is metadata only and never starts or changes a server.
+All `PRISMAQUANT_*` environment values are captured automatically.  Add other
+dispatch variables with `--dispatch-env`; names that look secret are redacted.
+
+## Fixed 0.6B and 27B matrix
+
+Use a matched 0.6B pair for rapid iteration, then repeat unchanged on the 27B
+pair before accepting a change.  The small model exposes launch and dispatch
+overhead quickly; the 27B gate establishes that the result survives realistic
+weight traffic.  A win on 0.6B is a lead, not a final result.
+
+Run all three shapes on both sizes:
+
+| Workload | Input | Output | Prompts/block | Concurrency | Primary metric |
+|---|---:|---:|---:|---:|---|
+| Prefill | 1400 | 1 | 16 | 1 | TTFT |
+| Batch-1 decode | 32 | 256 | 16 | 1 | TPOT, ITL, output tok/s |
+| Mixed online | 1024 | 128 | 32 | 4 | E2EL, TTFT, TPOT, p99 ITL |
+
+For every row use `--request-rate inf`, four unmeasured warmup prompts per
+block, seed 1234, and **at least three blocks**.  The runner derives a distinct
+seed for each block (`1234`, `1235`, `1236`, ...); use the same base seed for the
+native and Gridbook arms so every block is paired.  Fixed lengths are enforced
+with vLLM's random dataset at range ratio zero plus `ignore_eos`; the runner
+rejects a block if completed prompts or total input/output tokens differ from
+the requested totals.
+
+Keep prefix caching off for this primary matrix.  vLLM's readiness probe and
+warmups deliberately reuse the first request, so an enabled prefix cache would
+turn that measured request into a cache-hit benchmark.  Prefix-cached serving
+is valuable, but it belongs in a separately labelled workload with an explicit
+hit-rate distribution.
+
+Three blocks are the minimum smoke-quality measurement, not permission to
+overstate a small delta.  Use five or more blocks near parity or when variance
+is material.  Run the native and Gridbook arms back-to-back, reverse their order
+in a second session, and include every block value rather than reporting only
+the best one.  Restarting the server between final-validation sessions is
+preferred; allow the same model-load/JIT warmup before each measured arm.
+
+## Invocation template
+
+Supply model locations and revisions from the environment or your job runner;
+the harness contains no machine-local model paths.  For example, the decode row
+for either size/arm is:
+
+```bash
+gridbook-bench-serve \
+  --base-url "$BASE_URL" \
+  --model "$TOKENIZER_ID" \
+  --tokenizer "$TOKENIZER_ID" \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --model-id "$MODEL_ID_AT_REVISION" \
+  --image-id "$VLLM_IMAGE_DIGEST" \
+  --git-commit "$GRIDBOOK_COMMIT" \
+  --run-label "$ARM-$SIZE-decode" \
+  --server-arg=--enforce-eager \
+  --server-arg="--max-model-len=$MAX_MODEL_LEN" \
+  --dispatch-env CUDA_VISIBLE_DEVICES \
+  --input-len 32 \
+  --output-len 256 \
+  --num-prompts 16 \
+  --max-concurrency 1 \
+  --warmups 4 \
+  --blocks 3 \
+  --seed 1234 \
+  --request-rate inf \
+  --output "results/$ARM-$SIZE-decode.json"
+```
+
+Use the same template with the prefill and mixed-online values from the table.
+`--served-model-name` is the API alias; `--model-id` is the immutable artifact
+identity.  They are deliberately separate because production servers often use
+a short alias for a long Hub revision.  `--git-commit` may be omitted when the
+runner is invoked from a Git checkout; an installed wheel has no repository
+metadata, so supply the exact commit used to build it.
+
+The benchmark does not launch a server.  Start native and Gridbook servers with
+the recorded, matched arguments, wait until model loading and JIT compilation
+finish, then point the runner at the active arm.  Never serve both large arms on
+the same accelerator during a comparison.
+
+## Structured report and acceptance
+
+Each JSON report has schema `gridbook.vllm-bench-serve.v1` and contains:
+
+- UTC start/end timestamps and wall duration;
+- Gridbook git commit/dirty state and package, vLLM, Python, platform and host
+  versions;
+- supplied image, artifact, tokenizer, endpoint and served-model identities;
+- recorded server flags and dispatch environment;
+- the exact fixed workload, block seeds, and full vLLM command for each block;
+- raw vLLM detailed output for each block; and
+- mean, median, min, max and sample standard deviation across block metrics.
+
+A nonzero client exit, failed request, missing streaming metric, early EOS, or
+length mismatch makes the report `failed`.  A partial/failure report is still
+written so the run cannot be mistaken for missing data.  Existing reports are
+never overwritten unless `--overwrite` is explicit.
+
+For each paired block compute `Gridbook / native` for throughput and
+`native / Gridbook` for latency, so values above 1 consistently mean Gridbook
+is faster.  Report the median paired ratio and every constituent ratio.  Define
+the parity tolerance before looking at the results; do not call an interval
+that crosses it a win.  Decode parity is judged on TPOT/ITL and output
+throughput, prefill parity on TTFT, and mixed-load parity on all four latency
+metrics plus request/output throughput.  A throughput gain does not excuse
+regressed tail ITL or failed requests.
+
+For a release-grade claim, attach both reports, the exact server logs containing
+Gridbook dispatch lines, hardware clocks/power state, and the model/body-byte
+calculation.  Re-run generated-text correctness or quality evaluation whenever
+a performance change alters numerical association or dispatch, even if this
+latency protocol passes.

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -382,12 +382,13 @@ metadata, so supply the exact 40/64-hex commit used to build it. Set
 `vllm --version`. The byte inventory, its digest, the execution manifest, its
 digest, and paired server-evidence attachment/digest are required. The runner
 verifies their byte bindings and refuses an artifact larger than the declared
-budget before issuing a request. For a speculative cell use `--speculative-mode on
---speculative-config '{"method":"...","num_speculative_tokens":K,...}'`; the
-JSON must describe the exact server configuration, not merely say “enabled,”
-and the same strict-JSON object must appear in the recorded
-`--server-arg=--speculative-config=...`. A mismatch or a speculative server flag
-in an `off` cell fails before requests are issued.
+budget before issuing a request. For a speculative cell, use
+`--speculative-mode on` together with
+`--speculative-config '{"method":"...","num_speculative_tokens":K,...}'`.
+The JSON must describe the exact server configuration, not merely say
+“enabled,” and the same strict-JSON object must appear in the recorded
+`--server-arg=--speculative-config=...`. A mismatch or a speculative server
+flag in an `off` cell fails before requests are issued.
 Optional payload bytes use `--payload-bytes` together with a precise
 `--payload-scope`.
 

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -85,6 +85,14 @@ an exact 40- or 64-hex commit. Without it, provenance is detected only when
 wheel cannot accidentally inherit a parent repository. A dirty auto-detected
 checkout fails by default. `--allow-dirty` is explicitly research-only and
 forces `release_eligible: false` even when the measurement otherwise succeeds.
+An explicit `--git-commit` beside an installed wheel remains useful measurement
+metadata, but it cannot prove that the executing wheel was built from that
+commit and is therefore also `release_eligible: false`. Release-eligible harness
+provenance currently requires that this module execute from the exact clean
+checkout whose commit is recorded. The generated `--output` report is the sole
+path excluded from that checkout's dirty check, so the documented
+`results/...json` location does not invalidate its own run; no source,
+inventory, manifest, or server-evidence path receives that exclusion.
 
 `--server-arg` records the exact server command line; it is metadata only and
 never starts or changes a server. `--prefix-caching off` requires the recorded
@@ -95,6 +103,12 @@ paired, repeatable `--server-evidence PATH` and
 `--server-evidence-sha256 SHA256`. The runner hashes and records those external
 bytes but does not parse them or certify that a backend claim inside is true;
 reviewers must still inspect the bound log.
+Inventory, execution-manifest, and server-evidence files are re-read and
+SHA-256 checked immediately before requests and again after the final block.
+Any mutation makes the report fail, including a server log that continues to
+grow during measurement. Supply a closed startup/dispatch snapshot, retain that
+exact attachment beside the report, and publish it under the recorded digest;
+the report records the digest and path but does not embed arbitrary log bytes.
 The runner and server may be different containers or hosts, so their
 environments are never conflated.  `PRISMAQUANT_*` values visible to the
 benchmark process are labelled **runner environment**; add other runner values
@@ -432,9 +446,12 @@ TTFT/ITL gates.
 
 `measurement_valid: true` means only that every block satisfied this one-arm
 contract. `parity_acceptance` and `release_acceptance` are always false because
-the runner has no paired arm or quality evidence. `release_eligible` additionally
-requires clean/explicit Gridbook provenance and is forced false by
-`--allow-dirty`; it still is not a release decision.
+the runner has no paired arm or quality evidence. `release_eligible`
+additionally requires a clean, exact source-checkout binding for the harness and
+is forced false by `--allow-dirty` or argument-only installed-wheel provenance;
+it still is not a release decision. The clean Git state, digest-bound inputs,
+and client runtime identity are rechecked after the last request before that
+flag can become true.
 
 Detailed ITL entries are streamed **chunk** intervals, not a promise of one
 entry per generated token: one chunk can carry several regular or

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -17,8 +17,9 @@ to the streaming client in **`vllm bench serve`**.  Consequently:
 
 Do not replace TPOT with `whole request wall time / output tokens`.  That folds
 prefill into decode and can make a faster prefill path look like a faster decode
-kernel.  The report retains vLLM's raw detailed results as well as block-level
-summaries.
+kernel. The report retains vLLM's detailed metric evidence as well as
+block-level summaries, but deliberately omits generated completions and
+redacts non-empty server error bodies.
 
 The command surface in this protocol is parser-validated against vLLM
 `0.23.1rc1.dev764+g54b16d8a9.d20260703`.  The report records the client version;
@@ -354,7 +355,8 @@ Each JSON report has schema `gridbook.vllm-bench-serve.v2` and contains:
 - the exact workload controls, structured speculation mode/config, block seeds,
   and full vLLM command for each block;
 - the input-length ratio, validation envelope, and observed per-request lengths;
-- raw vLLM detailed output for each block; and
+- sanitized vLLM detailed metric output for each block (generated text omitted,
+  non-empty server error bodies redacted); and
 - mean, median, min, max, NumPy-linear block p05/p95, and sample standard
   deviation across block metrics.
 
@@ -364,7 +366,7 @@ requested percentile must be finite; TTFT and E2EL must be positive.  A
 multi-token response must also contain positive per-request ITL samples.
 One-token prefill probes are explicitly exempt from ITL/TPOT positivity because
 there is no post-first-token interval.  A partial/failure report retains the
-redacted command, return code, raw result when one exists, and validation error
+redacted command, return code, sanitized result when one exists, and validation error
 so the run cannot be mistaken for missing data.  The output name is atomically
 reserved before probes begin, preventing concurrent clients from both claiming
 it; existing reports are never overwritten unless `--overwrite` is explicit.
@@ -384,12 +386,11 @@ Request, output-token, and total-token throughput are independently recomputed
 from the finite positive raw duration and exact detailed totals. These checks
 reject contradictory summary data without inventing one ITL per token.
 
-Reports are created with mode `0600`, but treat them as **sensitive raw output**.
-`--save-detailed` includes generated model text and server error strings, which
-the harness cannot safely infer are public.  Review or remove those fields
-before attaching a report to an issue or publishing it.  Metadata credentials
-are redacted; arbitrary secrets echoed inside generated text or a server error
-are not.
+Reports are created with mode `0600`. The runner strips `generated_texts` and
+replaces non-empty values in `errors` before the first result checkpoint, then
+recursively applies the same metadata redaction to the remaining result. Treat
+reports as potentially sensitive anyway: no generic redactor can certify every
+future field a vLLM version may add. Review a report before publishing it.
 
 For each paired block compute `Gridbook / native` for throughput and
 `native / Gridbook` for latency, so values above 1 consistently mean Gridbook

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -203,6 +203,8 @@ unmeasured warmup prompts per block, dataset seed 1234, and **at least three
 blocks**.  The runner derives a distinct prompt-dataset seed for each block
 (`1234`, `1235`, `1236`, ...); use the same base seed for the native and
 Gridbook arms so every block is paired.
+The runner also pins vLLM request burstiness to `1.0` explicitly and reconciles
+that saved-result field instead of relying on a client-version default.
 This seed controls prompt construction, not generation.  Server sampling is
 separately and unconditionally pinned to greedy decoding with `--temperature
 0`. `--input-len` is the value sent to vLLM as `--random-input-len`; it is a

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -19,6 +19,11 @@ prefill into decode and can make a faster prefill path look like a faster decode
 kernel.  The report retains vLLM's raw detailed results as well as block-level
 summaries.
 
+The command surface in this protocol is parser-validated against vLLM
+`0.23.1rc1.dev764+g54b16d8a9.d20260703`.  The report records the client version;
+an older client missing a required streaming, warmup, detailed-result, or
+sampling flag fails rather than silently changing the protocol.
+
 ## What must match
 
 Before running either arm, record this checklist.  A row that differs is a new
@@ -32,7 +37,7 @@ experiment, not another sample of the same experiment.
 | Server | Same model length, KV dtype, eager/graph mode, memory utilization, batching and scheduler flags |
 | Features | Prefix caching off; speculative decode, LoRA, request logging, and observability identically configured or off |
 | Hardware | Same GPU, power/clock policy, thermals, and no competing workload |
-| Client | Same input/output lengths, prompts, seed, arrival rate, concurrency, warmups, and number of blocks |
+| Client | Same input/output lengths, prompts, dataset seed, arrival rate, concurrency, warmups, and blocks |
 
 Use a native quantized artifact made from the same base model and matched body
 bytes.  BF16 is a useful ceiling, but it is not the native denominator for this
@@ -43,8 +48,13 @@ The runner requires opaque `--image-id` and `--model-id` values and records them
 verbatim.  Prefer an image digest and a model repository plus immutable commit,
 not mutable tags such as `latest` or `main`.  `--server-arg` records the exact
 server command line; it is metadata only and never starts or changes a server.
-All `PRISMAQUANT_*` environment values are captured automatically.  Add other
-dispatch variables with `--dispatch-env`; names that look secret are redacted.
+The runner and server may be different containers or hosts, so their
+environments are never conflated.  `PRISMAQUANT_*` values visible to the
+benchmark process are labelled **runner environment**; add other runner values
+with `--runner-env`.  Record the actual separately managed server environment
+explicitly with repeatable `--server-env NAME=VALUE`.  Credentials, URL user
+info, sensitive URL query values, authorization headers, and secret-like
+arguments/environment keys are redacted from metadata and recorded commands.
 
 ## Fixed 0.6B and 27B matrix
 
@@ -62,12 +72,14 @@ Run all three shapes on both sizes:
 | Mixed online | 1024 | 128 | 32 | 4 | E2EL, TTFT, TPOT, p99 ITL |
 
 For every row use `--request-rate inf`, four unmeasured warmup prompts per
-block, seed 1234, and **at least three blocks**.  The runner derives a distinct
-seed for each block (`1234`, `1235`, `1236`, ...); use the same base seed for the
-native and Gridbook arms so every block is paired.  Fixed lengths are enforced
-with vLLM's random dataset at range ratio zero plus `ignore_eos`; the runner
-rejects a block if completed prompts or total input/output tokens differ from
-the requested totals.
+block, dataset seed 1234, and **at least three blocks**.  The runner derives a
+distinct prompt-dataset seed for each block (`1234`, `1235`, `1236`, ...); use
+the same base seed for the native and Gridbook arms so every block is paired.
+This seed controls prompt construction, not generation.  Server sampling is
+separately and unconditionally pinned to greedy decoding with `--temperature
+0`.  Fixed lengths are enforced with vLLM's random dataset at range ratio zero
+plus `ignore_eos`; the runner rejects a block if completed prompts, per-request
+lengths, or total input/output tokens differ from the requested values.
 
 Keep prefix caching off for this primary matrix.  vLLM's readiness probe and
 warmups deliberately reuse the first request, so an enabled prefix cache would
@@ -100,14 +112,16 @@ gridbook-bench-serve \
   --run-label "$ARM-$SIZE-decode" \
   --server-arg=--enforce-eager \
   --server-arg="--max-model-len=$MAX_MODEL_LEN" \
-  --dispatch-env CUDA_VISIBLE_DEVICES \
+  --runner-env CUDA_VISIBLE_DEVICES \
+  --server-env "CUDA_VISIBLE_DEVICES=$SERVER_CUDA_DEVICE" \
+  --server-env PRISMAQUANT_CB_DECODE=cuda \
   --input-len 32 \
   --output-len 256 \
   --num-prompts 16 \
   --max-concurrency 1 \
   --warmups 4 \
   --blocks 3 \
-  --seed 1234 \
+  --dataset-seed 1234 \
   --request-rate inf \
   --output "results/$ARM-$SIZE-decode.json"
 ```
@@ -133,14 +147,29 @@ Each JSON report has schema `gridbook.vllm-bench-serve.v1` and contains:
   versions;
 - supplied image, artifact, tokenizer, endpoint and served-model identities;
 - recorded server flags and dispatch environment;
+- runner environment and explicitly supplied server environment in separate
+  fields;
 - the exact fixed workload, block seeds, and full vLLM command for each block;
 - raw vLLM detailed output for each block; and
 - mean, median, min, max and sample standard deviation across block metrics.
 
 A nonzero client exit, failed request, missing streaming metric, early EOS, or
-length mismatch makes the report `failed`.  A partial/failure report is still
-written so the run cannot be mistaken for missing data.  Existing reports are
-never overwritten unless `--overwrite` is explicit.
+length mismatch makes the report `failed`.  Required throughput and every
+requested percentile must be finite; TTFT and E2EL must be positive.  A
+multi-token response must also contain positive per-request ITL samples.
+One-token prefill probes are explicitly exempt from ITL/TPOT positivity because
+there is no post-first-token interval.  A partial/failure report retains the
+redacted command, return code, raw result when one exists, and validation error
+so the run cannot be mistaken for missing data.  The output name is atomically
+reserved before probes begin, preventing concurrent clients from both claiming
+it; existing reports are never overwritten unless `--overwrite` is explicit.
+
+Reports are created with mode `0600`, but treat them as **sensitive raw output**.
+`--save-detailed` includes generated model text and server error strings, which
+the harness cannot safely infer are public.  Review or remove those fields
+before attaching a report to an issue or publishing it.  Metadata credentials
+are redacted; arbitrary secrets echoed inside generated text or a server error
+are not.
 
 For each paired block compute `Gridbook / native` for throughput and
 `native / Gridbook` for latency, so values above 1 consistently mean Gridbook

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -1,10 +1,10 @@
 # Native-parity serving protocol
 
 This is the reproducible performance gate for work intended to bring Gridbook
-to native vLLM parity.  It compares the same model family, exact whole-artifact
-byte budget, serving image, and controlled request distribution while changing
-only the declared quantization/backend contract.  It is a protocol, not a
-performance claim.
+to native vLLM parity. It compares the same model family, exact whole-artifact
+byte budget, serving image, and controlled request distribution while recording
+the complete quantization/backend/activation contract. It is a protocol, not a
+performance or quality claim.
 
 The runner is `gridbook-bench-serve` (or
 `python -m gridbook.bench_serve` from a checkout).  It delegates every request
@@ -41,14 +41,36 @@ experiment, not another sample of the same experiment.
 | Hardware | Same GPU, power/clock policy, thermals, and no competing workload |
 | Client | Same input/output lengths, prompts, dataset seed, arrival rate, concurrency, warmups, and blocks |
 
-Use a native quantized artifact made from the same base model.  The formal size
+Use a native quantized artifact made from the same base model. The formal size
 gate is integer arithmetic: **`whole_served_artifact_bytes <= B`**.  “Whole
 served artifact” means every model shard, config, tokenizer file, codebook,
 scale/index sidecar, and other file actually shipped for serving.  Download,
 JIT/compiler, engine, and KV caches are excluded.  Target bpp, quantizable-body
 bytes, and resident VRAM remain useful diagnostics, but none substitutes for
-the whole-artifact gate.  BF16 is a useful ceiling, not the native denominator;
+the whole-artifact gate. Model-payload bytes are recorded separately with an
+explicit scope and are never used for this gate. BF16 is a useful ceiling, not
+the native denominator;
 a 27B Gridbook result cannot be compared with a differently sized native model.
+
+The runner requires a SHA-256-bound inventory document, recomputes its integer
+file-byte sum, requires that sum to equal `--artifact-bytes`, and then applies
+the budget. It accepts a standalone `gridbook.artifact-inventory.v1` (canonical
+relative `path`, non-negative integer `bytes`, and file `sha256` per entry), a
+standalone `prismaquant.cb_export_artifact_inventory.v1`, or the producer's
+`quant_config.json` containing that PrismaQuant inventory under
+`provenance.artifact_inventory`. This lets new Gridbook exports feed their
+fixed-point whole-directory inventory directly into the harness. It also binds
+legacy/native reports to a reviewable document rather than an unaudited number
+on the command line. The runner validates the document and digest, but does not
+reopen terabytes of model shards; artifact publication must separately verify
+file contents. A standalone Gridbook inventory carries per-file digests for
+that purpose, while the current embedded PrismaQuant inventory carries sizes
+and is bound as a whole by the `quant_config.json` digest.
+An embedded export inventory is admissible only while the served file set and
+sizes still match it. If publication adds a model card, `.gitattributes`, or any
+other served-directory file, generate a standalone inventory from the final
+downloaded snapshot; the pre-upload export inventory is then payload provenance,
+not the formal whole-shipped-artifact gate.
 
 The runner requires opaque `--image-id` and `--model-id` values and records them
 verbatim.  Prefer an image digest and a model repository plus immutable commit,
@@ -62,7 +84,7 @@ explicitly with repeatable `--server-env NAME=VALUE`.  Credentials, URL user
 info, sensitive URL query values, authorization headers, and secret-like
 arguments/environment keys are redacted from metadata and recorded commands.
 
-Format labels are not execution evidence.  Every report requires the
+Format labels are not execution evidence. Every report requires the
 format/rung, serialized weight layout, scale coding, full weight/activation
 contract (`W4A4`, `W8A8`, and so on), concrete kernel/backend, tensor-parallel
 size, fallback state, exact server vLLM/runtime build, GPU identifier, driver,
@@ -71,12 +93,50 @@ fields because the benchmark may run outside the serving container.  Attach
 server log lines proving the backend and fallback state; `--server-arg` and a
 filename containing “native” do not prove dispatch.
 
+Every report also requires a SHA-256-bound
+`gridbook.execution-manifest.v1`. Its `assignments` enumerate serving units and
+their format/rung, layout, scale coding, W/A contract, concrete backend, and
+fallback state, and it is bound to the artifact-inventory digest and TP size.
+It must declare `coverage: "all_serving_units"`; a sampled-layer manifest is
+not release evidence.
+Uniform runs must repeat the manifest's one value on the corresponding CLI
+identity fields. If an assignment uses more than one value, that CLI field must
+say `mixed`. The manifest is the authoritative identity for mixed menus; a
+single average bpp or headline format is not.
+
+Minimal manifests look like this (real inventories enumerate every shipped
+file, and real mixed menus enumerate every serving unit or an auditable complete
+set of non-overlapping unit groups):
+
+```json
+{"schema":"gridbook.artifact-inventory.v1","total_bytes":123,"files":[{"path":"config.json","bytes":123,"sha256":"<64 hex>"}]}
+```
+
+For a new PrismaQuant export, pass its existing `quant_config.json` instead of
+translating the embedded inventory into the standalone form.
+
+```json
+{"schema":"gridbook.execution-manifest.v1","coverage":"all_serving_units","artifact_inventory_sha256":"<inventory JSON SHA-256>","tensor_parallel_size":1,"assignments":[{"unit":"model.*","format_rung":"FP8_CB_K36","serialized_layout":"product-codebook-indices-v1","scale_coding":"e4m3-per-block","quant_contract":"W8A8","kernel_backend":"gridbook-cuda-cb-gemv-v2","fallback_state":"none-observed"}]}
+```
+
+The digest arguments are the SHA-256 of the exact JSON file bytes, not a digest
+of a reserialized in-memory object.
+
 One important delegated-NVFP4 trap is **Marlin contract drift**.  An auto/native
 MoE path may select Marlin while dropping activation scales, making the executed
 operator W4A16 rather than W4A4.  Such a run cannot be labelled W4A4 even if the
 serialized weights are NVFP4.  Record the executed W/A contract and concrete
 backend, and prove both from server logs.  A silent fallback is a different arm,
 not a slower sample of the requested arm.
+An intentional Gridbook W4A16 arm is valid when its exact packing/metadata,
+profile, loader, and delegated backend are recorded as W4A16; it must never be
+used as evidence for W4A4 merely because both reuse a native weight family.
+
+The opt-in fused native-FP4 prefill path is another contract-changing cell, not
+a transparent acceleration switch: it moves activation scaling from the
+FP32-emulated group-scale bucket to native UE4M3 factors. Keep it explicitly
+labelled and opt-in until its own same-session served KL/PPL/task and routing/
+shape gates pass; arithmetic or latency parity alone cannot promote it.
 
 ## Approximate 0.6B smoke matrix
 
@@ -84,14 +144,15 @@ Use the 0.6B pair for rapid iteration only.  The small model exposes launch and
 dispatch overhead quickly, but its currently available arms are not a formal
 native-parity pair:
 
-| 0.6B arm | Whole shipped bytes | Executed contract |
-|---|---:|---|
-| Native | 870,290,032 B | W4A4 delegated NVFP4 (only if logs prove the non-Marlin W4A4 path) |
-| Gridbook CB | 871,628,664 B | W8A8 FP8_CB_K36 |
+| 0.6B arm | Model payload scope | Exact whole directory | Executed contract |
+|---|---:|---:|---|
+| Native | 870,290,032 B | 886,191,111 B | W4A4 delegated NVFP4 (only if logs prove the non-Marlin W4A4 path) |
+| Gridbook CB | 871,628,664 B (model plus `cb_codebooks.pqcb`) | 887,531,487 B | W8A8 FP8_CB_K36 |
 
-The CB artifact is **+1,338,632 B / +0.154%**.  It misses a `<=0.1%` matching
-tolerance and fails the exact `bytes <= B` gate when `B` is the native
-870,290,032 B.  More fundamentally, W4A4 native versus W8A8 FP8_CB_K36 is a
+At payload scope CB is **+1,338,632 B / +0.154%**. At exact whole-directory
+scope it is **+1,340,376 B / +0.15125%**. Both miss a `<=0.1%` matching
+tolerance, and CB fails the exact `bytes <= B` gate when `B` is the native
+whole-directory size. More fundamentally, W4A4 native versus W8A8 FP8_CB_K36 is a
 different whole execution contract.  These runs can identify promising kernels
 and regressions; they cannot establish release parity.
 
@@ -152,10 +213,13 @@ and covers the serving scheduler, not just one batch-1 kernel point:
 | MoE routing | Per-layer/per-step routed-token histograms, expert occupancy, active experts, and grouped-operator shape |
 | Grouped MoE | Time the whole routed/grouped operator including routing, packing, launches, kernel, and combine—not an isolated inner GEMM |
 
-`vllm bench serve` supplies request timing but does not emit speculative
-acceptance or MoE routing histograms.  Attach matched server telemetry/log
-artifacts for those fields, keyed by run label, block seed, and timestamps.
-Record the production batch/routed-token `M` seen in those attachments.  Never
+The pinned `vllm bench serve` emits speculative acceptance rate and length,
+draft count, draft/accepted token counts, and per-position acceptance rates.
+The runner requires and arithmetically reconciles every field when
+`--speculative-mode=on`, and forbids those fields when the mode is `off`.
+It does not emit MoE routing histograms. Attach matched server telemetry/log
+artifacts for routing, keyed by run label, block seed, and timestamps.
+Record the production batch/routed-token `M` seen in those attachments. Never
 extrapolate an `M=1` expert microbenchmark to grouped MoE serving: routing skew,
 packing, occupancy, expert grouping, and combine overhead are part of the
 operator that must reach parity.
@@ -165,6 +229,26 @@ separate labelled cells.  They must not be averaged together.  Acceptance-rate
 differences can move effective throughput even when the underlying decode
 kernel is unchanged, so publish acceptance beside throughput for every
 speculative arm.
+
+## Performance is a constraint, not the quality objective
+
+A release assignment minimizes predicted quality loss subject to hard limits:
+exact whole-artifact bytes `<= B`, p95 TTFT, p95 ITL and/or p05 throughput,
+resident weights plus KV plus peak scratch memory, backend/shape/TP legality,
+and serving-unit coupling. Do not replace those limits with
+`quality + lambda * time`, one blended `serve_ms`, or the sum of each layer's
+independently fastest format. That synthetic reference can exceed the byte
+budget. The performance denominator is the fastest **globally feasible**
+assignment under the same whole-artifact budget and execution constraints.
+
+Kernel and per-layer timings can propose candidates; they cannot promote an
+assignment. Final selection requires every arm to be evaluated in the same
+session against the same BF16 teacher capture with served KL/PPL and the
+declared downstream task suite, then measured end to end with this workload
+matrix. This prevents cross-session KL drift, a changed activation bucket, or
+an M=1 microbenchmark from being reported as a quality-preserving native-parity
+win. If a dispatch change alters numerical association, repeat the same-session
+quality gate even when generated smoke text looks unchanged.
 
 ## Invocation template
 
@@ -183,6 +267,8 @@ gridbook-bench-serve \
   --git-commit "$GRIDBOOK_COMMIT" \
   --run-label "$ARM-$SIZE-decode" \
   --artifact-bytes "$WHOLE_ARTIFACT_BYTES" \
+  --artifact-inventory "$ARTIFACT_INVENTORY_JSON" \
+  --artifact-inventory-sha256 "$ARTIFACT_INVENTORY_SHA256" \
   --byte-budget "$BYTE_BUDGET_BYTES" \
   --format-rung "$FORMAT_RUNG" \
   --serialized-layout "$SERIALIZED_LAYOUT" \
@@ -196,6 +282,9 @@ gridbook-bench-serve \
   --gpu-id "$GPU_ID" \
   --driver-version "$NVIDIA_DRIVER_VERSION" \
   --cuda-version "$SERVER_CUDA_VERSION" \
+  --execution-manifest "$EXECUTION_MANIFEST_JSON" \
+  --execution-manifest-sha256 "$EXECUTION_MANIFEST_SHA256" \
+  --speculative-mode off \
   --server-arg=--enforce-eager \
   --server-arg="--max-model-len=$MAX_MODEL_LEN" \
   --runner-env CUDA_VISIBLE_DEVICES \
@@ -218,9 +307,17 @@ Use the same template with the prefill and mixed-online values from the table.
 identity.  They are deliberately separate because production servers often use
 a short alias for a long Hub revision.  `--git-commit` may be omitted when the
 runner is invoked from a Git checkout; an installed wheel has no repository
-metadata, so supply the exact commit used to build it.  The byte and execution
-identity arguments are required: the runner refuses an artifact larger than
-the declared budget before issuing a request.
+metadata, so supply the exact commit used to build it. The byte inventory, its
+digest, the execution manifest, and its digest are required. The runner verifies
+their bindings and refuses an artifact larger than the declared budget before
+issuing a request. For a speculative cell use `--speculative-mode on
+--speculative-config '{"method":"...","num_speculative_tokens":K,...}'`; the
+JSON must describe the exact server configuration, not merely say “enabled,”
+and the same strict-JSON object must appear in the recorded
+`--server-arg=--speculative-config=...`. A mismatch or a speculative server flag
+in an `off` cell fails before requests are issued.
+Optional payload bytes use `--payload-bytes` together with a precise
+`--payload-scope`.
 
 The benchmark does not launch a server.  Start native and Gridbook servers with
 the recorded, matched arguments, wait until model loading and JIT compilation
@@ -229,23 +326,27 @@ the same accelerator during a comparison.
 
 ## Structured report and acceptance
 
-Each JSON report has schema `gridbook.vllm-bench-serve.v1` and contains:
+Each JSON report has schema `gridbook.vllm-bench-serve.v2` and contains:
 
 - UTC start/end timestamps and wall duration;
 - Gridbook git commit/dirty state and package, vLLM, Python, platform and host
   versions;
 - supplied image, artifact, tokenizer, endpoint and served-model identities;
-- exact whole-artifact bytes, budget, headroom, and byte-scope definition;
+- exact inventory-derived whole-artifact bytes, inventory digest/reference,
+  budget, headroom, and byte-scope definition, plus separately scoped optional
+  payload bytes;
 - structured format/rung, serialized layout/scale coding, W/A contract,
   concrete backend/fallback, TP size, client/server runtimes, GPU, driver, and
-  CUDA;
+  CUDA, plus the digest-bound per-serving-unit execution manifest;
 - recorded server flags and dispatch environment;
 - runner environment and explicitly supplied server environment in separate
   fields;
-- the exact workload controls, block seeds, and full vLLM command for each block;
+- the exact workload controls, structured speculation mode/config, block seeds,
+  and full vLLM command for each block;
 - the input-length ratio, validation envelope, and observed per-request lengths;
 - raw vLLM detailed output for each block; and
-- mean, median, min, max and sample standard deviation across block metrics.
+- mean, median, min, max, NumPy-linear block p05/p95, and sample standard
+  deviation across block metrics.
 
 A nonzero client exit, failed request, missing streaming metric, early EOS, or
 length mismatch makes the report `failed`.  Required throughput and every
@@ -257,16 +358,21 @@ redacted command, return code, raw result when one exists, and validation error
 so the run cannot be mistaken for missing data.  The output name is atomically
 reserved before probes begin, preventing concurrent clients from both claiming
 it; existing reports are never overwritten unless `--overwrite` is explicit.
+The CLI enforces at least four warmups, at least three independent blocks, and a
+percentile set containing p95; a report cannot quietly weaken the minimum
+TTFT/ITL gates.
 
 Detailed ITL entries are streamed **chunk** intervals, not a promise of one
 entry per generated token: one chunk can carry several regular or
 speculatively accepted tokens.  The harness therefore never requires
-`len(itls) == output_len - 1`.  It reconciles TTFT and flattened ITL means and
-medians against the detailed arrays, reconstructs per-request E2EL as
-`ttft + sum(itls)` with a small terminal-event allowance, and checks mean TPOT
-against `(mean E2EL - mean TTFT) / (fixed output_len - 1)`.  These consistency
-checks reject contradictory summary data without inventing token arrival times
-that the client did not observe.
+`len(itls) == output_len - 1`. It reconstructs mean, median, population standard
+deviation, and every requested percentile for TTFT and flattened ITL with
+NumPy-linear percentile semantics. It reconstructs per-request E2EL as
+`ttft + sum(itls)` and TPOT as `sum(itls) / (fixed output_len - 1)`, checking the
+same complete aggregate set with a small declared terminal-event allowance.
+Request, output-token, and total-token throughput are independently recomputed
+from the finite positive raw duration and exact detailed totals. These checks
+reject contradictory summary data without inventing one ITL per token.
 
 Reports are created with mode `0600`, but treat them as **sensitive raw output**.
 `--save-detailed` includes generated model text and server error strings, which

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -1,9 +1,10 @@
 # Native-parity serving protocol
 
 This is the reproducible performance gate for work intended to bring Gridbook
-to native vLLM parity.  It compares the same model family, byte budget, serving
-image, and fixed request stream while changing only the weight format/plugin
-dispatch under test.  It is a protocol, not a performance claim.
+to native vLLM parity.  It compares the same model family, exact whole-artifact
+byte budget, serving image, and controlled request distribution while changing
+only the declared quantization/backend contract.  It is a protocol, not a
+performance claim.
 
 The runner is `gridbook-bench-serve` (or
 `python -m gridbook.bench_serve` from a checkout).  It delegates every request
@@ -32,17 +33,22 @@ experiment, not another sample of the same experiment.
 | Dimension | Required match |
 |---|---|
 | Base model | Same architecture, tokenizer, revision, and non-quantized tensors |
-| Byte budget | Same target bpp and quantizable-body bytes; report the actual byte difference |
+| Byte budget | Exact whole served artifact is at or below the predeclared byte budget `B` |
 | Software | Same immutable vLLM image digest, CUDA/driver, Gridbook commit, and package version |
 | Server | Same model length, KV dtype, eager/graph mode, memory utilization, batching and scheduler flags |
+| Execution | Explicit format/rung, serialized layout, scale coding, W/A contract, concrete backend, TP size, and fallback state |
 | Features | Prefix caching off; speculative decode, LoRA, request logging, and observability identically configured or off |
 | Hardware | Same GPU, power/clock policy, thermals, and no competing workload |
 | Client | Same input/output lengths, prompts, dataset seed, arrival rate, concurrency, warmups, and blocks |
 
-Use a native quantized artifact made from the same base model and matched body
-bytes.  BF16 is a useful ceiling, but it is not the native denominator for this
-test.  A 27B Gridbook result must not be compared with a differently sized
-native model.
+Use a native quantized artifact made from the same base model.  The formal size
+gate is integer arithmetic: **`whole_served_artifact_bytes <= B`**.  “Whole
+served artifact” means every model shard, config, tokenizer file, codebook,
+scale/index sidecar, and other file actually shipped for serving.  Download,
+JIT/compiler, engine, and KV caches are excluded.  Target bpp, quantizable-body
+bytes, and resident VRAM remain useful diagnostics, but none substitutes for
+the whole-artifact gate.  BF16 is a useful ceiling, not the native denominator;
+a 27B Gridbook result cannot be compared with a differently sized native model.
 
 The runner requires opaque `--image-id` and `--model-id` values and records them
 verbatim.  Prefer an image digest and a model repository plus immutable commit,
@@ -56,14 +62,40 @@ explicitly with repeatable `--server-env NAME=VALUE`.  Credentials, URL user
 info, sensitive URL query values, authorization headers, and secret-like
 arguments/environment keys are redacted from metadata and recorded commands.
 
-## Fixed 0.6B and 27B matrix
+Format labels are not execution evidence.  Every report requires the
+format/rung, serialized weight layout, scale coding, full weight/activation
+contract (`W4A4`, `W8A8`, and so on), concrete kernel/backend, tensor-parallel
+size, fallback state, exact server vLLM/runtime build, GPU identifier, driver,
+and CUDA runtime.  Client and server runtime identifiers are separate required
+fields because the benchmark may run outside the serving container.  Attach
+server log lines proving the backend and fallback state; `--server-arg` and a
+filename containing “native” do not prove dispatch.
 
-Use a matched 0.6B pair for rapid iteration, then repeat unchanged on the 27B
-pair before accepting a change.  The small model exposes launch and dispatch
-overhead quickly; the 27B gate establishes that the result survives realistic
-weight traffic.  A win on 0.6B is a lead, not a final result.
+One important delegated-NVFP4 trap is **Marlin contract drift**.  An auto/native
+MoE path may select Marlin while dropping activation scales, making the executed
+operator W4A16 rather than W4A4.  Such a run cannot be labelled W4A4 even if the
+serialized weights are NVFP4.  Record the executed W/A contract and concrete
+backend, and prove both from server logs.  A silent fallback is a different arm,
+not a slower sample of the requested arm.
 
-Run all three shapes on both sizes:
+## Approximate 0.6B smoke matrix
+
+Use the 0.6B pair for rapid iteration only.  The small model exposes launch and
+dispatch overhead quickly, but its currently available arms are not a formal
+native-parity pair:
+
+| 0.6B arm | Whole shipped bytes | Executed contract |
+|---|---:|---|
+| Native | 870,290,032 B | W4A4 delegated NVFP4 (only if logs prove the non-Marlin W4A4 path) |
+| Gridbook CB | 871,628,664 B | W8A8 FP8_CB_K36 |
+
+The CB artifact is **+1,338,632 B / +0.154%**.  It misses a `<=0.1%` matching
+tolerance and fails the exact `bytes <= B` gate when `B` is the native
+870,290,032 B.  More fundamentally, W4A4 native versus W8A8 FP8_CB_K36 is a
+different whole execution contract.  These runs can identify promising kernels
+and regressions; they cannot establish release parity.
+
+Run these fixed shapes as the quick smoke on 0.6B and as the first 27B check:
 
 | Workload | Input | Output | Prompts/block | Concurrency | Primary metric |
 |---|---:|---:|---:|---:|---|
@@ -71,15 +103,26 @@ Run all three shapes on both sizes:
 | Batch-1 decode | 32 | 256 | 16 | 1 | TPOT, ITL, output tok/s |
 | Mixed online | 1024 | 128 | 32 | 4 | E2EL, TTFT, TPOT, p99 ITL |
 
-For every row use `--request-rate inf`, four unmeasured warmup prompts per
-block, dataset seed 1234, and **at least three blocks**.  The runner derives a
-distinct prompt-dataset seed for each block (`1234`, `1235`, `1236`, ...); use
-the same base seed for the native and Gridbook arms so every block is paired.
+For every fixed row use `--input-range-ratio 0`, `--request-rate inf`, four
+unmeasured warmup prompts per block, dataset seed 1234, and **at least three
+blocks**.  The runner derives a distinct prompt-dataset seed for each block
+(`1234`, `1235`, `1236`, ...); use the same base seed for the native and
+Gridbook arms so every block is paired.
 This seed controls prompt construction, not generation.  Server sampling is
 separately and unconditionally pinned to greedy decoding with `--temperature
 0`.  Fixed lengths are enforced with vLLM's random dataset at range ratio zero
 plus `ignore_eos`; the runner rejects a block if completed prompts, per-request
 lengths, or total input/output tokens differ from the requested values.
+
+For a prompt-length distribution, set `--input-range-ratio R` with
+`0 <= R < 1`.  The pinned vLLM client receives
+`{"input": R, "output": 0}`, so output length remains exact.  vLLM samples
+integer input lengths up through `ceil(input_len * (1 + R))`; its lower endpoint
+also depends on tokenizer-added special tokens and decode/re-encode correction,
+neither of which is emitted in result JSON.  The harness therefore uses the safe
+conservative envelope `[1, ceil(input_len * (1 + R))]`, requires integer positive
+per-request lengths, and requires their sum to equal `total_input_tokens`.  The
+exact per-request equality check remains exclusive to `R=0`.
 
 Keep prefix caching off for this primary matrix.  vLLM's readiness probe and
 warmups deliberately reuse the first request, so an enabled prefix cache would
@@ -93,6 +136,35 @@ is material.  Run the native and Gridbook arms back-to-back, reverse their order
 in a second session, and include every block value rather than reporting only
 the best one.  Restarting the server between final-validation sessions is
 preferred; allow the same model-load/JIT warmup before each measured arm.
+
+## Release matrix: 27B and shipped MoE behavior
+
+A release claim repeats the smoke shapes on the exact byte-admissible 27B pair
+and covers the serving scheduler, not just one batch-1 kernel point:
+
+| Lane | Required sweep/evidence |
+|---|---|
+| Prompt distribution | Fixed rows plus at least one declared nonzero input-range ratio using identical seeds |
+| Concurrency | Ladder `1, 2, 4, 8` plus the shipped maximum if higher; report every block and tail ITL |
+| Chunked prefill | Matched runs with chunked prefill off and on, recording chunk size/scheduler flags |
+| Plain decode | Non-speculative, batch-1 `M=1`; report TPOT/ITL and output throughput |
+| Shipped decode | Speculative and/or batched decode at the production `M`, including acceptance rate/length and routed work |
+| MoE routing | Per-layer/per-step routed-token histograms, expert occupancy, active experts, and grouped-operator shape |
+| Grouped MoE | Time the whole routed/grouped operator including routing, packing, launches, kernel, and combine—not an isolated inner GEMM |
+
+`vllm bench serve` supplies request timing but does not emit speculative
+acceptance or MoE routing histograms.  Attach matched server telemetry/log
+artifacts for those fields, keyed by run label, block seed, and timestamps.
+Record the production batch/routed-token `M` seen in those attachments.  Never
+extrapolate an `M=1` expert microbenchmark to grouped MoE serving: routing skew,
+packing, occupancy, expert grouping, and combine overhead are part of the
+operator that must reach parity.
+
+Chunked-prefill on/off, eager/graph mode, speculation, and scheduler changes are
+separate labelled cells.  They must not be averaged together.  Acceptance-rate
+differences can move effective throughput even when the underlying decode
+kernel is unchanged, so publish acceptance beside throughput for every
+speculative arm.
 
 ## Invocation template
 
@@ -110,6 +182,20 @@ gridbook-bench-serve \
   --image-id "$VLLM_IMAGE_DIGEST" \
   --git-commit "$GRIDBOOK_COMMIT" \
   --run-label "$ARM-$SIZE-decode" \
+  --artifact-bytes "$WHOLE_ARTIFACT_BYTES" \
+  --byte-budget "$BYTE_BUDGET_BYTES" \
+  --format-rung "$FORMAT_RUNG" \
+  --serialized-layout "$SERIALIZED_LAYOUT" \
+  --scale-coding "$SCALE_CODING" \
+  --quant-contract "$WEIGHT_ACTIVATION_CONTRACT" \
+  --kernel-backend "$CONCRETE_KERNEL_BACKEND" \
+  --tensor-parallel-size "$TP_SIZE" \
+  --fallback-state "$FALLBACK_STATE" \
+  --client-runtime-id "$BENCH_CLIENT_VLLM_RUNTIME_ID" \
+  --server-runtime-id "$SERVER_VLLM_RUNTIME_ID" \
+  --gpu-id "$GPU_ID" \
+  --driver-version "$NVIDIA_DRIVER_VERSION" \
+  --cuda-version "$SERVER_CUDA_VERSION" \
   --server-arg=--enforce-eager \
   --server-arg="--max-model-len=$MAX_MODEL_LEN" \
   --runner-env CUDA_VISIBLE_DEVICES \
@@ -122,6 +208,7 @@ gridbook-bench-serve \
   --warmups 4 \
   --blocks 3 \
   --dataset-seed 1234 \
+  --input-range-ratio 0 \
   --request-rate inf \
   --output "results/$ARM-$SIZE-decode.json"
 ```
@@ -131,7 +218,9 @@ Use the same template with the prefill and mixed-online values from the table.
 identity.  They are deliberately separate because production servers often use
 a short alias for a long Hub revision.  `--git-commit` may be omitted when the
 runner is invoked from a Git checkout; an installed wheel has no repository
-metadata, so supply the exact commit used to build it.
+metadata, so supply the exact commit used to build it.  The byte and execution
+identity arguments are required: the runner refuses an artifact larger than
+the declared budget before issuing a request.
 
 The benchmark does not launch a server.  Start native and Gridbook servers with
 the recorded, matched arguments, wait until model loading and JIT compilation
@@ -146,10 +235,15 @@ Each JSON report has schema `gridbook.vllm-bench-serve.v1` and contains:
 - Gridbook git commit/dirty state and package, vLLM, Python, platform and host
   versions;
 - supplied image, artifact, tokenizer, endpoint and served-model identities;
+- exact whole-artifact bytes, budget, headroom, and byte-scope definition;
+- structured format/rung, serialized layout/scale coding, W/A contract,
+  concrete backend/fallback, TP size, client/server runtimes, GPU, driver, and
+  CUDA;
 - recorded server flags and dispatch environment;
 - runner environment and explicitly supplied server environment in separate
   fields;
-- the exact fixed workload, block seeds, and full vLLM command for each block;
+- the exact workload controls, block seeds, and full vLLM command for each block;
+- the input-length ratio, validation envelope, and observed per-request lengths;
 - raw vLLM detailed output for each block; and
 - mean, median, min, max and sample standard deviation across block metrics.
 
@@ -163,6 +257,16 @@ redacted command, return code, raw result when one exists, and validation error
 so the run cannot be mistaken for missing data.  The output name is atomically
 reserved before probes begin, preventing concurrent clients from both claiming
 it; existing reports are never overwritten unless `--overwrite` is explicit.
+
+Detailed ITL entries are streamed **chunk** intervals, not a promise of one
+entry per generated token: one chunk can carry several regular or
+speculatively accepted tokens.  The harness therefore never requires
+`len(itls) == output_len - 1`.  It reconciles TTFT and flattened ITL means and
+medians against the detailed arrays, reconstructs per-request E2EL as
+`ttft + sum(itls)` with a small terminal-event allowance, and checks mean TPOT
+against `(mean E2EL - mean TTFT) / (fixed output_len - 1)`.  These consistency
+checks reject contradictory summary data without inventing token arrival times
+that the client did not observe.
 
 Reports are created with mode `0600`, but treat them as **sensitive raw output**.
 `--save-detailed` includes generated model text and server error strings, which
@@ -182,6 +286,8 @@ regressed tail ITL or failed requests.
 
 For a release-grade claim, attach both reports, the exact server logs containing
 Gridbook dispatch lines, hardware clocks/power state, and the model/body-byte
-calculation.  Re-run generated-text correctness or quality evaluation whenever
+calculation **plus the exact whole-shipped-artifact byte inventory**.  Attach
+the matched acceptance/routing telemetry required by the release matrix.  Re-run
+generated-text correctness or quality evaluation whenever
 a performance change alters numerical association or dispatch, even if this
 latency protocol passes.

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -423,8 +423,9 @@ Each JSON report has schema `gridbook.vllm-bench-serve.v2` and contains:
 - the input-length ratio, validation envelope, observed per-request lengths, and
   for ranged cells the expected and observed canonical vector digests by block;
 - exact reconciliation of pinned vLLM's saved `backend`, `endpoint_type`,
-  `label`, `model_id`, `tokenizer_id`, `num_prompts`, `request_rate`, and
-  `max_concurrency` invocation fields before metrics are accepted;
+  `label`, `model_id`, `tokenizer_id`, `num_prompts`, `request_rate`,
+  `burstiness`, and `max_concurrency` invocation fields before metrics are
+  accepted;
 - sanitized vLLM detailed metric output for each block (generated text omitted,
   the complete `errors` field omitted regardless of type); and
 - mean, median, min, max, NumPy-linear block p05/p95, and sample standard
@@ -434,6 +435,12 @@ A nonzero client exit, failed request, missing streaming metric, early EOS, or
 length mismatch makes the report `failed`.  Required throughput and every
 requested percentile must be finite; TTFT and E2EL must be positive.  A
 multi-token response must also contain positive per-request ITL samples.
+The saved-result object must have the exact field envelope emitted by the
+pinned client: append-style arrays, unrequested metadata/ramp fields, and extra
+percentile labels fail. Its timestamp shape, generated-text/start-time
+cardinality, null unrequested goodput, text-dataset `rtfx`, and finite peak
+diagnostics are validated before arbitrary completion and error text is
+discarded.
 One-token prefill probes are explicitly exempt from ITL/TPOT positivity because
 there is no post-first-token interval.  A partial/failure report retains the
 redacted command, return code, sanitized result when one exists, and validation error

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -75,6 +75,7 @@ REQUIRED_THROUGHPUT_RESULTS = (
 _PERCENTILE_RESULT = re.compile(
     r"^p(?:\d+(?:\.\d+)?(?:e[+-]?\d+)?)_(?:ttft|tpot|itl|e2el)_ms$"
 )
+_VLLM_RESULT_DATE = re.compile(r"^\d{8}-\d{6}$")
 _SENSITIVE_SEGMENTS = {
     "AUTH",
     "AUTHORIZATION",
@@ -127,6 +128,38 @@ _EXECUTION_ASSIGNMENT_FIELDS = (
     "quant_contract",
     "kernel_backend",
     "fallback_state",
+)
+
+_PINNED_RESULT_FIELDS = frozenset(
+    {
+        "date",
+        "endpoint_type",
+        "backend",
+        "label",
+        "model_id",
+        "tokenizer_id",
+        "num_prompts",
+        "request_rate",
+        "burstiness",
+        "max_concurrency",
+        "duration",
+        "completed",
+        "failed",
+        "total_input_tokens",
+        "total_output_tokens",
+        "request_goodput",
+        "input_lens",
+        "output_lens",
+        "ttfts",
+        "itls",
+        "start_times",
+        "generated_texts",
+        "errors",
+        "max_output_tokens_per_s",
+        "max_concurrent_requests",
+        "rtfx",
+        *SUMMARY_METRICS,
+    }
 )
 
 
@@ -1781,10 +1814,6 @@ def _load_result(path: Path) -> dict[str, Any]:
         raise BenchmarkError(f"vLLM did not create result file {path}") from exc
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
         raise BenchmarkError(f"vLLM result is not strict JSON: {path}") from exc
-    # ``--append-result`` creates a list; the harness never requests it, but
-    # accepting a singleton makes this resilient to vLLM version differences.
-    if isinstance(payload, list) and len(payload) == 1:
-        payload = payload[0]
     if not isinstance(payload, dict):
         raise BenchmarkError("vLLM result JSON must contain one object")
     return payload
@@ -2065,6 +2094,85 @@ def _validate_speculative_result(
         )
 
 
+def _validate_result_envelope(
+    result: Mapping[str, Any], args: argparse.Namespace
+) -> None:
+    """Validate the complete saved-result shape of the pinned vLLM client."""
+
+    expected_fields = set(_PINNED_RESULT_FIELDS)
+    for percentile in args.percentiles.split(","):
+        for metric in ("ttft", "tpot", "itl", "e2el"):
+            expected_fields.add(_percentile_result_key(percentile, metric))
+    if args.speculative_mode == "on":
+        expected_fields.update(_SPEC_RESULT_FIELDS)
+
+    observed_fields = set(result)
+    missing = sorted(expected_fields - observed_fields)
+    unexpected = sorted(observed_fields - expected_fields)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append("missing=" + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected=" + ", ".join(unexpected))
+        raise BenchmarkError(
+            "vLLM result envelope disagrees with the pinned client: "
+            + "; ".join(details)
+        )
+
+    date = result.get("date")
+    if not isinstance(date, str) or not _VLLM_RESULT_DATE.fullmatch(date):
+        raise BenchmarkError("vLLM result date does not use YYYYMMDD-HHMMSS")
+
+    generated_texts = result.get("generated_texts")
+    if (
+        not isinstance(generated_texts, list)
+        or len(generated_texts) != args.num_prompts
+        or any(not isinstance(value, str) for value in generated_texts)
+    ):
+        raise BenchmarkError(
+            "vLLM detailed result generated_texts must contain one string per prompt"
+        )
+
+    start_times = result.get("start_times")
+    if not isinstance(start_times, list) or len(start_times) != args.num_prompts:
+        raise BenchmarkError(
+            "vLLM detailed result start_times must contain one value per prompt"
+        )
+    bad_start_times = [
+        index
+        for index, value in enumerate(start_times)
+        if isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) < 0
+    ]
+    if bad_start_times:
+        raise BenchmarkError(
+            "vLLM detailed result has invalid start_times at request index: "
+            + ", ".join(str(index) for index in bad_start_times[:5])
+        )
+
+    if result.get("request_goodput") is not None:
+        raise BenchmarkError(
+            "vLLM result request_goodput must be null without a goodput command"
+        )
+    peak_output = _number(result, "max_output_tokens_per_s")
+    if peak_output is None or peak_output < 0:
+        raise BenchmarkError(
+            "vLLM result max_output_tokens_per_s must be finite and non-negative"
+        )
+    peak_concurrency = _exact_nonnegative_int(result, "max_concurrent_requests")
+    if peak_concurrency is None or not 1 <= peak_concurrency <= args.num_prompts:
+        raise BenchmarkError(
+            "vLLM result max_concurrent_requests must be a positive integer no "
+            "larger than num_prompts"
+        )
+    rtfx = _number(result, "rtfx")
+    if rtfx != 0:
+        raise BenchmarkError("vLLM result rtfx must be zero for the random text dataset")
+
+
 def validate_result(
     result: Mapping[str, Any], args: argparse.Namespace, *, block_index: int = 0
 ) -> None:
@@ -2336,6 +2444,7 @@ def validate_result(
         requested_percentiles,
         args.output_len,
     )
+    _validate_result_envelope(result, args)
 
 
 def summarize_blocks(blocks: Sequence[Mapping[str, Any]]) -> dict[str, Any]:

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -1126,6 +1126,43 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return args
 
 
+def _revalidate_bound_inputs(args: argparse.Namespace) -> None:
+    """Require every digest-bound input to match its parsed snapshot.
+
+    ``parse_args`` validates these files before a report is reserved.  They are
+    external mutable paths, however, so a long-lived caller could otherwise
+    change one after parsing while the report continued to claim the old
+    digest.  Comparing the complete normalized summaries also protects against
+    a future validator accidentally changing semantics without changing this
+    call site.
+    """
+
+    inventory = _validate_artifact_inventory(
+        args.artifact_inventory, args.artifact_inventory_sha256
+    )
+    if inventory != args.artifact_inventory_summary:
+        raise BenchmarkError(
+            "artifact inventory changed after command-line validation"
+        )
+    execution_manifest = _validate_execution_manifest(
+        args.execution_manifest,
+        args.execution_manifest_sha256,
+        inventory["sha256"],
+        args,
+    )
+    if execution_manifest != args.execution_manifest_summary:
+        raise BenchmarkError(
+            "execution manifest changed after command-line validation"
+        )
+    server_evidence = _validate_server_evidence(
+        args.server_evidence, args.server_evidence_sha256
+    )
+    if server_evidence != args.server_evidence_summary:
+        raise BenchmarkError(
+            "server evidence changed after command-line validation"
+        )
+
+
 def build_vllm_command(
     args: argparse.Namespace,
     *,
@@ -1344,7 +1381,10 @@ def redact_command(command: Sequence[str]) -> list[str]:
 
 
 def _git_state(
-    commit_override: str | None, *, allow_dirty: bool = False
+    commit_override: str | None,
+    *,
+    allow_dirty: bool = False,
+    generated_paths: Sequence[Path] = (),
 ) -> dict[str, Any]:
     if commit_override and not _GIT_COMMIT.fullmatch(commit_override):
         raise BenchmarkError("explicit Gridbook commit is not exact 40/64 hex")
@@ -1377,9 +1417,28 @@ def _git_state(
                     capture_output=True,
                     text=True,
                 ).stdout.strip()
+                status_command = [
+                    "git",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                    "--",
+                    ".",
+                ]
+                for generated_path in generated_paths:
+                    normalized_path = Path(
+                        os.path.abspath(os.fspath(generated_path.expanduser()))
+                    )
+                    try:
+                        relative_path = normalized_path.relative_to(checkout)
+                    except ValueError:
+                        continue
+                    status_command.append(
+                        ":(exclude,top,literal)" + relative_path.as_posix()
+                    )
                 detected_dirty = bool(
                     subprocess.run(
-                        ["git", "status", "--porcelain"],
+                        status_command,
                         cwd=checkout,
                         check=True,
                         capture_output=True,
@@ -1414,7 +1473,15 @@ def _git_state(
             "source": (
                 "argument+checkout" if detected_commit is not None else "argument"
             ),
-            "release_eligible": not allow_dirty and detected_dirty is not True,
+            # An assertion supplied beside an installed wheel is useful
+            # research metadata, but it is not proof that the executing bytes
+            # came from that commit.  Release eligibility requires the exact
+            # clean checkout that supplied this module.
+            "release_eligible": (
+                detected_commit is not None
+                and detected_dirty is False
+                and not allow_dirty
+            ),
         }
     if detected_commit is None:
         return {
@@ -1432,14 +1499,17 @@ def _git_state(
 
 
 def _package_version() -> str | None:
+    # Prefer the package that supplied this module.  Distribution metadata can
+    # describe a different globally installed Gridbook when a source checkout
+    # is selected via PYTHONPATH or an editable test setup.
     try:
-        return importlib.metadata.version("gridbook")
-    except importlib.metadata.PackageNotFoundError:
-        try:
-            from gridbook import __version__
+        from gridbook import __version__
 
-            return __version__
-        except (ImportError, AttributeError):
+        return __version__
+    except (ImportError, AttributeError):
+        try:
+            return importlib.metadata.version("gridbook")
+        except importlib.metadata.PackageNotFoundError:
             return None
 
 
@@ -1485,7 +1555,12 @@ def collect_metadata(
             probe_errors[name] = _redact_text(f"{type(exc).__name__}: {exc}")
             return fallback
 
-    git = _git_state(args.git_commit, allow_dirty=args.allow_dirty)
+    _revalidate_bound_inputs(args)
+    git = _git_state(
+        args.git_commit,
+        allow_dirty=args.allow_dirty,
+        generated_paths=(args.output,),
+    )
     client_runtime_probe = _vllm_version(args.vllm_executable)
     if client_runtime_probe is None:
         raise BenchmarkError(
@@ -1502,6 +1577,12 @@ def collect_metadata(
     }
     metadata = {
         "git": git,
+        "measurement_provenance": {
+            "digest_bound_inputs_verified_before_requests": True,
+            "digest_bound_inputs_verified_after_requests": False,
+            "git_state_verified_after_requests": False,
+            "client_runtime_verified_after_requests": False,
+        },
         "software": {
             "gridbook_version": probe("gridbook_version", _package_version),
             "runner_vllm_cli_probe": client_runtime_probe,
@@ -2500,6 +2581,25 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                 finally:
                     block["finished_at"] = _utc_now()
                     block["wall_duration_s"] = time.monotonic() - block_clock
+        _revalidate_bound_inputs(args)
+        ending_git = _git_state(
+            args.git_commit,
+            allow_dirty=args.allow_dirty,
+            generated_paths=(output_path,),
+        )
+        if ending_git != report["metadata"]["git"]:
+            raise BenchmarkError(
+                "Gridbook source provenance changed during the benchmark"
+            )
+        ending_client_runtime = _vllm_version(args.vllm_executable)
+        if ending_client_runtime != args.client_runtime_id:
+            raise BenchmarkError(
+                "vLLM client runtime identity changed during the benchmark"
+            )
+        provenance = report["metadata"]["measurement_provenance"]
+        provenance["digest_bound_inputs_verified_after_requests"] = True
+        provenance["git_state_verified_after_requests"] = True
+        provenance["client_runtime_verified_after_requests"] = True
         report["summary"] = summarize_blocks(report["blocks"])
         report["status"] = "success"
         report["measurement_valid"] = True

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -71,7 +71,9 @@ REQUIRED_THROUGHPUT_RESULTS = (
     "output_throughput",
     "total_token_throughput",
 )
-_PERCENTILE_RESULT = re.compile(r"^p(?:\d+(?:\.\d+)?)_(?:ttft|tpot|itl|e2el)_ms$")
+_PERCENTILE_RESULT = re.compile(
+    r"^p(?:\d+(?:\.\d+)?(?:e[+-]?\d+)?)_(?:ttft|tpot|itl|e2el)_ms$"
+)
 _SENSITIVE_SEGMENTS = {
     "AUTH",
     "AUTHORIZATION",
@@ -110,6 +112,11 @@ _SENSITIVE_HEADER = re.compile(
 )
 _URL = re.compile(r"https?://[^\s]+", re.IGNORECASE)
 _SHA256 = re.compile(r"^[0-9a-fA-F]{64}$")
+_GIT_COMMIT = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
+_RUN_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ENV_PREFIX = re.compile(r"^[A-Za-z][A-Za-z0-9_]+_$")
+_CONCRETE_UNIT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$")
 
 _EXECUTION_ASSIGNMENT_FIELDS = (
     "unit",
@@ -158,6 +165,34 @@ def _sha256(value: str) -> str:
     if not _SHA256.fullmatch(value):
         raise argparse.ArgumentTypeError("must be a 64-character SHA-256 hex digest")
     return value.lower()
+
+
+def _git_commit(value: str) -> str:
+    if not _GIT_COMMIT.fullmatch(value):
+        raise argparse.ArgumentTypeError("must be an exact 40- or 64-hex commit")
+    return value.lower()
+
+
+def _run_label(value: str) -> str:
+    if not _RUN_LABEL.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            "must be 1-128 characters using only letters, digits, '.', '_', or '-'"
+        )
+    return value
+
+
+def _environment_name(value: str) -> str:
+    if not _ENV_NAME.fullmatch(value):
+        raise argparse.ArgumentTypeError("must be an environment variable name")
+    return value
+
+
+def _environment_prefix(value: str) -> str:
+    if not _ENV_PREFIX.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            "must be at least three characters, start with a letter, and end in '_'"
+        )
+    return value
 
 
 def _strict_json_loads(value: str | bytes) -> Any:
@@ -209,6 +244,52 @@ def _read_hashed_json(
     if not isinstance(payload, dict):
         raise BenchmarkError(f"{label} must contain one JSON object")
     return payload, actual_digest
+
+
+def _validate_server_evidence(
+    paths: Sequence[Path], expected_digests: Sequence[str]
+) -> list[dict[str, Any]]:
+    if not paths or len(paths) != len(expected_digests):
+        raise BenchmarkError(
+            "server evidence requires one --server-evidence-sha256 per "
+            "--server-evidence attachment"
+        )
+    attachments: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, (path, expected_digest) in enumerate(zip(paths, expected_digests)):
+        normalized = os.path.abspath(os.fspath(path.expanduser()))
+        if normalized in seen:
+            raise BenchmarkError(f"duplicate server evidence attachment: {path}")
+        seen.add(normalized)
+        if not path.expanduser().is_file():
+            raise BenchmarkError(
+                f"server evidence attachment {index + 1} is not a regular file"
+            )
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            with path.expanduser().open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+                    size += len(chunk)
+        except OSError as exc:
+            raise BenchmarkError(
+                f"cannot read server evidence attachment {index + 1} {path}: {exc}"
+            ) from exc
+        actual_digest = digest.hexdigest()
+        if actual_digest != expected_digest:
+            raise BenchmarkError(
+                f"server evidence attachment {index + 1} SHA-256 mismatch: "
+                f"declared={expected_digest}, actual={actual_digest}"
+            )
+        attachments.append(
+            {
+                "reference": str(path),
+                "sha256": actual_digest,
+                "bytes": size,
+            }
+        )
+    return attachments
 
 
 def _canonical_inventory_path(name: Any, where: str) -> str:
@@ -359,7 +440,16 @@ def _validate_execution_manifest(
         raise BenchmarkError(
             "execution manifest coverage must declare all_serving_units"
         )
-    if payload.get("tensor_parallel_size") != args.tensor_parallel_size:
+    manifest_tp = payload.get("tensor_parallel_size")
+    if (
+        isinstance(manifest_tp, bool)
+        or not isinstance(manifest_tp, int)
+        or manifest_tp <= 0
+    ):
+        raise BenchmarkError(
+            "execution manifest tensor_parallel_size must be a positive integer"
+        )
+    if manifest_tp != args.tensor_parallel_size:
         raise BenchmarkError(
             "execution manifest tensor_parallel_size disagrees with the command"
         )
@@ -382,10 +472,37 @@ def _validate_execution_manifest(
                 raise BenchmarkError(
                     f"execution manifest assignments[{index}].{field} must be non-empty"
                 )
+            if value.strip().lower() == "mixed":
+                raise BenchmarkError(
+                    f"execution manifest assignments[{index}].{field} must be "
+                    "concrete, not 'mixed'"
+                )
             if field == "unit":
+                if not _CONCRETE_UNIT.fullmatch(value) or ".." in value:
+                    raise BenchmarkError(
+                        f"execution manifest assignments[{index}].unit must be a "
+                        "concrete serving-unit identifier without wildcards"
+                    )
                 if value in units:
                     raise BenchmarkError(
                         f"execution manifest contains duplicate unit {value!r}"
+                    )
+                overlap = next(
+                    (
+                        existing
+                        for existing in units
+                        if any(
+                            value.startswith(existing + separator)
+                            or existing.startswith(value + separator)
+                            for separator in (".", "/", ":")
+                        )
+                    ),
+                    None,
+                )
+                if overlap is not None:
+                    raise BenchmarkError(
+                        "execution manifest contains overlapping unit identifiers: "
+                        f"{overlap!r} and {value!r}"
                     )
                 units.add(value)
             else:
@@ -453,6 +570,11 @@ def _request_rate(value: str) -> str:
     return value
 
 
+def _percentile_label(value: str | float) -> str:
+    number = float(value)
+    return str(int(number)) if number.is_integer() else str(number)
+
+
 def _percentiles(value: str) -> str:
     try:
         parsed = [float(item) for item in value.split(",")]
@@ -464,7 +586,12 @@ def _percentiles(value: str) -> str:
         raise argparse.ArgumentTypeError("every percentile must be between 0 and 100")
     if len(set(parsed)) != len(parsed):
         raise argparse.ArgumentTypeError("percentiles must not contain duplicates")
-    return ",".join(f"{item:g}" for item in parsed)
+    labels = [_percentile_label(item) for item in parsed]
+    if len(set(labels)) != len(labels):
+        raise argparse.ArgumentTypeError(
+            "percentiles collide after pinned-vLLM float normalization"
+        )
+    return ",".join(labels)
 
 
 def _server_environment(value: str) -> tuple[str, str]:
@@ -508,6 +635,32 @@ def _recorded_speculative_config(server_args: Sequence[str]) -> dict[str, Any] |
     return config
 
 
+def _validate_recorded_prefix_caching(
+    declared_state: str, server_args: Sequence[str]
+) -> None:
+    enable_flag = "--enable-prefix-caching"
+    disable_flag = "--no-enable-prefix-caching"
+    recorded = {argument.strip() for argument in server_args}
+    enabled = enable_flag in recorded
+    disabled = disable_flag in recorded
+    if enabled and disabled:
+        raise BenchmarkError(
+            "recorded server args contain conflicting prefix-caching flags"
+        )
+    required_flag = enable_flag if declared_state == "on" else disable_flag
+    conflicting_flag = disable_flag if declared_state == "on" else enable_flag
+    if conflicting_flag in recorded:
+        raise BenchmarkError(
+            f"--prefix-caching={declared_state} conflicts with recorded "
+            f"{conflicting_flag}"
+        )
+    if required_flag not in recorded:
+        raise BenchmarkError(
+            f"--prefix-caching={declared_state} requires recorded server arg "
+            f"{required_flag}"
+        )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="gridbook-bench-serve",
@@ -545,6 +698,28 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     server.add_argument(
+        "--prefix-caching",
+        choices=("off", "on"),
+        required=True,
+        help="explicit server prefix-caching state, reconciled with --server-arg",
+    )
+    server.add_argument(
+        "--server-evidence",
+        action="append",
+        type=Path,
+        required=True,
+        metavar="PATH",
+        help="dispatch/startup log attachment to hash and record; repeatable",
+    )
+    server.add_argument(
+        "--server-evidence-sha256",
+        action="append",
+        type=_sha256,
+        required=True,
+        metavar="SHA256",
+        help="SHA-256 paired by order with each --server-evidence path",
+    )
+    server.add_argument(
         "--ready-timeout",
         type=_nonnegative_int,
         default=600,
@@ -578,12 +753,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     artifact.add_argument(
         "--git-commit",
-        type=_nonempty,
+        type=_git_commit,
         help="Gridbook commit override; otherwise detected from this checkout",
     )
     artifact.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="permit a dirty source checkout for research-only evidence",
+    )
+    artifact.add_argument(
         "--run-label",
-        type=_nonempty,
+        type=_run_label,
         required=True,
         help="short arm/workload label, for example gridbook-27b-decode",
     )
@@ -770,12 +950,24 @@ def build_parser() -> argparse.ArgumentParser:
             "remains fixed (default: 0)"
         ),
     )
+    workload.add_argument(
+        "--expected-input-lens-sha256",
+        action="append",
+        default=[],
+        type=_sha256,
+        metavar="SHA256",
+        help=(
+            "canonical detailed input_lens JSON-array digest for one block; "
+            "repeat in block order for nonzero --input-range-ratio"
+        ),
+    )
 
     dispatch = parser.add_argument_group("dispatch provenance")
     dispatch.add_argument(
         "--runner-env",
         action="append",
         default=[],
+        type=_environment_name,
         metavar="NAME",
         help="benchmark-runner environment variable to record; repeat as needed",
     )
@@ -783,6 +975,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--runner-env-prefix",
         action="append",
         default=["PRISMAQUANT_"],
+        type=_environment_prefix,
         metavar="PREFIX",
         help=(
             "record runner variables matching this prefix; repeat to add prefixes "
@@ -832,6 +1025,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
                 "--observed-input-len-min/--observed-input-len-max are forbidden "
                 "when --input-range-ratio=0"
             )
+        if args.expected_input_lens_sha256:
+            parser.error(
+                "--expected-input-lens-sha256 is forbidden when --input-range-ratio=0"
+            )
     else:
         if args.observed_input_len is not None:
             parser.error(
@@ -846,11 +1043,20 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             parser.error(
                 "--observed-input-len-min cannot exceed --observed-input-len-max"
             )
+        if len(args.expected_input_lens_sha256) != args.blocks:
+            parser.error(
+                "nonzero --input-range-ratio requires exactly one "
+                "--expected-input-lens-sha256 per block"
+            )
     if 95.0 not in {float(item) for item in args.percentiles.split(",")}:
-        parser.error("--percentiles must include 95 for the TTFT/ITL release gates")
+        parser.error("--percentiles must include 95 for the TTFT/ITL measurement gates")
     server_env_names = [name for name, _ in args.server_env]
     if len(server_env_names) != len(set(server_env_names)):
         parser.error("--server-env names must not be repeated")
+    if len(args.runner_env) != len(set(args.runner_env)):
+        parser.error("--runner-env names must not be repeated")
+    if len(args.runner_env_prefix) != len(set(args.runner_env_prefix)):
+        parser.error("--runner-env-prefix values must not be repeated")
     if args.artifact_bytes > args.byte_budget:
         parser.error(
             f"--artifact-bytes ({args.artifact_bytes}) exceeds --byte-budget "
@@ -876,6 +1082,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
                 "num_speculative_tokens"
             )
     try:
+        _validate_recorded_prefix_caching(args.prefix_caching, args.server_arg)
         recorded_speculative_config = _recorded_speculative_config(args.server_arg)
         if args.speculative_mode == "on":
             if recorded_speculative_config is None:
@@ -907,10 +1114,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             inventory["sha256"],
             args,
         )
+        server_evidence = _validate_server_evidence(
+            args.server_evidence, args.server_evidence_sha256
+        )
     except BenchmarkError as exc:
         parser.error(str(exc))
     args.artifact_inventory_summary = inventory
     args.execution_manifest_summary = execution_manifest
+    args.server_evidence_summary = server_evidence
     return args
 
 
@@ -1129,31 +1340,83 @@ def redact_command(command: Sequence[str]) -> list[str]:
     return redacted
 
 
-def _git_state(commit_override: str | None) -> dict[str, Any]:
-    if commit_override:
-        return {"commit": commit_override, "dirty": None, "source": "argument"}
+def _git_state(
+    commit_override: str | None, *, allow_dirty: bool = False
+) -> dict[str, Any]:
+    if commit_override and not _GIT_COMMIT.fullmatch(commit_override):
+        raise BenchmarkError("explicit Gridbook commit is not exact 40/64 hex")
 
-    checkout = Path(__file__).resolve().parents[1]
-    try:
-        commit = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=checkout,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        dirty = bool(
-            subprocess.run(
-                ["git", "status", "--porcelain"],
+    detected_commit: str | None = None
+    detected_dirty: bool | None = None
+    unavailable_source = "unavailable-non-source-install"
+    source_file = Path(__file__).resolve()
+    checkout = source_file.parents[1]
+    expected_source = checkout / "gridbook" / "bench_serve.py"
+    if (checkout / "pyproject.toml").is_file() and expected_source.is_file():
+        unavailable_source = "unavailable"
+        try:
+            if not source_file.samefile(expected_source):
+                raise OSError("source file is not rooted at the candidate checkout")
+            top_level = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
                 cwd=checkout,
                 check=True,
                 capture_output=True,
                 text=True,
             ).stdout.strip()
+            if Path(top_level).resolve() != checkout:
+                unavailable_source = "unavailable-root-mismatch"
+            else:
+                detected_commit = subprocess.run(
+                    ["git", "rev-parse", "HEAD"],
+                    cwd=checkout,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+                detected_dirty = bool(
+                    subprocess.run(
+                        ["git", "status", "--porcelain"],
+                        cwd=checkout,
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    ).stdout.strip()
+                )
+                if not _GIT_COMMIT.fullmatch(detected_commit):
+                    detected_commit = None
+                    unavailable_source = "unavailable-invalid-commit"
+        except (OSError, subprocess.CalledProcessError):
+            detected_commit = None
+            detected_dirty = None
+
+    if detected_dirty and not allow_dirty:
+        raise BenchmarkError(
+            "Gridbook checkout is dirty; commit the changes or pass --allow-dirty "
+            "for research-only evidence"
         )
-    except (OSError, subprocess.CalledProcessError):
-        return {"commit": None, "dirty": None, "source": "unavailable"}
-    return {"commit": commit, "dirty": dirty, "source": "checkout"}
+    if commit_override:
+        return {
+            "commit": commit_override.lower(),
+            "dirty": detected_dirty,
+            "source": (
+                "argument+checkout" if detected_commit is not None else "argument"
+            ),
+            "release_eligible": not allow_dirty and detected_dirty is not True,
+        }
+    if detected_commit is None:
+        return {
+            "commit": None,
+            "dirty": detected_dirty,
+            "source": unavailable_source,
+            "release_eligible": False,
+        }
+    return {
+        "commit": detected_commit.lower(),
+        "dirty": detected_dirty,
+        "source": "checkout",
+        "release_eligible": not allow_dirty and not detected_dirty,
+    }
 
 
 def _package_version() -> str | None:
@@ -1210,11 +1473,16 @@ def collect_metadata(
             probe_errors[name] = _redact_text(f"{type(exc).__name__}: {exc}")
             return fallback
 
-    git = probe(
-        "git",
-        lambda: _git_state(args.git_commit),
-        {"commit": None, "dirty": None, "source": "probe-error"},
-    )
+    git = _git_state(args.git_commit, allow_dirty=args.allow_dirty)
+    client_runtime_probe = _vllm_version(args.vllm_executable)
+    if client_runtime_probe is None:
+        raise BenchmarkError(
+            "vLLM client version probe failed; --client-runtime-id cannot be verified"
+        )
+    if client_runtime_probe != args.client_runtime_id:
+        raise BenchmarkError(
+            "--client-runtime-id disagrees with the successful vLLM --version probe"
+        )
     runner_env = os.environ if env is None else env
     explicit_server_env = {
         key: "<redacted>" if _is_sensitive_key(key) else _redact_text(value)
@@ -1224,9 +1492,7 @@ def collect_metadata(
         "git": git,
         "software": {
             "gridbook_version": probe("gridbook_version", _package_version),
-            "runner_vllm_cli_probe": probe(
-                "vllm_cli_version", lambda: _vllm_version(args.vllm_executable)
-            ),
+            "runner_vllm_cli_probe": client_runtime_probe,
             "python": probe("python", platform.python_version),
             "platform": probe("platform", platform.platform),
             "machine": probe("machine", platform.machine),
@@ -1297,6 +1563,20 @@ def collect_metadata(
             "endpoint": _redact_text(args.endpoint),
             "served_model_name": _redact_text(args.served_model_name or args.model),
             "recorded_args": redact_command(args.server_arg),
+            "prefix_caching": args.prefix_caching,
+            "evidence": {
+                "scope": (
+                    "digest-bound external dispatch/startup attachments; the "
+                    "harness verifies bytes, not semantic backend claims"
+                ),
+                "attachments": [
+                    {
+                        **attachment,
+                        "reference": _redact_text(attachment["reference"]),
+                    }
+                    for attachment in args.server_evidence_summary
+                ],
+            },
         },
         "dispatch": {
             "runner_environment": {
@@ -1351,6 +1631,14 @@ def collect_metadata(
                 "declared-exact" if args.input_range_ratio == 0 else "declared-range"
             ),
             "accepted_input_length_bounds": list(_observed_input_length_bounds(args)),
+            "expected_input_lens_sha256_by_block": [
+                {
+                    "block": index + 1,
+                    "dataset_seed": args.dataset_seed + index,
+                    "sha256": digest,
+                }
+                for index, digest in enumerate(args.expected_input_lens_sha256)
+            ],
             "aggregate_reconciliation": {
                 "throughput": (
                     "duration and exact token/request totals; 1e-9 relative/absolute"
@@ -1435,15 +1723,68 @@ def _nonfinite_paths(value: Any, path: str = "$") -> list[str]:
 
 
 def _percentile_result_key(percentile: str, metric: str) -> str:
-    number = float(percentile)
-    label = str(int(number)) if number.is_integer() else f"{number:g}"
-    return f"p{label}_{metric}_ms"
+    return f"p{_percentile_label(percentile)}_{metric}_ms"
 
 
 def _observed_input_length_bounds(args: argparse.Namespace) -> tuple[int, int]:
     if args.input_range_ratio == 0:
         return args.observed_input_len, args.observed_input_len
     return args.observed_input_len_min, args.observed_input_len_max
+
+
+def _canonical_input_lens_sha256(input_lens: Sequence[int]) -> str:
+    canonical = json.dumps(
+        list(input_lens),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("ascii")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _validate_result_invocation(
+    result: Mapping[str, Any], args: argparse.Namespace
+) -> None:
+    mismatches: list[str] = []
+    exact_strings = {
+        "backend": args.backend,
+        "endpoint_type": args.backend,
+        "label": args.run_label,
+        "model_id": args.model,
+        "tokenizer_id": args.tokenizer or args.model,
+    }
+    for field, expected in exact_strings.items():
+        value = result.get(field)
+        if not isinstance(value, str) or value != expected:
+            mismatches.append(field)
+
+    exact_integers = {
+        "num_prompts": args.num_prompts,
+        "max_concurrency": args.max_concurrency,
+    }
+    for field, expected in exact_integers.items():
+        value = result.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+            mismatches.append(field)
+
+    request_rate = result.get("request_rate")
+    if args.request_rate == "inf":
+        request_rate_matches = request_rate == "inf"
+    else:
+        request_rate_matches = (
+            not isinstance(request_rate, bool)
+            and isinstance(request_rate, (int, float))
+            and math.isfinite(float(request_rate))
+            and float(request_rate) == float(args.request_rate)
+        )
+    if not request_rate_matches:
+        mismatches.append("request_rate")
+
+    if mismatches:
+        raise BenchmarkError(
+            "vLLM result invocation fields disagree with the pinned client command: "
+            + ", ".join(mismatches)
+        )
 
 
 def _numpy_linear_percentile(samples: Sequence[float], percentile: float) -> float:
@@ -1471,7 +1812,7 @@ def _sample_aggregates(
         "std": statistics.pstdev(samples) if samples else 0.0,
     }
     for percentile in requested_percentiles:
-        aggregates[f"p{float(percentile):g}"] = _numpy_linear_percentile(
+        aggregates[f"p{_percentile_label(percentile)}"] = _numpy_linear_percentile(
             samples, float(percentile)
         )
     return aggregates
@@ -1621,12 +1962,15 @@ def _validate_speculative_result(
         )
 
 
-def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None:
+def validate_result(
+    result: Mapping[str, Any], args: argparse.Namespace, *, block_index: int = 0
+) -> None:
     nonfinite = _nonfinite_paths(result)
     if nonfinite:
         raise BenchmarkError(
             "vLLM result contains NaN/Infinity at: " + ", ".join(nonfinite[:10])
         )
+    _validate_result_invocation(result, args)
     _validate_speculative_result(result, args)
 
     duration = _number(result, "duration")
@@ -1724,6 +2068,19 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
         raise BenchmarkError(
             f"{mode} block has unexpected input_lens at request index: {preview}"
         )
+    observed_input_lens_digest = _canonical_input_lens_sha256(input_lens)
+    if args.input_range_ratio != 0:
+        try:
+            expected_input_lens_digest = args.expected_input_lens_sha256[block_index]
+        except IndexError as exc:
+            raise BenchmarkError(
+                f"no expected input_lens digest is bound to block {block_index + 1}"
+            ) from exc
+        if observed_input_lens_digest != expected_input_lens_digest:
+            raise BenchmarkError(
+                f"block {block_index + 1} input_lens SHA-256 disagrees with the "
+                "declared canonical vector digest"
+            )
     total_input = _exact_nonnegative_int(result, "total_input_tokens")
     observed_total_input = sum(input_lens)
     if total_input != observed_total_input:
@@ -2003,12 +2360,12 @@ def _sanitize_result_for_report(result: Mapping[str, Any]) -> dict[str, Any]:
             "reason": "arbitrary model output is not performance evidence",
         }
 
-    errors = sanitized.get("errors")
-    if isinstance(errors, list):
-        sanitized["errors"] = [
-            value if value is None or value == "" else "<redacted-server-error>"
-            for value in errors
-        ]
+    if "errors" in sanitized:
+        errors = sanitized.pop("errors")
+        sanitized["errors_omitted"] = {
+            "count": len(errors) if isinstance(errors, list) else None,
+            "reason": "arbitrary server error text is not performance evidence",
+        }
 
     return _json_safe(_redact_structured(sanitized))
 
@@ -2033,7 +2390,12 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
     report: dict[str, Any] = {
         "schema": SCHEMA,
         "status": "running",
-        "run_label": args.run_label,
+        "run_label": _redact_text(args.run_label),
+        "evidence_scope": "single-arm-serving-measurement",
+        "measurement_valid": False,
+        "parity_acceptance": False,
+        "release_acceptance": False,
+        "release_eligible": False,
         "started_at": started_at,
         "finished_at": None,
         "duration_s": None,
@@ -2073,6 +2435,12 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                     "returncode": None,
                     "raw_result": None,
                     "validation_error": None,
+                    "expected_input_lens_sha256": (
+                        args.expected_input_lens_sha256[block_index]
+                        if args.input_range_ratio != 0
+                        else None
+                    ),
+                    "observed_input_lens_sha256": None,
                 }
                 report["blocks"].append(block)
                 # A durable checkpoint makes the in-flight command available
@@ -2096,7 +2464,10 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                         result = _load_result(result_dir / filename)
                         block["raw_result"] = _sanitize_result_for_report(result)
                         _atomic_write_json(output_path, report)
-                        validate_result(result, args)
+                        validate_result(result, args, block_index=block_index)
+                        block["observed_input_lens_sha256"] = (
+                            _canonical_input_lens_sha256(result["input_lens"])
+                        )
                     except BenchmarkError as exc:
                         block["validation_error"] = _redact_text(str(exc))
                         raise
@@ -2109,6 +2480,8 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                     block["wall_duration_s"] = time.monotonic() - block_clock
         report["summary"] = summarize_blocks(report["blocks"])
         report["status"] = "success"
+        report["measurement_valid"] = True
+        report["release_eligible"] = report["metadata"]["git"]["release_eligible"]
     except BaseException as exc:
         report["status"] = "failed"
         report["error"] = _redact_text(f"{type(exc).__name__}: {exc}")

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import errno
+import hashlib
 import importlib.metadata
 import json
 import math
@@ -25,15 +26,20 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-
-SCHEMA = "gridbook.vllm-bench-serve.v1"
+SCHEMA = "gridbook.vllm-bench-serve.v2"
+ARTIFACT_INVENTORY_SCHEMA = "gridbook.artifact-inventory.v1"
+PRISMAQUANT_ARTIFACT_INVENTORY_SCHEMA = "prismaquant.cb_export_artifact_inventory.v1"
+EXECUTION_MANIFEST_SCHEMA = "gridbook.execution-manifest.v1"
 STREAMING_METRICS = "ttft,tpot,itl,e2el"
 DEFAULT_PERCENTILES = "50,90,95,99"
+MIN_WARMUPS = 4
+MIN_BLOCKS = 3
 
 # These are stable vLLM result names.  Percentile keys are added dynamically
 # below because the selected percentiles are configurable.
@@ -65,9 +71,7 @@ REQUIRED_THROUGHPUT_RESULTS = (
     "output_throughput",
     "total_token_throughput",
 )
-_PERCENTILE_RESULT = re.compile(
-    r"^p(?:\d+(?:\.\d+)?)_(?:ttft|tpot|itl|e2el)_ms$"
-)
+_PERCENTILE_RESULT = re.compile(r"^p(?:\d+(?:\.\d+)?)_(?:ttft|tpot|itl|e2el)_ms$")
 _SENSITIVE_SEGMENTS = {
     "AUTH",
     "AUTHORIZATION",
@@ -75,6 +79,7 @@ _SENSITIVE_SEGMENTS = {
     "COOKIE",
     "CREDENTIAL",
     "CREDENTIALS",
+    "HEADER",
     "KEY",
     "PASSWORD",
     "PASSWD",
@@ -85,12 +90,36 @@ _SENSITIVE_SEGMENTS = {
     "TOKEN",
 }
 _SENSITIVE_COMPOUNDS = ("APIKEY", "AUTHTOKEN", "ACCESSTOKEN", "REFRESHTOKEN")
+_SENSITIVE_OPTIONS = {
+    "-H",
+    "-b",
+    "--cookie",
+    "--extra-header",
+    "--extra-headers",
+    "--header",
+    "--headers",
+}
 _ASSIGNMENT = re.compile(r"(\b[-\w.]+\b\s*(?:=|:)\s*)([^\s,;]+)")
 _OPTION_VALUE = re.compile(r"((?:^|\s)(--?[-\w.]+)\s+)([^\s]+)")
 _AUTH_HEADER = re.compile(
     r"(?i)((?:proxy-)?authorization\s*:\s*)([^\s,;]+)(?:\s+([^\s,;]+))?"
 )
-_URL = re.compile(r"https?://[^\s]+", re.I)
+_SENSITIVE_HEADER = re.compile(
+    r"(?i)((?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key|api-key)"
+    r"\s*:\s*)(.*)$"
+)
+_URL = re.compile(r"https?://[^\s]+", re.IGNORECASE)
+_SHA256 = re.compile(r"^[0-9a-fA-F]{64}$")
+
+_EXECUTION_ASSIGNMENT_FIELDS = (
+    "unit",
+    "format_rung",
+    "serialized_layout",
+    "scale_coding",
+    "quant_contract",
+    "kernel_backend",
+    "fallback_state",
+)
 
 
 class BenchmarkError(RuntimeError):
@@ -98,8 +127,10 @@ class BenchmarkError(RuntimeError):
 
 
 def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
-        "+00:00", "Z"
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
     )
 
 
@@ -121,6 +152,283 @@ def _nonempty(value: str) -> str:
     if not value.strip():
         raise argparse.ArgumentTypeError("must not be empty")
     return value
+
+
+def _sha256(value: str) -> str:
+    if not _SHA256.fullmatch(value):
+        raise argparse.ArgumentTypeError("must be a 64-character SHA-256 hex digest")
+    return value.lower()
+
+
+def _strict_json_loads(value: str | bytes) -> Any:
+    def reject_constant(constant: str) -> None:
+        raise ValueError(f"non-finite JSON number {constant} is forbidden")
+
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, child in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON object key {key!r}")
+            result[key] = child
+        return result
+
+    return json.loads(
+        value,
+        parse_constant=reject_constant,
+        object_pairs_hook=unique_object,
+    )
+
+
+def _json_object(value: str) -> dict[str, Any]:
+    try:
+        parsed = _strict_json_loads(value)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("must be a valid JSON object") from exc
+    if not isinstance(parsed, dict) or not parsed:
+        raise argparse.ArgumentTypeError("must be a non-empty JSON object")
+    return parsed
+
+
+def _read_hashed_json(
+    path: Path, expected_digest: str, label: str
+) -> tuple[dict[str, Any], str]:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise BenchmarkError(f"cannot read {label} {path}: {exc}") from exc
+    actual_digest = hashlib.sha256(raw).hexdigest()
+    if actual_digest != expected_digest:
+        raise BenchmarkError(
+            f"{label} SHA-256 mismatch: declared={expected_digest}, "
+            f"actual={actual_digest}"
+        )
+    try:
+        payload = _strict_json_loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise BenchmarkError(f"{label} is not valid UTF-8 JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise BenchmarkError(f"{label} must contain one JSON object")
+    return payload, actual_digest
+
+
+def _canonical_inventory_path(name: Any, where: str) -> str:
+    if not isinstance(name, str) or not name.strip() or "\\" in name:
+        raise BenchmarkError(f"{where} must be a POSIX relative path")
+    path = PurePosixPath(name)
+    if (
+        path.is_absolute()
+        or str(path) != name
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise BenchmarkError(f"{where} is not canonical: {name!r}")
+    return name
+
+
+def _inventory_size(value: Any, where: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BenchmarkError(f"{where} must be a non-negative integer")
+    return value
+
+
+def _extract_prismaquant_inventory(
+    document: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    if document.get("schema") == PRISMAQUANT_ARTIFACT_INVENTORY_SCHEMA:
+        return document
+    provenance = document.get("provenance")
+    if not isinstance(provenance, Mapping):
+        return None
+    inventory = provenance.get("artifact_inventory")
+    if (
+        isinstance(inventory, Mapping)
+        and inventory.get("schema") == PRISMAQUANT_ARTIFACT_INVENTORY_SCHEMA
+    ):
+        return inventory
+    return None
+
+
+def _validate_artifact_inventory(path: Path, expected_digest: str) -> dict[str, Any]:
+    document, digest = _read_hashed_json(path, expected_digest, "artifact inventory")
+    normalized_files: list[dict[str, Any]] = []
+
+    if document.get("schema") == ARTIFACT_INVENTORY_SCHEMA:
+        files = document.get("files")
+        if not isinstance(files, list) or not files:
+            raise BenchmarkError("artifact inventory files must be a non-empty array")
+        seen: set[str] = set()
+        for index, entry in enumerate(files):
+            if not isinstance(entry, Mapping):
+                raise BenchmarkError(
+                    f"artifact inventory files[{index}] must be an object"
+                )
+            name = _canonical_inventory_path(
+                entry.get("path"), f"artifact inventory files[{index}].path"
+            )
+            if name in seen:
+                raise BenchmarkError(
+                    f"artifact inventory contains duplicate path {name!r}"
+                )
+            seen.add(name)
+            size = _inventory_size(
+                entry.get("bytes"), f"artifact inventory files[{index}].bytes"
+            )
+            file_digest = entry.get("sha256")
+            if not isinstance(file_digest, str) or not _SHA256.fullmatch(file_digest):
+                raise BenchmarkError(
+                    f"artifact inventory files[{index}].sha256 must be a SHA-256 digest"
+                )
+            normalized_files.append(
+                {"path": name, "bytes": size, "sha256": file_digest.lower()}
+            )
+        declared_total = _inventory_size(
+            document.get("total_bytes"), "artifact inventory total_bytes"
+        )
+        schema = ARTIFACT_INVENTORY_SCHEMA
+        source = "standalone-gridbook-inventory"
+    else:
+        inventory = _extract_prismaquant_inventory(document)
+        if inventory is None:
+            raise BenchmarkError(
+                "artifact inventory must be a gridbook.artifact-inventory.v1 "
+                "object, a prismaquant.cb_export_artifact_inventory.v1 object, "
+                "or a quant_config containing that PrismaQuant inventory"
+            )
+        if inventory.get("scope") != "all_regular_files_recursive":
+            raise BenchmarkError(
+                "PrismaQuant artifact inventory scope must be "
+                "all_regular_files_recursive"
+            )
+        file_bytes = inventory.get("file_bytes")
+        if not isinstance(file_bytes, Mapping) or not file_bytes:
+            raise BenchmarkError(
+                "PrismaQuant artifact inventory file_bytes must be a non-empty object"
+            )
+        for name_value, size_value in file_bytes.items():
+            name = _canonical_inventory_path(
+                name_value, "PrismaQuant artifact inventory file_bytes key"
+            )
+            size = _inventory_size(
+                size_value, f"PrismaQuant artifact inventory file_bytes[{name!r}]"
+            )
+            normalized_files.append({"path": name, "bytes": size})
+        normalized_files.sort(key=lambda entry: entry["path"])
+        declared_total = _inventory_size(
+            inventory.get("export_directory_bytes"),
+            "PrismaQuant artifact inventory export_directory_bytes",
+        )
+        schema = PRISMAQUANT_ARTIFACT_INVENTORY_SCHEMA
+        source = (
+            "standalone-prismaquant-inventory"
+            if document is inventory
+            else "quant-config-provenance"
+        )
+
+    computed_total = sum(entry["bytes"] for entry in normalized_files)
+    if declared_total != computed_total:
+        raise BenchmarkError(
+            "artifact inventory total disagrees with its file entries: "
+            f"declared={declared_total}, computed={computed_total}"
+        )
+    return {
+        "reference": str(path),
+        "sha256": digest,
+        "schema": schema,
+        "source": source,
+        "file_count": len(normalized_files),
+        "computed_total_bytes": computed_total,
+        "files": normalized_files,
+    }
+
+
+def _validate_execution_manifest(
+    path: Path,
+    expected_digest: str,
+    artifact_inventory_digest: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    payload, digest = _read_hashed_json(path, expected_digest, "execution manifest")
+    if payload.get("schema") != EXECUTION_MANIFEST_SCHEMA:
+        raise BenchmarkError(
+            "execution manifest schema must be " + EXECUTION_MANIFEST_SCHEMA
+        )
+    if payload.get("artifact_inventory_sha256") != artifact_inventory_digest:
+        raise BenchmarkError(
+            "execution manifest is not bound to the selected artifact inventory"
+        )
+    if payload.get("coverage") != "all_serving_units":
+        raise BenchmarkError(
+            "execution manifest coverage must declare all_serving_units"
+        )
+    if payload.get("tensor_parallel_size") != args.tensor_parallel_size:
+        raise BenchmarkError(
+            "execution manifest tensor_parallel_size disagrees with the command"
+        )
+    assignments = payload.get("assignments")
+    if not isinstance(assignments, list) or not assignments:
+        raise BenchmarkError("execution manifest assignments must be non-empty")
+
+    units: set[str] = set()
+    values: dict[str, set[str]] = {
+        field: set() for field in _EXECUTION_ASSIGNMENT_FIELDS if field != "unit"
+    }
+    for index, assignment in enumerate(assignments):
+        if not isinstance(assignment, Mapping):
+            raise BenchmarkError(
+                f"execution manifest assignments[{index}] must be an object"
+            )
+        for field in _EXECUTION_ASSIGNMENT_FIELDS:
+            value = assignment.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise BenchmarkError(
+                    f"execution manifest assignments[{index}].{field} must be non-empty"
+                )
+            if field == "unit":
+                if value in units:
+                    raise BenchmarkError(
+                        f"execution manifest contains duplicate unit {value!r}"
+                    )
+                units.add(value)
+            else:
+                values[field].add(value)
+
+    command_fields = {
+        "format_rung": args.format_rung,
+        "serialized_layout": args.serialized_layout,
+        "scale_coding": args.scale_coding,
+        "quant_contract": args.quant_contract,
+        "kernel_backend": args.kernel_backend,
+        "fallback_state": args.fallback_state,
+    }
+    for field, command_value in command_fields.items():
+        observed = values[field]
+        if len(observed) == 1:
+            only_value = next(iter(observed))
+            if command_value != only_value:
+                raise BenchmarkError(
+                    f"--{field.replace('_', '-')}={command_value!r} disagrees with "
+                    f"the uniform execution manifest value {only_value!r}"
+                )
+        elif command_value.lower() != "mixed":
+            raise BenchmarkError(
+                f"--{field.replace('_', '-')} must be 'mixed' because the execution "
+                f"manifest contains {len(observed)} values"
+            )
+
+    return {
+        "reference": str(path),
+        "sha256": digest,
+        "schema": EXECUTION_MANIFEST_SCHEMA,
+        "artifact_inventory_sha256": artifact_inventory_digest,
+        "coverage": "all_serving_units",
+        "assignment_count": len(assignments),
+        "assignments": [
+            {field: assignment[field] for field in _EXECUTION_ASSIGNMENT_FIELDS}
+            for assignment in assignments
+        ],
+        "distinct_values": {
+            field: sorted(field_values) for field, field_values in values.items()
+        },
+    }
 
 
 def _input_range_ratio(value: str) -> float:
@@ -166,6 +474,40 @@ def _server_environment(value: str) -> tuple[str, str]:
     return name, setting
 
 
+def _recorded_speculative_config(server_args: Sequence[str]) -> dict[str, Any] | None:
+    raw_configs: list[str] = []
+    index = 0
+    while index < len(server_args):
+        argument = server_args[index]
+        if argument == "--speculative-config":
+            if index + 1 >= len(server_args):
+                raise BenchmarkError("recorded --speculative-config has no JSON value")
+            raw_configs.append(server_args[index + 1])
+            index += 2
+            continue
+        match = re.fullmatch(r"--speculative-config(?:=|\s+)(.+)", argument, re.DOTALL)
+        if match:
+            raw_configs.append(match.group(1))
+        index += 1
+    if len(raw_configs) > 1:
+        raise BenchmarkError(
+            "recorded server args contain multiple speculative configs"
+        )
+    if not raw_configs:
+        return None
+    try:
+        config = _strict_json_loads(raw_configs[0])
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise BenchmarkError(
+            "recorded server --speculative-config is not strict JSON"
+        ) from exc
+    if not isinstance(config, dict) or not config:
+        raise BenchmarkError(
+            "recorded server --speculative-config must be a non-empty JSON object"
+        )
+    return config
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="gridbook-bench-serve",
@@ -175,7 +517,9 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     server = parser.add_argument_group("online server")
-    server.add_argument("--base-url", required=True, help="OpenAI-compatible base URL")
+    server.add_argument(
+        "--base-url", type=_nonempty, required=True, help="OpenAI-compatible base URL"
+    )
     server.add_argument(
         "--backend",
         default="openai",
@@ -187,6 +531,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     server.add_argument(
         "--served-model-name",
+        type=_nonempty,
         help="model name sent to the API (defaults to --model)",
     )
     server.add_argument(
@@ -210,29 +555,35 @@ def build_parser() -> argparse.ArgumentParser:
     artifact = parser.add_argument_group("artifact identity")
     artifact.add_argument(
         "--model",
+        type=_nonempty,
         required=True,
         help="model/tokenizer name understood by vLLM bench serve",
     )
     artifact.add_argument(
         "--tokenizer",
+        type=_nonempty,
         help="tokenizer name or revision (defaults to --model)",
     )
     artifact.add_argument(
         "--model-id",
+        type=_nonempty,
         required=True,
         help="exact served artifact identifier/revision recorded in the report",
     )
     artifact.add_argument(
         "--image-id",
+        type=_nonempty,
         required=True,
         help="exact serving image tag or digest recorded in the report",
     )
     artifact.add_argument(
         "--git-commit",
+        type=_nonempty,
         help="Gridbook commit override; otherwise detected from this checkout",
     )
     artifact.add_argument(
         "--run-label",
+        type=_nonempty,
         required=True,
         help="short arm/workload label, for example gridbook-27b-decode",
     )
@@ -241,6 +592,31 @@ def build_parser() -> argparse.ArgumentParser:
         type=_positive_int,
         required=True,
         help="exact whole served-artifact bytes, excluding caches",
+    )
+    artifact.add_argument(
+        "--artifact-inventory",
+        type=Path,
+        required=True,
+        help=(
+            "canonical standalone inventory or PrismaQuant quant_config.json "
+            "whose file-byte sum must equal --artifact-bytes"
+        ),
+    )
+    artifact.add_argument(
+        "--artifact-inventory-sha256",
+        type=_sha256,
+        required=True,
+        help="SHA-256 of the exact artifact-inventory JSON bytes",
+    )
+    artifact.add_argument(
+        "--payload-bytes",
+        type=_positive_int,
+        help="optional model-payload bytes (a diagnostic, never the budget gate)",
+    )
+    artifact.add_argument(
+        "--payload-scope",
+        type=_nonempty,
+        help="required explicit definition when --payload-bytes is supplied",
     )
     artifact.add_argument(
         "--byte-budget",
@@ -267,6 +643,37 @@ def build_parser() -> argparse.ArgumentParser:
     identity.add_argument("--gpu-id", type=_nonempty, required=True)
     identity.add_argument("--driver-version", type=_nonempty, required=True)
     identity.add_argument("--cuda-version", type=_nonempty, required=True)
+    identity.add_argument(
+        "--execution-manifest",
+        type=Path,
+        required=True,
+        help=(
+            "gridbook.execution-manifest.v1 JSON enumerating uniform or mixed "
+            "serving-unit assignments"
+        ),
+    )
+    identity.add_argument(
+        "--execution-manifest-sha256",
+        type=_sha256,
+        required=True,
+        help="SHA-256 of the exact execution-manifest JSON bytes",
+    )
+
+    speculation = parser.add_argument_group("speculative decoding")
+    speculation.add_argument(
+        "--speculative-mode",
+        choices=("off", "on"),
+        required=True,
+        help="whether this workload cell executes speculative decoding",
+    )
+    speculation.add_argument(
+        "--speculative-config",
+        type=_json_object,
+        help=(
+            "non-empty JSON object describing the exact server speculation "
+            "configuration; required when --speculative-mode=on"
+        ),
+    )
 
     workload = parser.add_argument_group("fixed workload")
     workload.add_argument("--input-len", type=_positive_int, required=True)
@@ -277,19 +684,17 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="measured prompts in each block",
     )
-    workload.add_argument(
-        "--max-concurrency", type=_positive_int, required=True
-    )
+    workload.add_argument("--max-concurrency", type=_positive_int, required=True)
     workload.add_argument(
         "--warmups",
         type=_nonnegative_int,
-        default=2,
-        help="unmeasured warmup prompts before each block (default: 2)",
+        default=MIN_WARMUPS,
+        help=f"unmeasured warmup prompts before each block (minimum: {MIN_WARMUPS})",
     )
     workload.add_argument(
         "--blocks",
         type=_positive_int,
-        default=3,
+        default=MIN_BLOCKS,
         help=(
             "independent client blocks; distinct deterministic dataset seed per "
             "block (default: 3)"
@@ -356,9 +761,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     output = parser.add_argument_group("runner and output")
-    output.add_argument(
-        "--vllm-executable", default="vllm", help="vLLM CLI executable"
-    )
+    output.add_argument("--vllm-executable", default="vllm", help="vLLM CLI executable")
     output.add_argument(
         "--output", type=Path, required=True, help="structured JSON report path"
     )
@@ -373,6 +776,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.max_concurrency > args.num_prompts:
         parser.error("--max-concurrency cannot exceed --num-prompts")
+    if args.warmups < MIN_WARMUPS:
+        parser.error(f"--warmups must be at least {MIN_WARMUPS}")
+    if args.blocks < MIN_BLOCKS:
+        parser.error(f"--blocks must be at least {MIN_BLOCKS}")
+    if 95.0 not in {float(item) for item in args.percentiles.split(",")}:
+        parser.error("--percentiles must include 95 for the TTFT/ITL release gates")
     server_env_names = [name for name, _ in args.server_env]
     if len(server_env_names) != len(set(server_env_names)):
         parser.error("--server-env names must not be repeated")
@@ -381,6 +790,61 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             f"--artifact-bytes ({args.artifact_bytes}) exceeds --byte-budget "
             f"({args.byte_budget})"
         )
+    if (args.payload_bytes is None) != (args.payload_scope is None):
+        parser.error("--payload-bytes and --payload-scope must be supplied together")
+    if args.payload_bytes is not None and args.payload_bytes > args.artifact_bytes:
+        parser.error("--payload-bytes cannot exceed --artifact-bytes")
+    if args.speculative_mode == "on" and args.speculative_config is None:
+        parser.error("--speculative-config is required when --speculative-mode=on")
+    if args.speculative_mode == "off" and args.speculative_config is not None:
+        parser.error("--speculative-config is forbidden when --speculative-mode=off")
+    if args.speculative_mode == "on":
+        speculative_tokens = args.speculative_config.get("num_speculative_tokens")
+        if (
+            isinstance(speculative_tokens, bool)
+            or not isinstance(speculative_tokens, int)
+            or speculative_tokens <= 0
+        ):
+            parser.error(
+                "--speculative-config must contain positive integer "
+                "num_speculative_tokens"
+            )
+    try:
+        recorded_speculative_config = _recorded_speculative_config(args.server_arg)
+        if args.speculative_mode == "on":
+            if recorded_speculative_config is None:
+                raise BenchmarkError(
+                    "--speculative-mode=on requires the exact --speculative-config "
+                    "in recorded --server-arg metadata"
+                )
+            if recorded_speculative_config != args.speculative_config:
+                raise BenchmarkError(
+                    "structured --speculative-config disagrees with recorded server args"
+                )
+        elif recorded_speculative_config is not None:
+            raise BenchmarkError(
+                "--speculative-mode=off conflicts with a recorded server "
+                "--speculative-config"
+            )
+        inventory = _validate_artifact_inventory(
+            args.artifact_inventory, args.artifact_inventory_sha256
+        )
+        if inventory["computed_total_bytes"] != args.artifact_bytes:
+            raise BenchmarkError(
+                "--artifact-bytes disagrees with the canonical inventory sum: "
+                f"declared={args.artifact_bytes}, "
+                f"computed={inventory['computed_total_bytes']}"
+            )
+        execution_manifest = _validate_execution_manifest(
+            args.execution_manifest,
+            args.execution_manifest_sha256,
+            inventory["sha256"],
+            args,
+        )
+    except BenchmarkError as exc:
+        parser.error(str(exc))
+    args.artifact_inventory_summary = inventory
+    args.execution_manifest_summary = execution_manifest
     return args
 
 
@@ -486,12 +950,65 @@ def _redact_url(value: str) -> str:
             ],
             doseq=True,
         )
-        return urlunsplit((parsed.scheme, netloc, parsed.path, query, parsed.fragment))
+        fragment = parsed.fragment
+        if fragment:
+            fragment_pairs = parse_qsl(fragment, keep_blank_values=True)
+            if "=" in fragment and fragment_pairs:
+                fragment = urlencode(
+                    [
+                        (
+                            key,
+                            "<redacted>" if _is_sensitive_key(key) else setting,
+                        )
+                        for key, setting in fragment_pairs
+                    ],
+                    doseq=True,
+                )
+            elif _is_sensitive_key(fragment):
+                fragment = "<redacted>"
+        return urlunsplit((parsed.scheme, netloc, parsed.path, query, fragment))
     except (TypeError, ValueError):
         return "<redacted-invalid-url>"
 
 
-def _redact_text(value: str) -> str:
+def _redact_structured(value: Any, *, parent_key: str | None = None) -> Any:
+    if parent_key is not None and _is_sensitive_key(parent_key):
+        return "<redacted>"
+    if isinstance(value, Mapping):
+        return {
+            str(key): _redact_structured(child, parent_key=str(key))
+            for key, child in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact_structured(child) for child in value]
+    if isinstance(value, str):
+        return _redact_text(value)
+    return value
+
+
+def _redact_embedded_json(value: str) -> str | None:
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(value):
+        if character not in "[{":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(value[index:])
+        except json.JSONDecodeError:
+            continue
+        if value[index + end :].strip():
+            continue
+        redacted = json.dumps(
+            _redact_structured(parsed), separators=(",", ":"), sort_keys=True
+        )
+        return _redact_plain_text(value[:index]) + redacted
+    return None
+
+
+def _is_sensitive_option(value: str) -> bool:
+    return value in _SENSITIVE_OPTIONS or _is_sensitive_key(value)
+
+
+def _redact_plain_text(value: str) -> str:
     def redact_url(match: re.Match[str]) -> str:
         return _redact_url(match.group(0))
 
@@ -505,16 +1022,43 @@ def _redact_text(value: str) -> str:
             "<redacted>" if _is_sensitive_key(match.group(2)) else match.group(3)
         )
 
-    def redact_authorization(match: re.Match[str]) -> str:
-        scheme_or_value = match.group(2)
-        if match.group(3) is None:
-            return match.group(1) + "<redacted>"
-        return match.group(1) + scheme_or_value + " <redacted>"
-
     redacted = _URL.sub(redact_url, str(value))
+    redacted = _SENSITIVE_HEADER.sub(
+        lambda match: match.group(1) + "<redacted>", redacted
+    )
     redacted = _ASSIGNMENT.sub(redact_assignment, redacted)
     redacted = _OPTION_VALUE.sub(redact_option, redacted)
-    return _AUTH_HEADER.sub(redact_authorization, redacted)
+    return _AUTH_HEADER.sub(lambda match: match.group(1) + "<redacted>", redacted)
+
+
+def _redact_text(value: str) -> str:
+    text = str(value)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, (dict, list)):
+        return json.dumps(
+            _redact_structured(parsed), separators=(",", ":"), sort_keys=True
+        )
+
+    option_equals = re.match(r"^(--?[-\w.]+)=(.*)$", text, re.DOTALL)
+    if option_equals:
+        option, setting = option_equals.groups()
+        if _is_sensitive_option(option):
+            return option + "=<redacted>"
+        return option + "=" + _redact_text(setting)
+    option_space = re.match(r"^(--?[-\w.]+)(\s+)(.*)$", text, re.DOTALL)
+    if option_space:
+        option, spacing, setting = option_space.groups()
+        if _is_sensitive_option(option):
+            return option + spacing + "<redacted>"
+        return option + spacing + _redact_text(setting)
+
+    embedded = _redact_embedded_json(text)
+    if embedded is not None:
+        return embedded
+    return _redact_plain_text(text)
 
 
 def redact_command(command: Sequence[str]) -> list[str]:
@@ -528,7 +1072,7 @@ def redact_command(command: Sequence[str]) -> list[str]:
         text = _redact_text(str(item))
         redacted.append(text)
         if str(item).startswith("-") and "=" not in str(item):
-            hide_next = _is_sensitive_key(str(item))
+            hide_next = _is_sensitive_option(str(item))
     return redacted
 
 
@@ -640,10 +1184,29 @@ def collect_metadata(
             "model_id": _redact_text(args.model_id),
             "benchmark_model": _redact_text(args.model),
             "tokenizer": _redact_text(args.tokenizer or args.model),
-            "whole_served_artifact_bytes": args.artifact_bytes,
+            "whole_served_artifact_bytes": args.artifact_inventory_summary[
+                "computed_total_bytes"
+            ],
             "byte_budget_bytes": args.byte_budget,
             "budget_headroom_bytes": args.byte_budget - args.artifact_bytes,
             "within_byte_budget": args.artifact_bytes <= args.byte_budget,
+            "payload": (
+                {
+                    "bytes": args.payload_bytes,
+                    "scope": _redact_text(args.payload_scope),
+                    "is_budget_gate": False,
+                }
+                if args.payload_bytes is not None
+                else None
+            ),
+            "inventory": _redact_structured(
+                {
+                    **args.artifact_inventory_summary,
+                    "reference": _redact_text(
+                        args.artifact_inventory_summary["reference"]
+                    ),
+                }
+            ),
             "byte_scope": (
                 "shipped model shards, configs, tokenizer, and sidecars; "
                 "runtime/download/JIT caches excluded"
@@ -659,6 +1222,14 @@ def collect_metadata(
             "kernel_backend": _redact_text(args.kernel_backend),
             "tensor_parallel_size": args.tensor_parallel_size,
             "fallback_state": _redact_text(args.fallback_state),
+            "manifest": _redact_structured(
+                {
+                    **args.execution_manifest_summary,
+                    "reference": _redact_text(
+                        args.execution_manifest_summary["reference"]
+                    ),
+                }
+            ),
             "client_runtime_id": _redact_text(args.client_runtime_id),
             "server_runtime_id": _redact_text(args.server_runtime_id),
             "hardware": {
@@ -671,9 +1242,7 @@ def collect_metadata(
             "base_url": _redact_url(args.base_url.rstrip("/")),
             "backend": args.backend,
             "endpoint": _redact_text(args.endpoint),
-            "served_model_name": _redact_text(
-                args.served_model_name or args.model
-            ),
+            "served_model_name": _redact_text(args.served_model_name or args.model),
             "recorded_args": redact_command(args.server_arg),
         },
         "dispatch": {
@@ -720,13 +1289,21 @@ def collect_metadata(
                 _input_length_bounds(args.input_len, args.input_range_ratio)
             ),
             "aggregate_reconciliation": {
-                "ttft_itl": "mean/median vs detailed arrays; 0.01 ms or 1e-5 relative",
+                "throughput": (
+                    "duration and exact token/request totals; 1e-9 relative/absolute"
+                ),
+                "ttft_itl": (
+                    "mean/median/population-std/all requested percentiles vs "
+                    "detailed arrays; NumPy-linear percentile semantics; "
+                    "1e-6 ms or 1e-9 relative"
+                ),
                 "e2el": (
-                    "mean/median vs TTFT+ITL; 5 ms or 0.5% terminal-SSE allowance"
+                    "all aggregates vs per-request TTFT+sum(ITL); 5 ms or 0.5% "
+                    "terminal-SSE allowance"
                 ),
                 "tpot": (
-                    "mean vs (mean_e2el-mean_ttft)/(fixed_output_len-1); "
-                    "0.05 ms or 0.5%"
+                    "all aggregates vs per-request sum(ITL)/(fixed_output_len-1); "
+                    "terminal-SSE allowance divided by output_len-1"
                 ),
                 "itl_cardinality": (
                     "not equated to output tokens because one SSE chunk may carry "
@@ -737,6 +1314,15 @@ def collect_metadata(
             "streaming": True,
             "metrics": STREAMING_METRICS.split(","),
             "percentiles": [float(item) for item in args.percentiles.split(",")],
+            "speculative_decoding": {
+                "mode": args.speculative_mode,
+                "config": _redact_structured(args.speculative_config),
+                "result_contract": (
+                    "all vLLM spec_decode_* fields required and reconciled"
+                    if args.speculative_mode == "on"
+                    else "spec_decode_* fields forbidden"
+                ),
+            },
         },
     }
     metadata["collection_errors"] = probe_errors
@@ -803,26 +1389,64 @@ def _input_length_bounds(input_len: int, ratio: float) -> tuple[int, int]:
     return 1, math.ceil(input_len * (1 + ratio))
 
 
-def _aggregate_tolerance_ms(metric: str, expected_ms: float) -> float:
+def _numpy_linear_percentile(samples: Sequence[float], percentile: float) -> float:
+    """NumPy's default percentile method without adding a NumPy dependency."""
+
+    if not samples:
+        return 0.0
+    ordered = sorted(float(value) for value in samples)
+    position = (len(ordered) - 1) * percentile / 100.0
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _sample_aggregates(
+    samples_ms: Sequence[float], requested_percentiles: Sequence[str]
+) -> dict[str, float]:
+    samples = [float(value) for value in samples_ms]
+    aggregates = {
+        "mean": statistics.fmean(samples) if samples else 0.0,
+        "median": statistics.median(samples) if samples else 0.0,
+        "std": statistics.pstdev(samples) if samples else 0.0,
+    }
+    for percentile in requested_percentiles:
+        aggregates[f"p{float(percentile):g}"] = _numpy_linear_percentile(
+            samples, float(percentile)
+        )
+    return aggregates
+
+
+def _aggregate_tolerance_ms(metric: str, expected_ms: float, output_len: int) -> float:
     if metric == "e2el":
         # vLLM's request latency extends through the terminal SSE event, while
         # detailed ITLs stop at the final token-bearing chunk.  Permit that
         # small transport tail, but not a fabricated decode-length gap.
         return max(5.0, abs(expected_ms) * 0.005)
-    return max(0.01, abs(expected_ms) * 1e-5)
+    if metric == "tpot" and output_len > 1:
+        return max(5.0 / (output_len - 1), abs(expected_ms) * 0.005)
+    return max(0.000001, abs(expected_ms) * 1e-9)
 
 
 def _reconcile_detailed_aggregate(
-    result: Mapping[str, Any], metric: str, samples_ms: Sequence[float]
+    result: Mapping[str, Any],
+    metric: str,
+    samples_ms: Sequence[float],
+    requested_percentiles: Sequence[str],
+    output_len: int,
 ) -> None:
-    expected = {
-        "mean": statistics.fmean(samples_ms) if samples_ms else 0.0,
-        "median": statistics.median(samples_ms) if samples_ms else 0.0,
-    }
+    expected = _sample_aggregates(samples_ms, requested_percentiles)
     for statistic_name, expected_ms in expected.items():
-        key = f"{statistic_name}_{metric}_ms"
+        if statistic_name.startswith("p"):
+            percentile = statistic_name[1:]
+            key = _percentile_result_key(percentile, metric)
+        else:
+            key = f"{statistic_name}_{metric}_ms"
         actual_ms = _number(result, key)
-        tolerance_ms = _aggregate_tolerance_ms(metric, expected_ms)
+        tolerance_ms = _aggregate_tolerance_ms(metric, expected_ms, output_len)
         if actual_ms is None or abs(actual_ms - expected_ms) > tolerance_ms:
             raise BenchmarkError(
                 f"{key} disagrees with detailed streaming evidence: "
@@ -831,12 +1455,126 @@ def _reconcile_detailed_aggregate(
             )
 
 
+_SPEC_RESULT_FIELDS = (
+    "spec_decode_acceptance_rate",
+    "spec_decode_acceptance_length",
+    "spec_decode_num_drafts",
+    "spec_decode_draft_tokens",
+    "spec_decode_accepted_tokens",
+    "spec_decode_per_position_acceptance_rates",
+)
+
+
+def _exact_nonnegative_int(result: Mapping[str, Any], key: str) -> int | None:
+    value = result.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _validate_speculative_result(
+    result: Mapping[str, Any], args: argparse.Namespace
+) -> None:
+    present = [key for key in _SPEC_RESULT_FIELDS if key in result]
+    if args.speculative_mode == "off":
+        if present:
+            raise BenchmarkError(
+                "non-speculative cell contains speculative result fields: "
+                + ", ".join(present)
+            )
+        return
+
+    missing = [key for key in _SPEC_RESULT_FIELDS if key not in result]
+    if missing:
+        raise BenchmarkError(
+            "speculative cell lacks required vLLM result fields: " + ", ".join(missing)
+        )
+    drafts = _exact_nonnegative_int(result, "spec_decode_num_drafts")
+    draft_tokens = _exact_nonnegative_int(result, "spec_decode_draft_tokens")
+    accepted = _exact_nonnegative_int(result, "spec_decode_accepted_tokens")
+    if drafts is None or drafts <= 0 or draft_tokens is None or draft_tokens <= 0:
+        raise BenchmarkError("speculative draft counts must be positive integers")
+    if accepted is None or accepted > draft_tokens:
+        raise BenchmarkError(
+            "spec_decode_accepted_tokens must be a non-negative integer no larger "
+            "than spec_decode_draft_tokens"
+        )
+    rate = _number(result, "spec_decode_acceptance_rate")
+    length = _number(result, "spec_decode_acceptance_length")
+    if rate is None or not 0 <= rate <= 100:
+        raise BenchmarkError("spec_decode_acceptance_rate must be in [0, 100]")
+    if length is None or length < 1:
+        raise BenchmarkError("spec_decode_acceptance_length must be at least 1")
+    expected_rate = accepted / draft_tokens * 100
+    expected_length = 1 + accepted / drafts
+    if not math.isclose(rate, expected_rate, rel_tol=1e-9, abs_tol=1e-9):
+        raise BenchmarkError(
+            "spec_decode_acceptance_rate does not reconcile with accepted/draft tokens"
+        )
+    if not math.isclose(length, expected_length, rel_tol=1e-9, abs_tol=1e-9):
+        raise BenchmarkError(
+            "spec_decode_acceptance_length does not reconcile with accepted tokens "
+            "per draft"
+        )
+
+    per_position = result.get("spec_decode_per_position_acceptance_rates")
+    if not isinstance(per_position, list) or not per_position:
+        raise BenchmarkError(
+            "spec_decode_per_position_acceptance_rates must be a non-empty array"
+        )
+    bad_positions = [
+        index
+        for index, value in enumerate(per_position)
+        if isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or not 0 <= float(value) <= 1
+    ]
+    if bad_positions:
+        raise BenchmarkError(
+            "speculative per-position acceptance rates must be finite values in [0, 1]"
+        )
+    configured_tokens = args.speculative_config.get("num_speculative_tokens")
+    if (
+        isinstance(configured_tokens, bool)
+        or not isinstance(configured_tokens, int)
+        or configured_tokens <= 0
+    ):
+        raise BenchmarkError(
+            "--speculative-config must contain positive integer num_speculative_tokens"
+        )
+    if len(per_position) != configured_tokens:
+        raise BenchmarkError(
+            "speculative per-position rate count disagrees with num_speculative_tokens"
+        )
+    if not drafts <= draft_tokens <= drafts * configured_tokens:
+        raise BenchmarkError(
+            "spec_decode_draft_tokens is outside the feasible range from "
+            "num_drafts and declared num_speculative_tokens"
+        )
+    expected_accepted_per_draft = accepted / drafts
+    if not math.isclose(
+        sum(map(float, per_position)),
+        expected_accepted_per_draft,
+        rel_tol=1e-9,
+        abs_tol=1e-9,
+    ):
+        raise BenchmarkError(
+            "speculative per-position rates do not reconcile with accepted tokens"
+        )
+
+
 def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None:
     nonfinite = _nonfinite_paths(result)
     if nonfinite:
         raise BenchmarkError(
             "vLLM result contains NaN/Infinity at: " + ", ".join(nonfinite[:10])
         )
+    _validate_speculative_result(result, args)
+
+    duration = _number(result, "duration")
+    if duration is None or duration <= 0:
+        raise BenchmarkError("vLLM result duration must be finite and positive")
 
     requested_percentiles = args.percentiles.split(",")
     required_metrics = list(REQUIRED_STREAMING_RESULTS)
@@ -889,32 +1627,20 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
             "vLLM result has negative latency metrics: " + ", ".join(negative)
         )
 
-    expected: dict[str, tuple[tuple[str, ...], int]] = {
-        "completed": (("completed",), args.num_prompts),
-        "failed": (("failed",), 0),
-        "total_output_tokens": (
-            ("total_output_tokens", "total_output"),
-            args.num_prompts * args.output_len,
-        ),
+    expected_counts: dict[str, int] = {
+        "completed": args.num_prompts,
+        "failed": 0,
+        "total_output_tokens": args.num_prompts * args.output_len,
     }
     if args.input_range_ratio == 0:
-        # Current vLLM uses *_tokens.  The shorter aliases keep results from
-        # older bench-serve releases usable without weakening the fixed gate.
-        expected["total_input_tokens"] = (
-            ("total_input_tokens", "total_input"),
-            args.num_prompts * args.input_len,
-        )
+        expected_counts["total_input_tokens"] = args.num_prompts * args.input_len
     mismatches = []
-    for label, (aliases, wanted) in expected.items():
-        actual = None
-        for key in aliases:
-            actual = _number(result, key)
-            if actual is not None:
-                break
+    for label, wanted in expected_counts.items():
+        actual = _exact_nonnegative_int(result, label)
         if actual is None:
             mismatches.append(f"{label}=missing (expected {wanted})")
         elif actual != wanted:
-            mismatches.append(f"{label}={actual:g} (expected {wanted})")
+            mismatches.append(f"{label}={actual} (expected {wanted})")
     if mismatches:
         raise BenchmarkError(
             "fixed-shape block was not completed exactly: " + "; ".join(mismatches)
@@ -939,18 +1665,13 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
         raise BenchmarkError(
             f"{mode} block has unexpected input_lens at request index: {preview}"
         )
-    if args.input_range_ratio > 0:
-        total_input = None
-        for key in ("total_input_tokens", "total_input"):
-            total_input = _number(result, key)
-            if total_input is not None:
-                break
-        observed_total = sum(input_lens)
-        if total_input != observed_total:
-            raise BenchmarkError(
-                "distributed input lengths do not reconcile with total_input_tokens: "
-                f"{total_input} != {observed_total}"
-            )
+    total_input = _exact_nonnegative_int(result, "total_input_tokens")
+    observed_total_input = sum(input_lens)
+    if total_input != observed_total_input:
+        raise BenchmarkError(
+            "input lengths do not reconcile with total_input_tokens: "
+            f"{total_input} != {observed_total_input}"
+        )
 
     output_lens = result.get("output_lens")
     if not isinstance(output_lens, list) or len(output_lens) != args.num_prompts:
@@ -967,9 +1688,35 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
     if wrong_outputs:
         preview = ", ".join(str(index) for index in wrong_outputs[:5])
         raise BenchmarkError(
-            "fixed output block has unexpected output_lens at request index: "
-            + preview
+            "fixed output block has unexpected output_lens at request index: " + preview
         )
+    total_output = _exact_nonnegative_int(result, "total_output_tokens")
+    observed_total_output = sum(output_lens)
+    if total_output != observed_total_output:
+        raise BenchmarkError(
+            "output lengths do not reconcile with total_output_tokens: "
+            f"{total_output} != {observed_total_output}"
+        )
+
+    expected_throughputs = {
+        "request_throughput": args.num_prompts / duration,
+        "output_throughput": observed_total_output / duration,
+        "total_token_throughput": (observed_total_input + observed_total_output)
+        / duration,
+    }
+    for key, expected_throughput in expected_throughputs.items():
+        actual_throughput = _number(result, key)
+        if actual_throughput is None or not math.isclose(
+            actual_throughput,
+            expected_throughput,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise BenchmarkError(
+                f"{key} disagrees with duration and exact totals: "
+                f"reported={actual_throughput}, "
+                f"reconstructed={expected_throughput:.12g}"
+            )
 
     errors = result.get("errors")
     if not isinstance(errors, list) or len(errors) != args.num_prompts:
@@ -1007,6 +1754,11 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
                 "multi-token response has no inter-token latency samples at "
                 f"request index {request_index}"
             )
+        if args.output_len == 1 and request_itls:
+            raise BenchmarkError(
+                "single-token response unexpectedly contains inter-token latency "
+                f"samples at request index {request_index}"
+            )
         for interval_index, value in enumerate(request_itls):
             if (
                 isinstance(value, bool)
@@ -1024,39 +1776,47 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
     # reconstructing it also validates that each detailed request has a finite,
     # positive end-to-end latency.  output_len=1 intentionally has no ITLs.
     e2els = [
-        float(ttft) + sum(map(float, intervals))
-        for ttft, intervals in zip(ttfts, itls)
+        float(ttft) + sum(map(float, intervals)) for ttft, intervals in zip(ttfts, itls)
     ]
     if any(not math.isfinite(value) or value <= 0 for value in e2els):
         raise BenchmarkError("derived detailed E2EL contains a non-finite value")
 
     _reconcile_detailed_aggregate(
-        result, "ttft", [float(value) * 1000 for value in ttfts]
+        result,
+        "ttft",
+        [float(value) * 1000 for value in ttfts],
+        requested_percentiles,
+        args.output_len,
     )
     _reconcile_detailed_aggregate(
         result,
         "itl",
         [float(value) * 1000 for intervals in itls for value in intervals],
+        requested_percentiles,
+        args.output_len,
     )
     _reconcile_detailed_aggregate(
-        result, "e2el", [value * 1000 for value in e2els]
+        result,
+        "e2el",
+        [value * 1000 for value in e2els],
+        requested_percentiles,
+        args.output_len,
     )
-    if args.output_len > 1:
-        # All outputs are fixed length, so linearity makes this exact even
-        # though medians cannot be reconstructed from aggregate medians and an
-        # SSE chunk may carry multiple speculative tokens.
-        expected_mean_tpot = (
-            _number(result, "mean_e2el_ms") - _number(result, "mean_ttft_ms")
-        ) / (args.output_len - 1)
-        reported_mean_tpot = _number(result, "mean_tpot_ms")
-        tolerance = max(0.05, abs(expected_mean_tpot) * 0.005)
-        if abs(reported_mean_tpot - expected_mean_tpot) > tolerance:
-            raise BenchmarkError(
-                "mean_tpot_ms disagrees with mean E2EL/TTFT and fixed output "
-                f"length: reported={reported_mean_tpot}, "
-                f"reconstructed={expected_mean_tpot:.6f}, "
-                f"tolerance={tolerance:.6f} ms"
-            )
+    tpot_samples = (
+        [
+            sum(map(float, intervals)) * 1000 / (args.output_len - 1)
+            for intervals in itls
+        ]
+        if args.output_len > 1
+        else []
+    )
+    _reconcile_detailed_aggregate(
+        result,
+        "tpot",
+        tpot_samples,
+        requested_percentiles,
+        args.output_len,
+    )
 
 
 def summarize_blocks(blocks: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -1077,6 +1837,8 @@ def summarize_blocks(blocks: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             "median": statistics.median(numeric),
             "min": min(numeric),
             "max": max(numeric),
+            "block_p05": _numpy_linear_percentile(numeric, 5),
+            "block_p95": _numpy_linear_percentile(numeric, 95),
             "sample_stdev": statistics.stdev(numeric) if len(numeric) > 1 else None,
         }
     return {"completed_blocks": len(blocks), "metrics": metrics}

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -13,6 +13,7 @@ makes the command builder/unit tests independent of a live server.
 from __future__ import annotations
 
 import argparse
+import errno
 import importlib.metadata
 import json
 import math
@@ -87,7 +88,7 @@ _SENSITIVE_COMPOUNDS = ("APIKEY", "AUTHTOKEN", "ACCESSTOKEN", "REFRESHTOKEN")
 _ASSIGNMENT = re.compile(r"(\b[-\w.]+\b\s*(?:=|:)\s*)([^\s,;]+)")
 _OPTION_VALUE = re.compile(r"((?:^|\s)(--?[-\w.]+)\s+)([^\s]+)")
 _AUTH_HEADER = re.compile(
-    r"(?i)(authorization\s*:\s*(?:basic|bearer)\s+)([^\s,;]+)"
+    r"(?i)((?:proxy-)?authorization\s*:\s*)([^\s,;]+)(?:\s+([^\s,;]+))?"
 )
 _URL = re.compile(r"https?://[^\s]+", re.I)
 
@@ -114,6 +115,22 @@ def _nonnegative_int(value: str) -> int:
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be zero or greater")
     return parsed
+
+
+def _nonempty(value: str) -> str:
+    if not value.strip():
+        raise argparse.ArgumentTypeError("must not be empty")
+    return value
+
+
+def _input_range_ratio(value: str) -> float:
+    try:
+        ratio = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number in [0, 1)") from exc
+    if not math.isfinite(ratio) or not 0 <= ratio < 1:
+        raise argparse.ArgumentTypeError("must be a finite number in [0, 1)")
+    return ratio
 
 
 def _request_rate(value: str) -> str:
@@ -219,6 +236,37 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="short arm/workload label, for example gridbook-27b-decode",
     )
+    artifact.add_argument(
+        "--artifact-bytes",
+        type=_positive_int,
+        required=True,
+        help="exact whole served-artifact bytes, excluding caches",
+    )
+    artifact.add_argument(
+        "--byte-budget",
+        type=_positive_int,
+        required=True,
+        help="maximum allowed whole served-artifact bytes",
+    )
+
+    identity = parser.add_argument_group("delegated execution identity")
+    identity.add_argument("--format-rung", type=_nonempty, required=True)
+    identity.add_argument("--serialized-layout", type=_nonempty, required=True)
+    identity.add_argument("--scale-coding", type=_nonempty, required=True)
+    identity.add_argument(
+        "--quant-contract",
+        type=_nonempty,
+        required=True,
+        help="weight/activation contract, for example W4A4 or W8A8",
+    )
+    identity.add_argument("--kernel-backend", type=_nonempty, required=True)
+    identity.add_argument("--tensor-parallel-size", type=_positive_int, required=True)
+    identity.add_argument("--fallback-state", type=_nonempty, required=True)
+    identity.add_argument("--client-runtime-id", type=_nonempty, required=True)
+    identity.add_argument("--server-runtime-id", type=_nonempty, required=True)
+    identity.add_argument("--gpu-id", type=_nonempty, required=True)
+    identity.add_argument("--driver-version", type=_nonempty, required=True)
+    identity.add_argument("--cuda-version", type=_nonempty, required=True)
 
     workload = parser.add_argument_group("fixed workload")
     workload.add_argument("--input-len", type=_positive_int, required=True)
@@ -266,6 +314,15 @@ def build_parser() -> argparse.ArgumentParser:
         type=_percentiles,
         default=DEFAULT_PERCENTILES,
         help=f"reported metric percentiles (default: {DEFAULT_PERCENTILES})",
+    )
+    workload.add_argument(
+        "--input-range-ratio",
+        type=_input_range_ratio,
+        default=0.0,
+        help=(
+            "uniform random input-length range ratio in [0,1); output length "
+            "remains fixed (default: 0)"
+        ),
     )
 
     dispatch = parser.add_argument_group("dispatch provenance")
@@ -319,6 +376,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     server_env_names = [name for name, _ in args.server_env]
     if len(server_env_names) != len(set(server_env_names)):
         parser.error("--server-env names must not be repeated")
+    if args.artifact_bytes > args.byte_budget:
+        parser.error(
+            f"--artifact-bytes ({args.artifact_bytes}) exceeds --byte-budget "
+            f"({args.byte_budget})"
+        )
     return args
 
 
@@ -355,7 +417,11 @@ def build_vllm_command(
         "--random-output-len",
         str(args.output_len),
         "--random-range-ratio",
-        "0",
+        json.dumps(
+            {"input": args.input_range_ratio, "output": 0.0},
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
         "--num-prompts",
         str(args.num_prompts),
         "--num-warmups",
@@ -439,10 +505,16 @@ def _redact_text(value: str) -> str:
             "<redacted>" if _is_sensitive_key(match.group(2)) else match.group(3)
         )
 
+    def redact_authorization(match: re.Match[str]) -> str:
+        scheme_or_value = match.group(2)
+        if match.group(3) is None:
+            return match.group(1) + "<redacted>"
+        return match.group(1) + scheme_or_value + " <redacted>"
+
     redacted = _URL.sub(redact_url, str(value))
-    redacted = _AUTH_HEADER.sub(r"\1<redacted>", redacted)
     redacted = _ASSIGNMENT.sub(redact_assignment, redacted)
-    return _OPTION_VALUE.sub(redact_option, redacted)
+    redacted = _OPTION_VALUE.sub(redact_option, redacted)
+    return _AUTH_HEADER.sub(redact_authorization, redacted)
 
 
 def redact_command(command: Sequence[str]) -> list[str]:
@@ -555,7 +627,7 @@ def collect_metadata(
         "git": git,
         "software": {
             "gridbook_version": probe("gridbook_version", _package_version),
-            "vllm_cli_version": probe(
+            "runner_vllm_cli_probe": probe(
                 "vllm_cli_version", lambda: _vllm_version(args.vllm_executable)
             ),
             "python": probe("python", platform.python_version),
@@ -568,6 +640,32 @@ def collect_metadata(
             "model_id": _redact_text(args.model_id),
             "benchmark_model": _redact_text(args.model),
             "tokenizer": _redact_text(args.tokenizer or args.model),
+            "whole_served_artifact_bytes": args.artifact_bytes,
+            "byte_budget_bytes": args.byte_budget,
+            "budget_headroom_bytes": args.byte_budget - args.artifact_bytes,
+            "within_byte_budget": args.artifact_bytes <= args.byte_budget,
+            "byte_scope": (
+                "shipped model shards, configs, tokenizer, and sidecars; "
+                "runtime/download/JIT caches excluded"
+            ),
+        },
+        "execution_identity": {
+            "format_rung": _redact_text(args.format_rung),
+            "serialization": {
+                "layout": _redact_text(args.serialized_layout),
+                "scale_coding": _redact_text(args.scale_coding),
+            },
+            "quant_contract": _redact_text(args.quant_contract),
+            "kernel_backend": _redact_text(args.kernel_backend),
+            "tensor_parallel_size": args.tensor_parallel_size,
+            "fallback_state": _redact_text(args.fallback_state),
+            "client_runtime_id": _redact_text(args.client_runtime_id),
+            "server_runtime_id": _redact_text(args.server_runtime_id),
+            "hardware": {
+                "gpu_id": _redact_text(args.gpu_id),
+                "driver_version": _redact_text(args.driver_version),
+                "cuda_version": _redact_text(args.cuda_version),
+            },
         },
         "server": {
             "base_url": _redact_url(args.base_url.rstrip("/")),
@@ -576,7 +674,7 @@ def collect_metadata(
             "served_model_name": _redact_text(
                 args.served_model_name or args.model
             ),
-            "recorded_args": [_redact_text(value) for value in args.server_arg],
+            "recorded_args": redact_command(args.server_arg),
         },
         "dispatch": {
             "runner_environment": {
@@ -610,7 +708,31 @@ def collect_metadata(
                 "sampling_seed": None,
             },
             "request_rate": args.request_rate,
-            "random_range_ratio": 0,
+            "input_range_ratio": args.input_range_ratio,
+            "vllm_range_ratio": {
+                "input": args.input_range_ratio,
+                "output": 0.0,
+            },
+            "input_length_validation": (
+                "exact" if args.input_range_ratio == 0 else "conservative-range"
+            ),
+            "accepted_input_length_bounds": list(
+                _input_length_bounds(args.input_len, args.input_range_ratio)
+            ),
+            "aggregate_reconciliation": {
+                "ttft_itl": "mean/median vs detailed arrays; 0.01 ms or 1e-5 relative",
+                "e2el": (
+                    "mean/median vs TTFT+ITL; 5 ms or 0.5% terminal-SSE allowance"
+                ),
+                "tpot": (
+                    "mean vs (mean_e2el-mean_ttft)/(fixed_output_len-1); "
+                    "0.05 ms or 0.5%"
+                ),
+                "itl_cardinality": (
+                    "not equated to output tokens because one SSE chunk may carry "
+                    "multiple tokens"
+                ),
+            },
             "ignore_eos": True,
             "streaming": True,
             "metrics": STREAMING_METRICS.split(","),
@@ -667,6 +789,46 @@ def _percentile_result_key(percentile: str, metric: str) -> str:
     number = float(percentile)
     label = str(int(number)) if number.is_integer() else f"{number:g}"
     return f"p{label}_{metric}_ms"
+
+
+def _input_length_bounds(input_len: int, ratio: float) -> tuple[int, int]:
+    if ratio == 0:
+        return input_len, input_len
+    # Pinned vLLM 0.23 samples through ceil(input_len * (1 + ratio)), but its
+    # lower endpoint is computed after subtracting tokenizer-added special
+    # tokens and its decode/re-encode correction can shorten a prompt.  That
+    # special-token count is not exposed in bench-serve JSON.  One token is
+    # therefore the only universally safe lower bound; the upper bound remains
+    # exact and useful, and totals/per-request types are checked independently.
+    return 1, math.ceil(input_len * (1 + ratio))
+
+
+def _aggregate_tolerance_ms(metric: str, expected_ms: float) -> float:
+    if metric == "e2el":
+        # vLLM's request latency extends through the terminal SSE event, while
+        # detailed ITLs stop at the final token-bearing chunk.  Permit that
+        # small transport tail, but not a fabricated decode-length gap.
+        return max(5.0, abs(expected_ms) * 0.005)
+    return max(0.01, abs(expected_ms) * 1e-5)
+
+
+def _reconcile_detailed_aggregate(
+    result: Mapping[str, Any], metric: str, samples_ms: Sequence[float]
+) -> None:
+    expected = {
+        "mean": statistics.fmean(samples_ms) if samples_ms else 0.0,
+        "median": statistics.median(samples_ms) if samples_ms else 0.0,
+    }
+    for statistic_name, expected_ms in expected.items():
+        key = f"{statistic_name}_{metric}_ms"
+        actual_ms = _number(result, key)
+        tolerance_ms = _aggregate_tolerance_ms(metric, expected_ms)
+        if actual_ms is None or abs(actual_ms - expected_ms) > tolerance_ms:
+            raise BenchmarkError(
+                f"{key} disagrees with detailed streaming evidence: "
+                f"reported={actual_ms}, reconstructed={expected_ms:.6f}, "
+                f"tolerance={tolerance_ms:.6f} ms"
+            )
 
 
 def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None:
@@ -727,27 +889,28 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
             "vLLM result has negative latency metrics: " + ", ".join(negative)
         )
 
-    expected = {
+    expected: dict[str, tuple[tuple[str, ...], int]] = {
         "completed": (("completed",), args.num_prompts),
         "failed": (("failed",), 0),
-        # Current vLLM uses *_tokens.  The shorter aliases keep reports made by
-        # older bench-serve releases usable without weakening the exact-length
-        # gate.
-        "total_input_tokens": (
-            ("total_input_tokens", "total_input"),
-            args.num_prompts * args.input_len,
-        ),
         "total_output_tokens": (
             ("total_output_tokens", "total_output"),
             args.num_prompts * args.output_len,
         ),
     }
+    if args.input_range_ratio == 0:
+        # Current vLLM uses *_tokens.  The shorter aliases keep results from
+        # older bench-serve releases usable without weakening the fixed gate.
+        expected["total_input_tokens"] = (
+            ("total_input_tokens", "total_input"),
+            args.num_prompts * args.input_len,
+        )
     mismatches = []
     for label, (aliases, wanted) in expected.items():
-        actual = next(
-            (_number(result, key) for key in aliases if _number(result, key) is not None),
-            None,
-        )
+        actual = None
+        for key in aliases:
+            actual = _number(result, key)
+            if actual is not None:
+                break
         if actual is None:
             mismatches.append(f"{label}=missing (expected {wanted})")
         elif actual != wanted:
@@ -757,18 +920,56 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
             "fixed-shape block was not completed exactly: " + "; ".join(mismatches)
         )
 
-    for key, wanted in (("input_lens", args.input_len), ("output_lens", args.output_len)):
-        lengths = result.get(key)
-        if not isinstance(lengths, list) or len(lengths) != args.num_prompts:
+    input_lens = result.get("input_lens")
+    if not isinstance(input_lens, list) or len(input_lens) != args.num_prompts:
+        raise BenchmarkError(
+            "vLLM detailed result input_lens must contain one value per prompt"
+        )
+    lower, upper = _input_length_bounds(args.input_len, args.input_range_ratio)
+    wrong_inputs = [
+        index
+        for index, value in enumerate(input_lens)
+        if isinstance(value, bool)
+        or not isinstance(value, int)
+        or not lower <= value <= upper
+    ]
+    if wrong_inputs:
+        preview = ", ".join(str(index) for index in wrong_inputs[:5])
+        mode = "fixed" if args.input_range_ratio == 0 else f"range [{lower}, {upper}]"
+        raise BenchmarkError(
+            f"{mode} block has unexpected input_lens at request index: {preview}"
+        )
+    if args.input_range_ratio > 0:
+        total_input = None
+        for key in ("total_input_tokens", "total_input"):
+            total_input = _number(result, key)
+            if total_input is not None:
+                break
+        observed_total = sum(input_lens)
+        if total_input != observed_total:
             raise BenchmarkError(
-                f"vLLM detailed result {key} must contain one value per prompt"
+                "distributed input lengths do not reconcile with total_input_tokens: "
+                f"{total_input} != {observed_total}"
             )
-        wrong = [index for index, value in enumerate(lengths) if value != wanted]
-        if wrong:
-            preview = ", ".join(str(index) for index in wrong[:5])
-            raise BenchmarkError(
-                f"fixed-shape block has unexpected {key} at request index: {preview}"
-            )
+
+    output_lens = result.get("output_lens")
+    if not isinstance(output_lens, list) or len(output_lens) != args.num_prompts:
+        raise BenchmarkError(
+            "vLLM detailed result output_lens must contain one value per prompt"
+        )
+    wrong_outputs = [
+        index
+        for index, value in enumerate(output_lens)
+        if isinstance(value, bool)
+        or not isinstance(value, int)
+        or value != args.output_len
+    ]
+    if wrong_outputs:
+        preview = ", ".join(str(index) for index in wrong_outputs[:5])
+        raise BenchmarkError(
+            "fixed output block has unexpected output_lens at request index: "
+            + preview
+        )
 
     errors = result.get("errors")
     if not isinstance(errors, list) or len(errors) != args.num_prompts:
@@ -829,6 +1030,34 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
     if any(not math.isfinite(value) or value <= 0 for value in e2els):
         raise BenchmarkError("derived detailed E2EL contains a non-finite value")
 
+    _reconcile_detailed_aggregate(
+        result, "ttft", [float(value) * 1000 for value in ttfts]
+    )
+    _reconcile_detailed_aggregate(
+        result,
+        "itl",
+        [float(value) * 1000 for intervals in itls for value in intervals],
+    )
+    _reconcile_detailed_aggregate(
+        result, "e2el", [value * 1000 for value in e2els]
+    )
+    if args.output_len > 1:
+        # All outputs are fixed length, so linearity makes this exact even
+        # though medians cannot be reconstructed from aggregate medians and an
+        # SSE chunk may carry multiple speculative tokens.
+        expected_mean_tpot = (
+            _number(result, "mean_e2el_ms") - _number(result, "mean_ttft_ms")
+        ) / (args.output_len - 1)
+        reported_mean_tpot = _number(result, "mean_tpot_ms")
+        tolerance = max(0.05, abs(expected_mean_tpot) * 0.005)
+        if abs(reported_mean_tpot - expected_mean_tpot) > tolerance:
+            raise BenchmarkError(
+                "mean_tpot_ms disagrees with mean E2EL/TTFT and fixed output "
+                f"length: reported={reported_mean_tpot}, "
+                f"reconstructed={expected_mean_tpot:.6f}, "
+                f"tolerance={tolerance:.6f} ms"
+            )
+
 
 def summarize_blocks(blocks: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     results = [block["raw_result"] for block in blocks]
@@ -862,13 +1091,25 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
         with os.fdopen(fd, "w") as handle:
             json.dump(payload, handle, indent=2, sort_keys=True, allow_nan=False)
             handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(temporary, path)
+        _fsync_directory(path.parent)
     except BaseException:
         try:
             os.unlink(temporary)
         except FileNotFoundError:
             pass
         raise
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _reserve_output(path: Path, *, overwrite: bool) -> None:
@@ -880,14 +1121,21 @@ def _reserve_output(path: Path, *, overwrite: bool) -> None:
     """
 
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise BenchmarkError(f"refusing to reserve symlink output: {path}")
     flags = os.O_WRONLY | os.O_CREAT
     flags |= os.O_TRUNC if overwrite else os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(path, flags, 0o600)
     except FileExistsError as exc:
         raise BenchmarkError(
             f"output already exists: {path} (pass --overwrite to replace it)"
         ) from exc
+    except OSError as exc:
+        if exc.errno == errno.ELOOP or path.is_symlink():
+            raise BenchmarkError(f"refusing to reserve symlink output: {path}") from exc
+        raise
     with os.fdopen(descriptor, "w") as handle:
         os.fchmod(handle.fileno(), 0o600)
         json.dump(
@@ -896,6 +1144,9 @@ def _reserve_output(path: Path, *, overwrite: bool) -> None:
             allow_nan=False,
         )
         handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    _fsync_directory(path.parent)
 
 
 def _json_safe(value: Any) -> Any:
@@ -920,7 +1171,11 @@ def _run_command(command: Sequence[str]) -> int:
 
 
 def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
-    output_path = args.output.expanduser().resolve()
+    # ``resolve()`` follows the final component and would turn an explicitly
+    # rejected output symlink into its target before _reserve_output sees it.
+    # abspath-style normalization preserves that final component for the
+    # O_NOFOLLOW/symlink gate while still making report paths deterministic.
+    output_path = Path(os.path.abspath(os.fspath(args.output.expanduser())))
     _reserve_output(output_path, overwrite=args.overwrite)
 
     started_at = _utc_now()

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -1395,6 +1395,15 @@ def _git_state(
             "Gridbook checkout is dirty; commit the changes or pass --allow-dirty "
             "for research-only evidence"
         )
+    if (
+        commit_override is not None
+        and detected_commit is not None
+        and commit_override.lower() != detected_commit.lower()
+    ):
+        raise BenchmarkError(
+            "explicit Gridbook commit disagrees with the exact source checkout: "
+            f"argument={commit_override.lower()}, checkout={detected_commit.lower()}"
+        )
     if commit_override:
         return {
             "commit": commit_override.lower(),

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -40,6 +40,7 @@ STREAMING_METRICS = "ttft,tpot,itl,e2el"
 DEFAULT_PERCENTILES = "50,90,95,99"
 MIN_WARMUPS = 4
 MIN_BLOCKS = 3
+REQUEST_BURSTINESS = 1.0
 
 # These are stable vLLM result names.  Percentile keys are added dynamically
 # below because the selected percentiles are configurable.
@@ -1171,6 +1172,8 @@ def build_vllm_command(
         str(args.max_concurrency),
         "--request-rate",
         args.request_rate,
+        "--burstiness",
+        str(REQUEST_BURSTINESS),
         "--seed",
         str(dataset_seed),
         "--temperature",
@@ -1631,6 +1634,7 @@ def collect_metadata(
                 "sampling_seed": None,
             },
             "request_rate": args.request_rate,
+            "request_burstiness": REQUEST_BURSTINESS,
             "input_range_ratio": args.input_range_ratio,
             "vllm_range_ratio": {
                 "input": args.input_range_ratio,
@@ -1788,6 +1792,15 @@ def _validate_result_invocation(
         )
     if not request_rate_matches:
         mismatches.append("request_rate")
+
+    burstiness = result.get("burstiness")
+    if (
+        isinstance(burstiness, bool)
+        or not isinstance(burstiness, (int, float))
+        or not math.isfinite(float(burstiness))
+        or float(burstiness) != REQUEST_BURSTINESS
+    ):
+        mismatches.append("burstiness")
 
     if mismatches:
         raise BenchmarkError(

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -1984,6 +1984,35 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
+def _sanitize_result_for_report(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Retain metric evidence without persisting arbitrary model/server text.
+
+    ``vllm bench serve --save-detailed`` includes generated completions and may
+    include an arbitrary server error body. Neither is needed to reconstruct
+    the performance metrics, and generic credential-pattern redaction cannot
+    prove such free text is safe to publish. Keep their cardinality/position
+    evidence while omitting their contents, then apply the normal recursive
+    redaction and non-finite JSON conversion to every remaining field.
+    """
+
+    sanitized = dict(result)
+    generated = sanitized.pop("generated_texts", None)
+    if generated is not None:
+        sanitized["generated_texts_omitted"] = {
+            "count": len(generated) if isinstance(generated, list) else None,
+            "reason": "arbitrary model output is not performance evidence",
+        }
+
+    errors = sanitized.get("errors")
+    if isinstance(errors, list):
+        sanitized["errors"] = [
+            value if value is None or value == "" else "<redacted-server-error>"
+            for value in errors
+        ]
+
+    return _json_safe(_redact_structured(sanitized))
+
+
 def _run_command(command: Sequence[str]) -> int:
     try:
         return subprocess.run(command, check=False).returncode
@@ -2065,7 +2094,7 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                         )
                     try:
                         result = _load_result(result_dir / filename)
-                        block["raw_result"] = _json_safe(result)
+                        block["raw_result"] = _sanitize_result_for_report(result)
                         _atomic_write_json(output_path, report)
                         validate_result(result, args)
                     except BenchmarkError as exc:

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -642,7 +642,19 @@ def build_parser() -> argparse.ArgumentParser:
     identity.add_argument("--server-runtime-id", type=_nonempty, required=True)
     identity.add_argument("--gpu-id", type=_nonempty, required=True)
     identity.add_argument("--driver-version", type=_nonempty, required=True)
-    identity.add_argument("--cuda-version", type=_nonempty, required=True)
+    accelerator_runtime = identity.add_mutually_exclusive_group(required=True)
+    accelerator_runtime.add_argument(
+        "--accelerator-runtime",
+        dest="accelerator_runtime",
+        type=_nonempty,
+        help="accelerator runtime identity, for example CUDA 13.0 or ROCm 7.0",
+    )
+    accelerator_runtime.add_argument(
+        "--cuda-version",
+        dest="accelerator_runtime",
+        type=_nonempty,
+        help="deprecated alias for --accelerator-runtime",
+    )
     identity.add_argument(
         "--execution-manifest",
         type=Path,
@@ -676,7 +688,36 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     workload = parser.add_argument_group("fixed workload")
-    workload.add_argument("--input-len", type=_positive_int, required=True)
+    workload.add_argument(
+        "--input-len",
+        type=_positive_int,
+        required=True,
+        help="requested vLLM random-dataset target before tokenizer adjustment",
+    )
+    workload.add_argument(
+        "--observed-input-len",
+        type=_positive_int,
+        help=(
+            "exact input_lens value expected in vLLM output; required when "
+            "--input-range-ratio=0"
+        ),
+    )
+    workload.add_argument(
+        "--observed-input-len-min",
+        type=_positive_int,
+        help=(
+            "declared inclusive lower input_lens bound; required with "
+            "--observed-input-len-max when --input-range-ratio is nonzero"
+        ),
+    )
+    workload.add_argument(
+        "--observed-input-len-max",
+        type=_positive_int,
+        help=(
+            "declared inclusive upper input_lens bound; required with "
+            "--observed-input-len-min when --input-range-ratio is nonzero"
+        ),
+    )
     workload.add_argument("--output-len", type=_positive_int, required=True)
     workload.add_argument(
         "--num-prompts",
@@ -780,6 +821,31 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         parser.error(f"--warmups must be at least {MIN_WARMUPS}")
     if args.blocks < MIN_BLOCKS:
         parser.error(f"--blocks must be at least {MIN_BLOCKS}")
+    if args.input_range_ratio == 0:
+        if args.observed_input_len is None:
+            parser.error("--observed-input-len is required when --input-range-ratio=0")
+        if (
+            args.observed_input_len_min is not None
+            or args.observed_input_len_max is not None
+        ):
+            parser.error(
+                "--observed-input-len-min/--observed-input-len-max are forbidden "
+                "when --input-range-ratio=0"
+            )
+    else:
+        if args.observed_input_len is not None:
+            parser.error(
+                "--observed-input-len is forbidden when --input-range-ratio is nonzero"
+            )
+        if args.observed_input_len_min is None or args.observed_input_len_max is None:
+            parser.error(
+                "--observed-input-len-min and --observed-input-len-max are required "
+                "when --input-range-ratio is nonzero"
+            )
+        if args.observed_input_len_min > args.observed_input_len_max:
+            parser.error(
+                "--observed-input-len-min cannot exceed --observed-input-len-max"
+            )
     if 95.0 not in {float(item) for item in args.percentiles.split(",")}:
         parser.error("--percentiles must include 95 for the TTFT/ITL release gates")
     server_env_names = [name for name, _ in args.server_env]
@@ -950,22 +1016,9 @@ def _redact_url(value: str) -> str:
             ],
             doseq=True,
         )
-        fragment = parsed.fragment
-        if fragment:
-            fragment_pairs = parse_qsl(fragment, keep_blank_values=True)
-            if "=" in fragment and fragment_pairs:
-                fragment = urlencode(
-                    [
-                        (
-                            key,
-                            "<redacted>" if _is_sensitive_key(key) else setting,
-                        )
-                        for key, setting in fragment_pairs
-                    ],
-                    doseq=True,
-                )
-            elif _is_sensitive_key(fragment):
-                fragment = "<redacted>"
+        # Unlike a query, a fragment is opaque to the server and may carry an
+        # unkeyed credential.  There is no sound allowlist, so fail closed.
+        fragment = "<redacted>" if parsed.fragment else ""
         return urlunsplit((parsed.scheme, netloc, parsed.path, query, fragment))
     except (TypeError, ValueError):
         return "<redacted-invalid-url>"
@@ -1235,7 +1288,7 @@ def collect_metadata(
             "hardware": {
                 "gpu_id": _redact_text(args.gpu_id),
                 "driver_version": _redact_text(args.driver_version),
-                "cuda_version": _redact_text(args.cuda_version),
+                "accelerator_runtime": _redact_text(args.accelerator_runtime),
             },
         },
         "server": {
@@ -1261,7 +1314,19 @@ def collect_metadata(
         },
         "workload": {
             "dataset": "random",
-            "input_len": args.input_len,
+            "requested_random_input_len": args.input_len,
+            "observed_input_length_contract": (
+                {
+                    "mode": "exact",
+                    "value": args.observed_input_len,
+                }
+                if args.input_range_ratio == 0
+                else {
+                    "mode": "range",
+                    "minimum": args.observed_input_len_min,
+                    "maximum": args.observed_input_len_max,
+                }
+            ),
             "output_len": args.output_len,
             "num_prompts_per_block": args.num_prompts,
             "warmups_per_block": args.warmups,
@@ -1283,11 +1348,9 @@ def collect_metadata(
                 "output": 0.0,
             },
             "input_length_validation": (
-                "exact" if args.input_range_ratio == 0 else "conservative-range"
+                "declared-exact" if args.input_range_ratio == 0 else "declared-range"
             ),
-            "accepted_input_length_bounds": list(
-                _input_length_bounds(args.input_len, args.input_range_ratio)
-            ),
+            "accepted_input_length_bounds": list(_observed_input_length_bounds(args)),
             "aggregate_reconciliation": {
                 "throughput": (
                     "duration and exact token/request totals; 1e-9 relative/absolute"
@@ -1331,11 +1394,11 @@ def collect_metadata(
 
 def _load_result(path: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text())
+        payload = _strict_json_loads(path.read_bytes())
     except FileNotFoundError as exc:
         raise BenchmarkError(f"vLLM did not create result file {path}") from exc
-    except json.JSONDecodeError as exc:
-        raise BenchmarkError(f"vLLM result is not valid JSON: {path}") from exc
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise BenchmarkError(f"vLLM result is not strict JSON: {path}") from exc
     # ``--append-result`` creates a list; the harness never requests it, but
     # accepting a singleton makes this resilient to vLLM version differences.
     if isinstance(payload, list) and len(payload) == 1:
@@ -1377,16 +1440,10 @@ def _percentile_result_key(percentile: str, metric: str) -> str:
     return f"p{label}_{metric}_ms"
 
 
-def _input_length_bounds(input_len: int, ratio: float) -> tuple[int, int]:
-    if ratio == 0:
-        return input_len, input_len
-    # Pinned vLLM 0.23 samples through ceil(input_len * (1 + ratio)), but its
-    # lower endpoint is computed after subtracting tokenizer-added special
-    # tokens and its decode/re-encode correction can shorten a prompt.  That
-    # special-token count is not exposed in bench-serve JSON.  One token is
-    # therefore the only universally safe lower bound; the upper bound remains
-    # exact and useful, and totals/per-request types are checked independently.
-    return 1, math.ceil(input_len * (1 + ratio))
+def _observed_input_length_bounds(args: argparse.Namespace) -> tuple[int, int]:
+    if args.input_range_ratio == 0:
+        return args.observed_input_len, args.observed_input_len
+    return args.observed_input_len_min, args.observed_input_len_max
 
 
 def _numpy_linear_percentile(samples: Sequence[float], percentile: float) -> float:
@@ -1633,7 +1690,9 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
         "total_output_tokens": args.num_prompts * args.output_len,
     }
     if args.input_range_ratio == 0:
-        expected_counts["total_input_tokens"] = args.num_prompts * args.input_len
+        expected_counts["total_input_tokens"] = (
+            args.num_prompts * args.observed_input_len
+        )
     mismatches = []
     for label, wanted in expected_counts.items():
         actual = _exact_nonnegative_int(result, label)
@@ -1651,7 +1710,7 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
         raise BenchmarkError(
             "vLLM detailed result input_lens must contain one value per prompt"
         )
-    lower, upper = _input_length_bounds(args.input_len, args.input_range_ratio)
+    lower, upper = _observed_input_length_bounds(args)
     wrong_inputs = [
         index
         for index, value in enumerate(input_lens)

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -2691,6 +2691,8 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                     block["finished_at"] = _utc_now()
                     block["wall_duration_s"] = time.monotonic() - block_clock
         _revalidate_bound_inputs(args)
+        provenance = report["metadata"]["measurement_provenance"]
+        provenance["digest_bound_inputs_verified_after_requests"] = True
         ending_git = _git_state(
             args.git_commit,
             allow_dirty=args.allow_dirty,
@@ -2700,14 +2702,12 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
             raise BenchmarkError(
                 "Gridbook source provenance changed during the benchmark"
             )
+        provenance["git_state_verified_after_requests"] = True
         ending_client_runtime = _vllm_version(args.vllm_executable)
         if ending_client_runtime != args.client_runtime_id:
             raise BenchmarkError(
                 "vLLM client runtime identity changed during the benchmark"
             )
-        provenance = report["metadata"]["measurement_provenance"]
-        provenance["digest_bound_inputs_verified_after_requests"] = True
-        provenance["git_state_verified_after_requests"] = True
         provenance["client_runtime_verified_after_requests"] = True
         report["summary"] = summarize_blocks(report["blocks"])
         report["status"] = "success"

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -1,0 +1,664 @@
+"""Reproducible online serving benchmarks for native/Gridbook parity work.
+
+This module is intentionally a thin orchestrator around ``vllm bench serve``.
+vLLM owns the streaming client and therefore the TTFT, TPOT, ITL, and E2EL
+definitions; Gridbook only fixes the workload, separates independent blocks,
+and records enough provenance to make two runs comparable.
+
+There are no imports from vLLM (or torch) here.  The benchmark executable is a
+subprocess, which keeps ``import gridbook`` usable in CPU-only environments and
+makes the command builder/unit tests independent of a live server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA = "gridbook.vllm-bench-serve.v1"
+STREAMING_METRICS = "ttft,tpot,itl,e2el"
+DEFAULT_PERCENTILES = "50,90,95,99"
+
+# These are stable vLLM result names.  Percentile keys are added dynamically
+# below because the selected percentiles are configurable.
+SUMMARY_METRICS = (
+    "request_throughput",
+    "output_throughput",
+    "total_token_throughput",
+    "mean_ttft_ms",
+    "median_ttft_ms",
+    "std_ttft_ms",
+    "mean_tpot_ms",
+    "median_tpot_ms",
+    "std_tpot_ms",
+    "mean_itl_ms",
+    "median_itl_ms",
+    "std_itl_ms",
+    "mean_e2el_ms",
+    "median_e2el_ms",
+    "std_e2el_ms",
+)
+REQUIRED_STREAMING_RESULTS = (
+    "mean_ttft_ms",
+    "mean_tpot_ms",
+    "mean_itl_ms",
+    "mean_e2el_ms",
+)
+_PERCENTILE_RESULT = re.compile(
+    r"^p(?:\d+(?:\.\d+)?)_(?:ttft|tpot|itl|e2el)_ms$"
+)
+_SENSITIVE_ENV = re.compile(r"(?:TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)", re.I)
+
+
+class BenchmarkError(RuntimeError):
+    """A benchmark failed before it produced a trustworthy block."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
+def _request_rate(value: str) -> str:
+    if value.lower() in {"inf", "infinity"}:
+        return "inf"
+    try:
+        rate = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive number or 'inf'") from exc
+    if not math.isfinite(rate) or rate <= 0:
+        raise argparse.ArgumentTypeError("must be a positive number or 'inf'")
+    return value
+
+
+def _percentiles(value: str) -> str:
+    try:
+        parsed = [float(item) for item in value.split(",")]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a comma-separated list of numbers"
+        ) from exc
+    if not parsed or any(not 0 < item < 100 for item in parsed):
+        raise argparse.ArgumentTypeError("every percentile must be between 0 and 100")
+    if len(set(parsed)) != len(parsed):
+        raise argparse.ArgumentTypeError("percentiles must not contain duplicates")
+    return ",".join(f"{item:g}" for item in parsed)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gridbook-bench-serve",
+        description=(
+            "Run fixed-shape, streaming vLLM serving benchmarks in independent "
+            "blocks and save metrics plus reproducibility metadata as JSON."
+        ),
+    )
+    server = parser.add_argument_group("online server")
+    server.add_argument("--base-url", required=True, help="OpenAI-compatible base URL")
+    server.add_argument(
+        "--backend",
+        default="openai",
+        help="vLLM bench serve backend (default: openai)",
+    )
+    server.add_argument(
+        "--endpoint", default="/v1/completions", help="streaming completion endpoint"
+    )
+    server.add_argument(
+        "--served-model-name",
+        help="model name sent to the API (defaults to --model)",
+    )
+    server.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        metavar="ARG",
+        help=(
+            "exact server argument to record as metadata; repeat as needed "
+            "(this does not start or modify the server)"
+        ),
+    )
+    server.add_argument(
+        "--ready-timeout",
+        type=_nonnegative_int,
+        default=600,
+        metavar="SECONDS",
+        help="vLLM endpoint readiness timeout (default: 600)",
+    )
+
+    artifact = parser.add_argument_group("artifact identity")
+    artifact.add_argument(
+        "--model",
+        required=True,
+        help="model/tokenizer name understood by vLLM bench serve",
+    )
+    artifact.add_argument(
+        "--tokenizer",
+        help="tokenizer name or revision (defaults to --model)",
+    )
+    artifact.add_argument(
+        "--model-id",
+        required=True,
+        help="exact served artifact identifier/revision recorded in the report",
+    )
+    artifact.add_argument(
+        "--image-id",
+        required=True,
+        help="exact serving image tag or digest recorded in the report",
+    )
+    artifact.add_argument(
+        "--git-commit",
+        help="Gridbook commit override; otherwise detected from this checkout",
+    )
+    artifact.add_argument(
+        "--run-label",
+        required=True,
+        help="short arm/workload label, for example gridbook-27b-decode",
+    )
+
+    workload = parser.add_argument_group("fixed workload")
+    workload.add_argument("--input-len", type=_positive_int, required=True)
+    workload.add_argument("--output-len", type=_positive_int, required=True)
+    workload.add_argument(
+        "--num-prompts",
+        type=_positive_int,
+        required=True,
+        help="measured prompts in each block",
+    )
+    workload.add_argument(
+        "--max-concurrency", type=_positive_int, required=True
+    )
+    workload.add_argument(
+        "--warmups",
+        type=_nonnegative_int,
+        default=2,
+        help="unmeasured warmup prompts before each block (default: 2)",
+    )
+    workload.add_argument(
+        "--blocks",
+        type=_positive_int,
+        default=3,
+        help="independent client blocks; distinct deterministic seed per block (default: 3)",
+    )
+    workload.add_argument("--seed", type=int, default=1234)
+    workload.add_argument(
+        "--request-rate",
+        type=_request_rate,
+        default="inf",
+        help="request arrival rate or 'inf' for a closed saturation block (default: inf)",
+    )
+    workload.add_argument(
+        "--percentiles",
+        type=_percentiles,
+        default=DEFAULT_PERCENTILES,
+        help=f"reported metric percentiles (default: {DEFAULT_PERCENTILES})",
+    )
+
+    dispatch = parser.add_argument_group("dispatch provenance")
+    dispatch.add_argument(
+        "--dispatch-env",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="environment variable to record; repeat as needed",
+    )
+    dispatch.add_argument(
+        "--dispatch-env-prefix",
+        action="append",
+        default=["PRISMAQUANT_"],
+        metavar="PREFIX",
+        help=(
+            "record variables matching this prefix; repeat to add prefixes "
+            "(PRISMAQUANT_ is always included)"
+        ),
+    )
+
+    output = parser.add_argument_group("runner and output")
+    output.add_argument(
+        "--vllm-executable", default="vllm", help="vLLM CLI executable"
+    )
+    output.add_argument(
+        "--output", type=Path, required=True, help="structured JSON report path"
+    )
+    output.add_argument(
+        "--overwrite", action="store_true", help="replace an existing report"
+    )
+    return parser
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.max_concurrency > args.num_prompts:
+        parser.error("--max-concurrency cannot exceed --num-prompts")
+    return args
+
+
+def build_vllm_command(
+    args: argparse.Namespace,
+    *,
+    block_index: int,
+    result_dir: Path,
+    result_filename: str,
+) -> list[str]:
+    """Build one official streaming ``vllm bench serve`` invocation."""
+
+    seed = args.seed + block_index
+    return [
+        args.vllm_executable,
+        "bench",
+        "serve",
+        "--backend",
+        args.backend,
+        "--base-url",
+        args.base_url.rstrip("/"),
+        "--endpoint",
+        args.endpoint,
+        "--model",
+        args.model,
+        "--served-model-name",
+        args.served_model_name or args.model,
+        "--tokenizer",
+        args.tokenizer or args.model,
+        "--dataset-name",
+        "random",
+        "--random-input-len",
+        str(args.input_len),
+        "--random-output-len",
+        str(args.output_len),
+        "--random-range-ratio",
+        "0",
+        "--num-prompts",
+        str(args.num_prompts),
+        "--num-warmups",
+        str(args.warmups),
+        "--max-concurrency",
+        str(args.max_concurrency),
+        "--request-rate",
+        args.request_rate,
+        "--seed",
+        str(seed),
+        "--ignore-eos",
+        "--disable-shuffle",
+        "--percentile-metrics",
+        STREAMING_METRICS,
+        "--metric-percentiles",
+        args.percentiles,
+        "--save-result",
+        "--save-detailed",
+        "--result-dir",
+        str(result_dir),
+        "--result-filename",
+        result_filename,
+        "--ready-check-timeout-sec",
+        str(args.ready_timeout),
+        "--label",
+        args.run_label,
+        "--disable-tqdm",
+    ]
+
+
+def _git_state(commit_override: str | None) -> dict[str, Any]:
+    if commit_override:
+        return {"commit": commit_override, "dirty": None, "source": "argument"}
+
+    checkout = Path(__file__).resolve().parents[1]
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        dirty = bool(
+            subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return {"commit": None, "dirty": None, "source": "unavailable"}
+    return {"commit": commit, "dirty": dirty, "source": "checkout"}
+
+
+def _package_version() -> str | None:
+    try:
+        return importlib.metadata.version("gridbook")
+    except importlib.metadata.PackageNotFoundError:
+        try:
+            from gridbook import __version__
+
+            return __version__
+        except (ImportError, AttributeError):
+            return None
+
+
+def _vllm_version(executable: str) -> str | None:
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = result.stdout.strip() or result.stderr.strip()
+    return output or None
+
+
+def capture_dispatch_environment(
+    env: Mapping[str, str], names: Sequence[str], prefixes: Sequence[str]
+) -> dict[str, str | None]:
+    selected = set(names)
+    selected.update(
+        key for key in env if any(key.startswith(prefix) for prefix in prefixes)
+    )
+    captured: dict[str, str | None] = {}
+    for key in sorted(selected):
+        value = env.get(key)
+        if value is not None and _SENSITIVE_ENV.search(key):
+            value = "<redacted>"
+        captured[key] = value
+    return captured
+
+
+def collect_metadata(
+    args: argparse.Namespace, env: Mapping[str, str] | None = None
+) -> dict[str, Any]:
+    git = _git_state(args.git_commit)
+    if not git["commit"]:
+        raise BenchmarkError(
+            "Gridbook commit is unavailable; run from a checkout or pass --git-commit"
+        )
+    return {
+        "git": git,
+        "software": {
+            "gridbook_version": _package_version(),
+            "vllm_cli_version": _vllm_version(args.vllm_executable),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "hostname": platform.node(),
+        },
+        "artifacts": {
+            "image_id": args.image_id,
+            "model_id": args.model_id,
+            "benchmark_model": args.model,
+            "tokenizer": args.tokenizer or args.model,
+        },
+        "server": {
+            "base_url": args.base_url.rstrip("/"),
+            "backend": args.backend,
+            "endpoint": args.endpoint,
+            "served_model_name": args.served_model_name or args.model,
+            "recorded_args": list(args.server_arg),
+        },
+        "dispatch": {
+            "environment": capture_dispatch_environment(
+                os.environ if env is None else env,
+                args.dispatch_env,
+                args.dispatch_env_prefix,
+            )
+        },
+        "workload": {
+            "dataset": "random",
+            "input_len": args.input_len,
+            "output_len": args.output_len,
+            "num_prompts_per_block": args.num_prompts,
+            "warmups_per_block": args.warmups,
+            "max_concurrency": args.max_concurrency,
+            "blocks": args.blocks,
+            "base_seed": args.seed,
+            "block_seeds": [args.seed + index for index in range(args.blocks)],
+            "request_rate": args.request_rate,
+            "random_range_ratio": 0,
+            "ignore_eos": True,
+            "streaming": True,
+            "metrics": STREAMING_METRICS.split(","),
+            "percentiles": [float(item) for item in args.percentiles.split(",")],
+        },
+    }
+
+
+def _load_result(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise BenchmarkError(f"vLLM did not create result file {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkError(f"vLLM result is not valid JSON: {path}") from exc
+    # ``--append-result`` creates a list; the harness never requests it, but
+    # accepting a singleton makes this resilient to vLLM version differences.
+    if isinstance(payload, list) and len(payload) == 1:
+        payload = payload[0]
+    if not isinstance(payload, dict):
+        raise BenchmarkError("vLLM result JSON must contain one object")
+    return payload
+
+
+def _number(result: Mapping[str, Any], key: str) -> float | None:
+    value = result.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None:
+    missing = [key for key in REQUIRED_STREAMING_RESULTS if _number(result, key) is None]
+    if missing:
+        raise BenchmarkError(
+            "vLLM result lacks streaming metrics: " + ", ".join(missing)
+        )
+
+    expected = {
+        "completed": (("completed",), args.num_prompts),
+        "failed": (("failed",), 0),
+        # Current vLLM uses *_tokens.  The shorter aliases keep reports made by
+        # older bench-serve releases usable without weakening the exact-length
+        # gate.
+        "total_input_tokens": (
+            ("total_input_tokens", "total_input"),
+            args.num_prompts * args.input_len,
+        ),
+        "total_output_tokens": (
+            ("total_output_tokens", "total_output"),
+            args.num_prompts * args.output_len,
+        ),
+    }
+    mismatches = []
+    for label, (aliases, wanted) in expected.items():
+        actual = next(
+            (_number(result, key) for key in aliases if _number(result, key) is not None),
+            None,
+        )
+        if actual is None:
+            mismatches.append(f"{label}=missing (expected {wanted})")
+        elif actual != wanted:
+            mismatches.append(f"{label}={actual:g} (expected {wanted})")
+    if mismatches:
+        raise BenchmarkError(
+            "fixed-shape block was not completed exactly: " + "; ".join(mismatches)
+        )
+
+    for key, wanted in (("input_lens", args.input_len), ("output_lens", args.output_len)):
+        lengths = result.get(key)
+        if not isinstance(lengths, list) or len(lengths) != args.num_prompts:
+            raise BenchmarkError(
+                f"vLLM detailed result {key} must contain one value per prompt"
+            )
+        wrong = [index for index, value in enumerate(lengths) if value != wanted]
+        if wrong:
+            preview = ", ".join(str(index) for index in wrong[:5])
+            raise BenchmarkError(
+                f"fixed-shape block has unexpected {key} at request index: {preview}"
+            )
+
+
+def summarize_blocks(blocks: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    results = [block["result"] for block in blocks]
+    metric_names = set(SUMMARY_METRICS)
+    for result in results:
+        metric_names.update(key for key in result if _PERCENTILE_RESULT.match(key))
+
+    metrics: dict[str, Any] = {}
+    for name in sorted(metric_names):
+        values = [_number(result, name) for result in results]
+        if any(value is None for value in values):
+            continue
+        numeric = [value for value in values if value is not None]
+        metrics[name] = {
+            "values": numeric,
+            "mean": statistics.fmean(numeric),
+            "median": statistics.median(numeric),
+            "min": min(numeric),
+            "max": max(numeric),
+            "sample_stdev": statistics.stdev(numeric) if len(numeric) > 1 else None,
+        }
+    return {"completed_blocks": len(blocks), "metrics": metrics}
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _run_command(command: Sequence[str]) -> int:
+    try:
+        return subprocess.run(command, check=False).returncode
+    except OSError as exc:
+        raise BenchmarkError(f"could not execute {command[0]!r}: {exc}") from exc
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    output_path = args.output.expanduser().resolve()
+    if output_path.exists() and not args.overwrite:
+        raise BenchmarkError(
+            f"output already exists: {output_path} (pass --overwrite to replace it)"
+        )
+
+    started_at = _utc_now()
+    started_clock = time.monotonic()
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "run_label": args.run_label,
+        "started_at": started_at,
+        "finished_at": None,
+        "duration_s": None,
+        "metadata": collect_metadata(args),
+        "blocks": [],
+        "summary": None,
+    }
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="gridbook-bench-serve-") as raw_dir:
+            result_dir = Path(raw_dir)
+            for block_index in range(args.blocks):
+                filename = f"block-{block_index + 1:03d}.json"
+                command = build_vllm_command(
+                    args,
+                    block_index=block_index,
+                    result_dir=result_dir,
+                    result_filename=filename,
+                )
+                block_started = _utc_now()
+                block_clock = time.monotonic()
+                print(
+                    f"[{args.run_label}] block {block_index + 1}/{args.blocks} "
+                    f"seed={args.seed + block_index}",
+                    flush=True,
+                )
+                returncode = _run_command(command)
+                if returncode != 0:
+                    raise BenchmarkError(
+                        f"vLLM bench serve failed in block {block_index + 1} "
+                        f"with exit code {returncode}"
+                    )
+                result = _load_result(result_dir / filename)
+                validate_result(result, args)
+                report["blocks"].append(
+                    {
+                        "index": block_index + 1,
+                        "seed": args.seed + block_index,
+                        "started_at": block_started,
+                        "finished_at": _utc_now(),
+                        "wall_duration_s": time.monotonic() - block_clock,
+                        "command": command,
+                        "result": result,
+                    }
+                )
+        report["summary"] = summarize_blocks(report["blocks"])
+        report["status"] = "success"
+    except BaseException as exc:
+        report["status"] = "failed"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        raise
+    finally:
+        report["finished_at"] = _utc_now()
+        report["duration_s"] = time.monotonic() - started_clock
+        _atomic_write_json(output_path, report)
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        report = run_benchmark(args)
+    except BenchmarkError as exc:
+        print(f"gridbook-bench-serve: {exc}", file=sys.stderr)
+        return 2
+    print(
+        f"saved {len(report['blocks'])} validated block(s) to "
+        f"{args.output.expanduser().resolve()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gridbook/bench_serve.py
+++ b/gridbook/bench_serve.py
@@ -27,6 +27,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 SCHEMA = "gridbook.vllm-bench-serve.v1"
@@ -58,10 +59,37 @@ REQUIRED_STREAMING_RESULTS = (
     "mean_itl_ms",
     "mean_e2el_ms",
 )
+REQUIRED_THROUGHPUT_RESULTS = (
+    "request_throughput",
+    "output_throughput",
+    "total_token_throughput",
+)
 _PERCENTILE_RESULT = re.compile(
     r"^p(?:\d+(?:\.\d+)?)_(?:ttft|tpot|itl|e2el)_ms$"
 )
-_SENSITIVE_ENV = re.compile(r"(?:TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)", re.I)
+_SENSITIVE_SEGMENTS = {
+    "AUTH",
+    "AUTHORIZATION",
+    "BEARER",
+    "COOKIE",
+    "CREDENTIAL",
+    "CREDENTIALS",
+    "KEY",
+    "PASSWORD",
+    "PASSWD",
+    "PRIVATE",
+    "SECRET",
+    "SESSION",
+    "SIGNATURE",
+    "TOKEN",
+}
+_SENSITIVE_COMPOUNDS = ("APIKEY", "AUTHTOKEN", "ACCESSTOKEN", "REFRESHTOKEN")
+_ASSIGNMENT = re.compile(r"(\b[-\w.]+\b\s*(?:=|:)\s*)([^\s,;]+)")
+_OPTION_VALUE = re.compile(r"((?:^|\s)(--?[-\w.]+)\s+)([^\s]+)")
+_AUTH_HEADER = re.compile(
+    r"(?i)(authorization\s*:\s*(?:basic|bearer)\s+)([^\s,;]+)"
+)
+_URL = re.compile(r"https?://[^\s]+", re.I)
 
 
 class BenchmarkError(RuntimeError):
@@ -114,6 +142,13 @@ def _percentiles(value: str) -> str:
     return ",".join(f"{item:g}" for item in parsed)
 
 
+def _server_environment(value: str) -> tuple[str, str]:
+    name, separator, setting = value.partition("=")
+    if not separator or not name or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        raise argparse.ArgumentTypeError("must have the form NAME=VALUE")
+    return name, setting
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="gridbook-bench-serve",
@@ -127,6 +162,7 @@ def build_parser() -> argparse.ArgumentParser:
     server.add_argument(
         "--backend",
         default="openai",
+        choices=("openai",),
         help="vLLM bench serve backend (default: openai)",
     )
     server.add_argument(
@@ -206,9 +242,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--blocks",
         type=_positive_int,
         default=3,
-        help="independent client blocks; distinct deterministic seed per block (default: 3)",
+        help=(
+            "independent client blocks; distinct deterministic dataset seed per "
+            "block (default: 3)"
+        ),
     )
-    workload.add_argument("--seed", type=int, default=1234)
+    workload.add_argument(
+        "--dataset-seed",
+        "--seed",
+        dest="dataset_seed",
+        type=int,
+        default=1234,
+        help="random prompt seed; server generation is separately pinned greedy",
+    )
     workload.add_argument(
         "--request-rate",
         type=_request_rate,
@@ -224,20 +270,31 @@ def build_parser() -> argparse.ArgumentParser:
 
     dispatch = parser.add_argument_group("dispatch provenance")
     dispatch.add_argument(
-        "--dispatch-env",
+        "--runner-env",
         action="append",
         default=[],
         metavar="NAME",
-        help="environment variable to record; repeat as needed",
+        help="benchmark-runner environment variable to record; repeat as needed",
     )
     dispatch.add_argument(
-        "--dispatch-env-prefix",
+        "--runner-env-prefix",
         action="append",
         default=["PRISMAQUANT_"],
         metavar="PREFIX",
         help=(
-            "record variables matching this prefix; repeat to add prefixes "
+            "record runner variables matching this prefix; repeat to add prefixes "
             "(PRISMAQUANT_ is always included)"
+        ),
+    )
+    dispatch.add_argument(
+        "--server-env",
+        action="append",
+        default=[],
+        type=_server_environment,
+        metavar="NAME=VALUE",
+        help=(
+            "explicit environment from the separately managed server; repeat as "
+            "needed (never inferred from the runner)"
         ),
     )
 
@@ -259,6 +316,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.max_concurrency > args.num_prompts:
         parser.error("--max-concurrency cannot exceed --num-prompts")
+    server_env_names = [name for name, _ in args.server_env]
+    if len(server_env_names) != len(set(server_env_names)):
+        parser.error("--server-env names must not be repeated")
     return args
 
 
@@ -271,7 +331,7 @@ def build_vllm_command(
 ) -> list[str]:
     """Build one official streaming ``vllm bench serve`` invocation."""
 
-    seed = args.seed + block_index
+    dataset_seed = args.dataset_seed + block_index
     return [
         args.vllm_executable,
         "bench",
@@ -305,7 +365,9 @@ def build_vllm_command(
         "--request-rate",
         args.request_rate,
         "--seed",
-        str(seed),
+        str(dataset_seed),
+        "--temperature",
+        "0",
         "--ignore-eos",
         "--disable-shuffle",
         "--percentile-metrics",
@@ -324,6 +386,78 @@ def build_vllm_command(
         args.run_label,
         "--disable-tqdm",
     ]
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.upper().strip("-")
+    segments = set(filter(None, re.split(r"[^A-Z0-9]+|_+", normalized)))
+    if segments & _SENSITIVE_SEGMENTS:
+        return True
+    compact = re.sub(r"[^A-Z0-9]", "", normalized)
+    return any(marker in compact for marker in _SENSITIVE_COMPOUNDS)
+
+
+def _redact_url(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+        if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+            return value
+        hostname = parsed.hostname
+        if hostname is None:
+            return "<redacted-invalid-url>"
+        host = f"[{hostname}]" if ":" in hostname else hostname
+        try:
+            port = parsed.port
+        except ValueError:
+            return "<redacted-invalid-url>"
+        if port is not None:
+            host = f"{host}:{port}"
+        netloc = f"<redacted>@{host}" if parsed.username is not None else host
+        query = urlencode(
+            [
+                (key, "<redacted>" if _is_sensitive_key(key) else setting)
+                for key, setting in parse_qsl(parsed.query, keep_blank_values=True)
+            ],
+            doseq=True,
+        )
+        return urlunsplit((parsed.scheme, netloc, parsed.path, query, parsed.fragment))
+    except (TypeError, ValueError):
+        return "<redacted-invalid-url>"
+
+
+def _redact_text(value: str) -> str:
+    def redact_url(match: re.Match[str]) -> str:
+        return _redact_url(match.group(0))
+
+    def redact_assignment(match: re.Match[str]) -> str:
+        prefix = match.group(1)
+        key = re.split(r"\s*(?:=|:)\s*", prefix, maxsplit=1)[0]
+        return prefix + ("<redacted>" if _is_sensitive_key(key) else match.group(2))
+
+    def redact_option(match: re.Match[str]) -> str:
+        return match.group(1) + (
+            "<redacted>" if _is_sensitive_key(match.group(2)) else match.group(3)
+        )
+
+    redacted = _URL.sub(redact_url, str(value))
+    redacted = _AUTH_HEADER.sub(r"\1<redacted>", redacted)
+    redacted = _ASSIGNMENT.sub(redact_assignment, redacted)
+    return _OPTION_VALUE.sub(redact_option, redacted)
+
+
+def redact_command(command: Sequence[str]) -> list[str]:
+    redacted: list[str] = []
+    hide_next = False
+    for item in command:
+        if hide_next:
+            redacted.append("<redacted>")
+            hide_next = False
+            continue
+        text = _redact_text(str(item))
+        redacted.append(text)
+        if str(item).startswith("-") and "=" not in str(item):
+            hide_next = _is_sensitive_key(str(item))
+    return redacted
 
 
 def _git_state(commit_override: str | None) -> dict[str, Any]:
@@ -389,8 +523,8 @@ def capture_dispatch_environment(
     captured: dict[str, str | None] = {}
     for key in sorted(selected):
         value = env.get(key)
-        if value is not None and _SENSITIVE_ENV.search(key):
-            value = "<redacted>"
+        if value is not None:
+            value = "<redacted>" if _is_sensitive_key(key) else _redact_text(value)
         captured[key] = value
     return captured
 
@@ -398,40 +532,65 @@ def capture_dispatch_environment(
 def collect_metadata(
     args: argparse.Namespace, env: Mapping[str, str] | None = None
 ) -> dict[str, Any]:
-    git = _git_state(args.git_commit)
-    if not git["commit"]:
-        raise BenchmarkError(
-            "Gridbook commit is unavailable; run from a checkout or pass --git-commit"
-        )
-    return {
+    probe_errors: dict[str, str] = {}
+
+    def probe(name: str, function, fallback=None):
+        try:
+            return function()
+        except Exception as exc:  # noqa: BLE001 - metadata cannot hide run failure
+            probe_errors[name] = _redact_text(f"{type(exc).__name__}: {exc}")
+            return fallback
+
+    git = probe(
+        "git",
+        lambda: _git_state(args.git_commit),
+        {"commit": None, "dirty": None, "source": "probe-error"},
+    )
+    runner_env = os.environ if env is None else env
+    explicit_server_env = {
+        key: "<redacted>" if _is_sensitive_key(key) else _redact_text(value)
+        for key, value in sorted(args.server_env)
+    }
+    metadata = {
         "git": git,
         "software": {
-            "gridbook_version": _package_version(),
-            "vllm_cli_version": _vllm_version(args.vllm_executable),
-            "python": platform.python_version(),
-            "platform": platform.platform(),
-            "machine": platform.machine(),
-            "hostname": platform.node(),
+            "gridbook_version": probe("gridbook_version", _package_version),
+            "vllm_cli_version": probe(
+                "vllm_cli_version", lambda: _vllm_version(args.vllm_executable)
+            ),
+            "python": probe("python", platform.python_version),
+            "platform": probe("platform", platform.platform),
+            "machine": probe("machine", platform.machine),
+            "hostname": probe("hostname", platform.node),
         },
         "artifacts": {
-            "image_id": args.image_id,
-            "model_id": args.model_id,
-            "benchmark_model": args.model,
-            "tokenizer": args.tokenizer or args.model,
+            "image_id": _redact_text(args.image_id),
+            "model_id": _redact_text(args.model_id),
+            "benchmark_model": _redact_text(args.model),
+            "tokenizer": _redact_text(args.tokenizer or args.model),
         },
         "server": {
-            "base_url": args.base_url.rstrip("/"),
+            "base_url": _redact_url(args.base_url.rstrip("/")),
             "backend": args.backend,
-            "endpoint": args.endpoint,
-            "served_model_name": args.served_model_name or args.model,
-            "recorded_args": list(args.server_arg),
+            "endpoint": _redact_text(args.endpoint),
+            "served_model_name": _redact_text(
+                args.served_model_name or args.model
+            ),
+            "recorded_args": [_redact_text(value) for value in args.server_arg],
         },
         "dispatch": {
-            "environment": capture_dispatch_environment(
-                os.environ if env is None else env,
-                args.dispatch_env,
-                args.dispatch_env_prefix,
-            )
+            "runner_environment": {
+                "source": "benchmark process",
+                "values": capture_dispatch_environment(
+                    runner_env,
+                    args.runner_env,
+                    args.runner_env_prefix,
+                ),
+            },
+            "server_environment": {
+                "source": "explicit --server-env arguments",
+                "values": explicit_server_env,
+            },
         },
         "workload": {
             "dataset": "random",
@@ -441,8 +600,15 @@ def collect_metadata(
             "warmups_per_block": args.warmups,
             "max_concurrency": args.max_concurrency,
             "blocks": args.blocks,
-            "base_seed": args.seed,
-            "block_seeds": [args.seed + index for index in range(args.blocks)],
+            "dataset_base_seed": args.dataset_seed,
+            "dataset_block_seeds": [
+                args.dataset_seed + index for index in range(args.blocks)
+            ],
+            "sampling": {
+                "strategy": "greedy",
+                "temperature": 0.0,
+                "sampling_seed": None,
+            },
             "request_rate": args.request_rate,
             "random_range_ratio": 0,
             "ignore_eos": True,
@@ -451,6 +617,8 @@ def collect_metadata(
             "percentiles": [float(item) for item in args.percentiles.split(",")],
         },
     }
+    metadata["collection_errors"] = probe_errors
+    return metadata
 
 
 def _load_result(path: Path) -> dict[str, Any]:
@@ -473,14 +641,90 @@ def _number(result: Mapping[str, Any], key: str) -> float | None:
     value = result.get(key)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
-    return float(value)
+    number = float(value)
+    return number if math.isfinite(number) else None
+
+
+def _nonfinite_paths(value: Any, path: str = "$") -> list[str]:
+    if isinstance(value, bool) or value is None:
+        return []
+    if isinstance(value, float) and not math.isfinite(value):
+        return [path]
+    if isinstance(value, Mapping):
+        paths: list[str] = []
+        for key, child in value.items():
+            paths.extend(_nonfinite_paths(child, f"{path}.{key}"))
+        return paths
+    if isinstance(value, (list, tuple)):
+        paths = []
+        for index, child in enumerate(value):
+            paths.extend(_nonfinite_paths(child, f"{path}[{index}]"))
+        return paths
+    return []
+
+
+def _percentile_result_key(percentile: str, metric: str) -> str:
+    number = float(percentile)
+    label = str(int(number)) if number.is_integer() else f"{number:g}"
+    return f"p{label}_{metric}_ms"
 
 
 def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None:
-    missing = [key for key in REQUIRED_STREAMING_RESULTS if _number(result, key) is None]
+    nonfinite = _nonfinite_paths(result)
+    if nonfinite:
+        raise BenchmarkError(
+            "vLLM result contains NaN/Infinity at: " + ", ".join(nonfinite[:10])
+        )
+
+    requested_percentiles = args.percentiles.split(",")
+    required_metrics = list(REQUIRED_STREAMING_RESULTS)
+    required_metrics.extend(REQUIRED_THROUGHPUT_RESULTS)
+    for metric in ("ttft", "tpot", "itl", "e2el"):
+        required_metrics.extend((f"median_{metric}_ms", f"std_{metric}_ms"))
+        required_metrics.extend(
+            _percentile_result_key(percentile, metric)
+            for percentile in requested_percentiles
+        )
+    missing = [key for key in required_metrics if _number(result, key) is None]
     if missing:
         raise BenchmarkError(
-            "vLLM result lacks streaming metrics: " + ", ".join(missing)
+            "vLLM result lacks finite required metrics: " + ", ".join(missing)
+        )
+
+    positive_metrics = list(REQUIRED_THROUGHPUT_RESULTS)
+    for metric in ("ttft", "e2el"):
+        positive_metrics.extend((f"mean_{metric}_ms", f"median_{metric}_ms"))
+        positive_metrics.extend(
+            _percentile_result_key(percentile, metric)
+            for percentile in requested_percentiles
+        )
+    if args.output_len > 1:
+        for metric in ("tpot", "itl"):
+            positive_metrics.extend((f"mean_{metric}_ms", f"median_{metric}_ms"))
+            positive_metrics.extend(
+                _percentile_result_key(percentile, metric)
+                for percentile in requested_percentiles
+            )
+    nonpositive = [key for key in positive_metrics if _number(result, key) <= 0]
+    if nonpositive:
+        raise BenchmarkError(
+            "vLLM result has non-positive latency/throughput metrics: "
+            + ", ".join(nonpositive)
+        )
+    nonnegative_metrics = [
+        f"std_{metric}_ms" for metric in ("ttft", "tpot", "itl", "e2el")
+    ]
+    if args.output_len == 1:
+        for metric in ("tpot", "itl"):
+            nonnegative_metrics.extend((f"mean_{metric}_ms", f"median_{metric}_ms"))
+            nonnegative_metrics.extend(
+                _percentile_result_key(percentile, metric)
+                for percentile in requested_percentiles
+            )
+    negative = [key for key in nonnegative_metrics if _number(result, key) < 0]
+    if negative:
+        raise BenchmarkError(
+            "vLLM result has negative latency metrics: " + ", ".join(negative)
         )
 
     expected = {
@@ -526,9 +770,68 @@ def validate_result(result: Mapping[str, Any], args: argparse.Namespace) -> None
                 f"fixed-shape block has unexpected {key} at request index: {preview}"
             )
 
+    errors = result.get("errors")
+    if not isinstance(errors, list) or len(errors) != args.num_prompts:
+        raise BenchmarkError("vLLM detailed result errors must cover every prompt")
+    if any(error is not None and error != "" for error in errors):
+        raise BenchmarkError("vLLM detailed result contains request errors")
+
+    ttfts = result.get("ttfts")
+    if not isinstance(ttfts, list) or len(ttfts) != args.num_prompts:
+        raise BenchmarkError("vLLM detailed result ttfts must cover every prompt")
+    bad_ttft = [
+        index
+        for index, value in enumerate(ttfts)
+        if isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or value <= 0
+    ]
+    if bad_ttft:
+        raise BenchmarkError(
+            "vLLM detailed result has non-positive/non-finite TTFT at request "
+            f"index: {', '.join(str(index) for index in bad_ttft[:5])}"
+        )
+
+    itls = result.get("itls")
+    if not isinstance(itls, list) or len(itls) != args.num_prompts:
+        raise BenchmarkError("vLLM detailed result itls must cover every prompt")
+    for request_index, request_itls in enumerate(itls):
+        if not isinstance(request_itls, list):
+            raise BenchmarkError(
+                f"vLLM detailed result itls[{request_index}] must be an array"
+            )
+        if args.output_len > 1 and not request_itls:
+            raise BenchmarkError(
+                "multi-token response has no inter-token latency samples at "
+                f"request index {request_index}"
+            )
+        for interval_index, value in enumerate(request_itls):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                or value <= 0
+            ):
+                raise BenchmarkError(
+                    "vLLM detailed result has non-positive/non-finite ITL at "
+                    f"request {request_index}, interval {interval_index}"
+                )
+
+    # vLLM does not currently emit a per-request E2EL array.  Its streaming
+    # definition is exactly TTFT plus the subsequent inter-token intervals, so
+    # reconstructing it also validates that each detailed request has a finite,
+    # positive end-to-end latency.  output_len=1 intentionally has no ITLs.
+    e2els = [
+        float(ttft) + sum(map(float, intervals))
+        for ttft, intervals in zip(ttfts, itls)
+    ]
+    if any(not math.isfinite(value) or value <= 0 for value in e2els):
+        raise BenchmarkError("derived detailed E2EL contains a non-finite value")
+
 
 def summarize_blocks(blocks: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
-    results = [block["result"] for block in blocks]
+    results = [block["raw_result"] for block in blocks]
     metric_names = set(SUMMARY_METRICS)
     for result in results:
         metric_names.update(key for key in result if _PERCENTILE_RESULT.match(key))
@@ -557,7 +860,7 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
     )
     try:
         with os.fdopen(fd, "w") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
+            json.dump(payload, handle, indent=2, sort_keys=True, allow_nan=False)
             handle.write("\n")
         os.replace(temporary, path)
     except BaseException:
@@ -566,6 +869,47 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
         except FileNotFoundError:
             pass
         raise
+
+
+def _reserve_output(path: Path, *, overwrite: bool) -> None:
+    """Atomically claim ``path`` before probes or requests begin.
+
+    ``exists()`` followed by a write has a race in which two benchmark clients
+    both believe a result name is free.  O_EXCL makes exactly one of them the
+    owner.  Explicit ``--overwrite`` opts out of that protection by design.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_TRUNC if overwrite else os.O_EXCL
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise BenchmarkError(
+            f"output already exists: {path} (pass --overwrite to replace it)"
+        ) from exc
+    with os.fdopen(descriptor, "w") as handle:
+        os.fchmod(handle.fileno(), 0o600)
+        json.dump(
+            {"schema": SCHEMA, "status": "reserved", "reserved_at": _utc_now()},
+            handle,
+            allow_nan=False,
+        )
+        handle.write("\n")
+
+
+def _json_safe(value: Any) -> Any:
+    """Preserve invalid numeric evidence without emitting invalid JSON."""
+
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return {"nonfinite_float": "NaN"}
+        return {"nonfinite_float": "Infinity" if value > 0 else "-Infinity"}
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(child) for key, child in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(child) for child in value]
+    return value
 
 
 def _run_command(command: Sequence[str]) -> int:
@@ -577,10 +921,7 @@ def _run_command(command: Sequence[str]) -> int:
 
 def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
     output_path = args.output.expanduser().resolve()
-    if output_path.exists() and not args.overwrite:
-        raise BenchmarkError(
-            f"output already exists: {output_path} (pass --overwrite to replace it)"
-        )
+    _reserve_output(output_path, overwrite=args.overwrite)
 
     started_at = _utc_now()
     started_clock = time.monotonic()
@@ -591,12 +932,19 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         "started_at": started_at,
         "finished_at": None,
         "duration_s": None,
-        "metadata": collect_metadata(args),
+        "metadata": None,
         "blocks": [],
         "summary": None,
     }
 
     try:
+        report["metadata"] = collect_metadata(args)
+        _atomic_write_json(output_path, report)
+        if not report["metadata"]["git"]["commit"]:
+            raise BenchmarkError(
+                "Gridbook commit is unavailable; run from a checkout or pass "
+                "--git-commit"
+            )
         with tempfile.TemporaryDirectory(prefix="gridbook-bench-serve-") as raw_dir:
             result_dir = Path(raw_dir)
             for block_index in range(args.blocks):
@@ -609,35 +957,56 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                 )
                 block_started = _utc_now()
                 block_clock = time.monotonic()
+                block: dict[str, Any] = {
+                    "index": block_index + 1,
+                    "dataset_seed": args.dataset_seed + block_index,
+                    "status": "running",
+                    "started_at": block_started,
+                    "finished_at": None,
+                    "wall_duration_s": None,
+                    "command": redact_command(command),
+                    "returncode": None,
+                    "raw_result": None,
+                    "validation_error": None,
+                }
+                report["blocks"].append(block)
+                # A durable checkpoint makes the in-flight command available
+                # even if the client is interrupted before vLLM returns.
+                _atomic_write_json(output_path, report)
                 print(
                     f"[{args.run_label}] block {block_index + 1}/{args.blocks} "
-                    f"seed={args.seed + block_index}",
+                    f"dataset_seed={args.dataset_seed + block_index}",
                     flush=True,
                 )
-                returncode = _run_command(command)
-                if returncode != 0:
-                    raise BenchmarkError(
-                        f"vLLM bench serve failed in block {block_index + 1} "
-                        f"with exit code {returncode}"
-                    )
-                result = _load_result(result_dir / filename)
-                validate_result(result, args)
-                report["blocks"].append(
-                    {
-                        "index": block_index + 1,
-                        "seed": args.seed + block_index,
-                        "started_at": block_started,
-                        "finished_at": _utc_now(),
-                        "wall_duration_s": time.monotonic() - block_clock,
-                        "command": command,
-                        "result": result,
-                    }
-                )
+                try:
+                    returncode = _run_command(command)
+                    block["returncode"] = returncode
+                    _atomic_write_json(output_path, report)
+                    if returncode != 0:
+                        raise BenchmarkError(
+                            f"vLLM bench serve failed in block {block_index + 1} "
+                            f"with exit code {returncode}"
+                        )
+                    try:
+                        result = _load_result(result_dir / filename)
+                        block["raw_result"] = _json_safe(result)
+                        _atomic_write_json(output_path, report)
+                        validate_result(result, args)
+                    except BenchmarkError as exc:
+                        block["validation_error"] = _redact_text(str(exc))
+                        raise
+                    block["status"] = "success"
+                except BaseException:
+                    block["status"] = "failed"
+                    raise
+                finally:
+                    block["finished_at"] = _utc_now()
+                    block["wall_duration_s"] = time.monotonic() - block_clock
         report["summary"] = summarize_blocks(report["blocks"])
         report["status"] = "success"
     except BaseException as exc:
         report["status"] = "failed"
-        report["error"] = f"{type(exc).__name__}: {exc}"
+        report["error"] = _redact_text(f"{type(exc).__name__}: {exc}")
         raise
     finally:
         report["finished_at"] = _utc_now()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ Documentation = "https://github.com/RobTand/gridbook/blob/master/docs/SPEC.md"
 [project.entry-points."vllm.general_plugins"]
 gridbook = "gridbook:register"
 
+[project.scripts]
+gridbook-bench-serve = "gridbook.bench_serve:main"
+
 [tool.setuptools.dynamic]
 version = { attr = "gridbook.__version__" }
 

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -15,8 +15,8 @@ import pytest
 from gridbook import bench_serve
 
 
-def _parse(tmp_path, *extra):
-    argv = [
+def _argv(tmp_path):
+    return [
         "--base-url",
         "http://127.0.0.1:8000/",
         "--model",
@@ -31,6 +31,34 @@ def _parse(tmp_path, *extra):
         "deadbeef",
         "--run-label",
         "gridbook-0.6b-decode",
+        "--artifact-bytes",
+        "800",
+        "--byte-budget",
+        "900",
+        "--format-rung",
+        "FP8_CB_K36",
+        "--serialized-layout",
+        "product-codebook-indices-v1",
+        "--scale-coding",
+        "e4m3-per-block",
+        "--quant-contract",
+        "W8A8",
+        "--kernel-backend",
+        "gridbook-cuda-cb-gemv-v2",
+        "--tensor-parallel-size",
+        "1",
+        "--fallback-state",
+        "none-observed",
+        "--client-runtime-id",
+        "vllm-bench@g54b16d8a9",
+        "--server-runtime-id",
+        "vllm@g54b16d8a9+gridbook-0.3.0",
+        "--gpu-id",
+        "NVIDIA-GB10:GPU-1234",
+        "--driver-version",
+        "580.00",
+        "--cuda-version",
+        "13.0",
         "--input-len",
         "32",
         "--output-len",
@@ -41,17 +69,31 @@ def _parse(tmp_path, *extra):
         "1",
         "--output",
         str(tmp_path / "report.json"),
-        *extra,
     ]
-    return bench_serve.parse_args(argv)
+
+
+def _parse(tmp_path, *extra):
+    return bench_serve.parse_args([*_argv(tmp_path), *extra])
 
 
 def _option(command, name):
     return command[command.index(name) + 1]
 
 
+def _without_option(argv, name):
+    index = argv.index(name)
+    return [*argv[:index], *argv[index + 2 :]]
+
+
 def _valid_result(args, *, offset=0.0):
     multi_token = args.output_len > 1
+    ttft_ms = 20.0 + offset
+    # Detailed ITLs describe streamed chunk arrivals, not token cardinality.
+    # Keeping one interval for a 256-token response protects compatibility with
+    # bundled/speculatively accepted token chunks.
+    itl_ms = 2.0 + offset if multi_token else 0.0
+    e2el_ms = ttft_ms + itl_ms
+    tpot_ms = itl_ms / (args.output_len - 1) if multi_token else 0.0
     result = {
         "completed": args.num_prompts,
         "failed": 0,
@@ -60,31 +102,32 @@ def _valid_result(args, *, offset=0.0):
         "input_lens": [args.input_len] * args.num_prompts,
         "output_lens": [args.output_len] * args.num_prompts,
         "errors": [""] * args.num_prompts,
-        "ttfts": [0.020 + offset / 1000] * args.num_prompts,
-        "itls": [[0.002 + offset / 1000] if multi_token else []
-                 for _ in range(args.num_prompts)],
+        "ttfts": [ttft_ms / 1000] * args.num_prompts,
+        "itls": [
+            [itl_ms / 1000] if multi_token else []
+            for _ in range(args.num_prompts)
+        ],
         "request_throughput": 2.0 + offset,
         "output_throughput": 500.0 + offset,
         "total_token_throughput": 600.0 + offset,
-        "mean_ttft_ms": 20.0 + offset,
-        "median_ttft_ms": 19.0 + offset,
-        "std_ttft_ms": 1.0,
-        "p99_ttft_ms": 22.0 + offset,
-        "mean_tpot_ms": 2.0 + offset if multi_token else 0.0,
-        "median_tpot_ms": 1.9 + offset if multi_token else 0.0,
-        "std_tpot_ms": 0.1,
-        "mean_itl_ms": 2.1 + offset if multi_token else 0.0,
-        "median_itl_ms": 2.0 + offset if multi_token else 0.0,
-        "std_itl_ms": 0.2,
-        "mean_e2el_ms": 530.0 + offset,
-        "median_e2el_ms": 525.0 + offset,
-        "std_e2el_ms": 5.0,
+        "mean_ttft_ms": ttft_ms,
+        "median_ttft_ms": ttft_ms,
+        "std_ttft_ms": 0.0,
+        "mean_tpot_ms": tpot_ms,
+        "median_tpot_ms": tpot_ms,
+        "std_tpot_ms": 0.0,
+        "mean_itl_ms": itl_ms,
+        "median_itl_ms": itl_ms,
+        "std_itl_ms": 0.0,
+        "mean_e2el_ms": e2el_ms,
+        "median_e2el_ms": e2el_ms,
+        "std_e2el_ms": 0.0,
     }
     percentile_values = {
-        "ttft": 22.0 + offset,
-        "tpot": 2.2 + offset if multi_token else 0.0,
-        "itl": 2.5 + offset if multi_token else 0.0,
-        "e2el": 540.0 + offset,
+        "ttft": ttft_ms,
+        "tpot": tpot_ms,
+        "itl": itl_ms,
+        "e2el": e2el_ms,
     }
     for percentile in args.percentiles.split(","):
         for metric, value in percentile_values.items():
@@ -108,7 +151,10 @@ def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
     assert _option(command, "--dataset-name") == "random"
     assert _option(command, "--random-input-len") == "32"
     assert _option(command, "--random-output-len") == "256"
-    assert _option(command, "--random-range-ratio") == "0"
+    assert json.loads(_option(command, "--random-range-ratio")) == {
+        "input": 0.0,
+        "output": 0.0,
+    }
     assert _option(command, "--num-warmups") == "4"
     assert _option(command, "--seed") == "902"
     assert _option(command, "--temperature") == "0"
@@ -147,6 +193,50 @@ def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
         _parse(tmp_path, "--server-env", "MISSING_EQUALS")
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--server-env", "MODE=a", "--server-env", "MODE=b")
+    for ratio in ("-0.01", "1", "nan", "not-a-number"):
+        with pytest.raises(SystemExit):
+            _parse(tmp_path, "--input-range-ratio", ratio)
+
+
+def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
+    required = (
+        "--artifact-bytes",
+        "--byte-budget",
+        "--format-rung",
+        "--serialized-layout",
+        "--scale-coding",
+        "--quant-contract",
+        "--kernel-backend",
+        "--tensor-parallel-size",
+        "--fallback-state",
+        "--client-runtime-id",
+        "--server-runtime-id",
+        "--gpu-id",
+        "--driver-version",
+        "--cuda-version",
+    )
+    for option in required:
+        with pytest.raises(SystemExit):
+            bench_serve.parse_args(_without_option(_argv(tmp_path), option))
+
+
+def test_whole_artifact_must_fit_exact_byte_budget(tmp_path):
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--artifact-bytes",
+            "901",
+            "--byte-budget",
+            "900",
+        )
+    args = _parse(
+        tmp_path,
+        "--artifact-bytes",
+        "900",
+        "--byte-budget",
+        "900",
+    )
+    assert args.artifact_bytes == args.byte_budget == 900
 
 
 def test_dispatch_environment_is_sorted_explicit_and_secret_safe():
@@ -198,9 +288,31 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
         "source": "argument",
     }
     assert metadata["software"]["gridbook_version"] == "0.3.0"
-    assert metadata["software"]["vllm_cli_version"] == "vLLM 1.2"
+    assert metadata["software"]["runner_vllm_cli_probe"] == "vLLM 1.2"
     assert metadata["artifacts"]["image_id"].endswith("sha256:abc")
     assert metadata["artifacts"]["model_id"] == "org/artifact@0123456"
+    assert metadata["artifacts"]["whole_served_artifact_bytes"] == 800
+    assert metadata["artifacts"]["byte_budget_bytes"] == 900
+    assert metadata["artifacts"]["budget_headroom_bytes"] == 100
+    assert metadata["artifacts"]["within_byte_budget"] is True
+    assert metadata["execution_identity"] == {
+        "format_rung": "FP8_CB_K36",
+        "serialization": {
+            "layout": "product-codebook-indices-v1",
+            "scale_coding": "e4m3-per-block",
+        },
+        "quant_contract": "W8A8",
+        "kernel_backend": "gridbook-cuda-cb-gemv-v2",
+        "tensor_parallel_size": 1,
+        "fallback_state": "none-observed",
+        "client_runtime_id": "vllm-bench@g54b16d8a9",
+        "server_runtime_id": "vllm@g54b16d8a9+gridbook-0.3.0",
+        "hardware": {
+            "gpu_id": "NVIDIA-GB10:GPU-1234",
+            "driver_version": "580.00",
+            "cuda_version": "13.0",
+        },
+    }
     assert metadata["server"]["recorded_args"] == ["--enforce-eager"]
     assert metadata["dispatch"]["runner_environment"] == {
         "source": "benchmark process",
@@ -234,6 +346,9 @@ def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
         secret_url,
         "--server-arg=--hf-token supersecret",
         "--server-arg=Authorization: Bearer abc123",
+        "--server-arg=Authorization: Token token-secret",
+        "--server-arg=--hf-token",
+        "--server-arg=split-secret",
         "--server-arg=MONKEY=visible",
     )
     metadata = bench_serve.collect_metadata(args, {})
@@ -243,7 +358,15 @@ def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
     redacted_command = bench_serve.redact_command(command)
     serialized = json.dumps({"metadata": metadata, "command": redacted_command})
 
-    for secret in ("alice", "password", "topsecret", "supersecret", "abc123"):
+    for secret in (
+        "alice",
+        "password",
+        "topsecret",
+        "supersecret",
+        "abc123",
+        "token-secret",
+        "split-secret",
+    ):
         assert secret not in serialized
     assert "mode=fast" in metadata["server"]["base_url"]
     assert "MONKEY=visible" in serialized
@@ -278,6 +401,10 @@ def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_p
     with pytest.raises(bench_serve.BenchmarkError, match="unexpected output_lens"):
         bench_serve.validate_result(uneven, args)
 
+    uneven_input = dict(result, input_lens=[31, 33] + [32] * 6)
+    with pytest.raises(bench_serve.BenchmarkError, match="unexpected input_lens"):
+        bench_serve.validate_result(uneven_input, args)
+
 
 def test_validate_result_requires_detailed_positive_streaming_arrays(tmp_path):
     args = _parse(tmp_path)
@@ -305,12 +432,77 @@ def test_validate_result_requires_detailed_positive_streaming_arrays(tmp_path):
         bench_serve.validate_result(zero_itl, args)
 
 
+def test_validate_result_reconciles_aggregate_and_detailed_timings(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+
+    bad_ttft = dict(result, mean_ttft_ms=result["mean_ttft_ms"] + 1.0)
+    with pytest.raises(bench_serve.BenchmarkError, match="mean_ttft_ms disagrees"):
+        bench_serve.validate_result(bad_ttft, args)
+
+    bad_itl = dict(result, median_itl_ms=result["median_itl_ms"] + 1.0)
+    with pytest.raises(bench_serve.BenchmarkError, match="median_itl_ms disagrees"):
+        bench_serve.validate_result(bad_itl, args)
+
+    bad_e2el = dict(result, mean_e2el_ms=result["mean_e2el_ms"] + 10.0)
+    with pytest.raises(bench_serve.BenchmarkError, match="mean_e2el_ms disagrees"):
+        bench_serve.validate_result(bad_e2el, args)
+
+    bad_tpot = dict(result, mean_tpot_ms=result["mean_tpot_ms"] + 1.0)
+    with pytest.raises(bench_serve.BenchmarkError, match="mean_tpot_ms disagrees"):
+        bench_serve.validate_result(bad_tpot, args)
+
+
 def test_single_token_prefill_explicitly_allows_empty_itl_and_zero_tpot(tmp_path):
     args = _parse(tmp_path, "--output-len", "1")
     result = _valid_result(args)
     assert all(not intervals for intervals in result["itls"])
     assert result["mean_itl_ms"] == result["mean_tpot_ms"] == 0.0
     bench_serve.validate_result(result, args)
+
+
+def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
+    args = _parse(tmp_path, "--input-range-ratio", "0.25")
+    command = bench_serve.build_vllm_command(
+        args, block_index=0, result_dir=tmp_path, result_filename="raw.json"
+    )
+    assert json.loads(_option(command, "--random-range-ratio")) == {
+        "input": 0.25,
+        "output": 0.0,
+    }
+    assert bench_serve._input_length_bounds(32, 0.25) == (1, 40)
+    metadata = bench_serve.collect_metadata(args, {})
+    assert metadata["workload"]["input_range_ratio"] == 0.25
+    assert metadata["workload"]["vllm_range_ratio"] == {
+        "input": 0.25,
+        "output": 0.0,
+    }
+    assert metadata["workload"]["accepted_input_length_bounds"] == [1, 40]
+
+    input_lens = [24, 26, 28, 30, 32, 34, 36, 40]
+    result = _valid_result(args)
+    result["input_lens"] = input_lens
+    result["total_input_tokens"] = sum(input_lens)
+    bench_serve.validate_result(result, args)
+
+    too_long = dict(result, input_lens=[41, *input_lens[1:]])
+    too_long["total_input_tokens"] = sum(too_long["input_lens"])
+    with pytest.raises(bench_serve.BenchmarkError, match=r"range \[1, 40\]"):
+        bench_serve.validate_result(too_long, args)
+
+    wrong_type = dict(result, input_lens=[24.0, *input_lens[1:]])
+    with pytest.raises(bench_serve.BenchmarkError, match="unexpected input_lens"):
+        bench_serve.validate_result(wrong_type, args)
+
+    wrong_output_type = dict(
+        result, output_lens=[256.0, *result["output_lens"][1:]]
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="unexpected output_lens"):
+        bench_serve.validate_result(wrong_output_type, args)
+
+    wrong_total = dict(result, total_input_tokens=sum(input_lens) + 1)
+    with pytest.raises(bench_serve.BenchmarkError, match="do not reconcile"):
+        bench_serve.validate_result(wrong_total, args)
 
 
 def test_validate_result_requires_throughput_percentiles_and_finite_numbers(tmp_path):
@@ -351,7 +543,7 @@ def test_summary_keeps_independent_values_and_sample_dispersion(tmp_path):
     assert ttft["mean"] == pytest.approx(21.0)
     assert ttft["median"] == pytest.approx(21.0)
     assert ttft["sample_stdev"] == pytest.approx(1.0)
-    assert summary["metrics"]["p99_itl_ms"]["values"] == [2.5, 3.5, 4.5]
+    assert summary["metrics"]["p99_itl_ms"]["values"] == [2.0, 3.0, 4.0]
 
 
 def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypatch):
@@ -504,6 +696,23 @@ def test_existing_report_is_never_replaced_without_opt_in(tmp_path, monkeypatch)
     with pytest.raises(bench_serve.BenchmarkError, match="already exists"):
         bench_serve.run_benchmark(args)
     assert args.output.read_text() == "keep me"
+
+
+def test_overwrite_fails_closed_on_symlink_output(tmp_path, monkeypatch):
+    target = tmp_path / "target.json"
+    target.write_text("keep target")
+    link = tmp_path / "report.json"
+    link.symlink_to(target)
+    args = _parse(tmp_path, "--overwrite")
+    monkeypatch.setattr(
+        bench_serve,
+        "_run_command",
+        lambda command: pytest.fail("benchmark must not start"),
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="symlink"):
+        bench_serve.run_benchmark(args)
+    assert link.is_symlink()
+    assert target.read_text() == "keep target"
 
 
 def test_output_reservation_has_exactly_one_concurrent_winner(tmp_path):

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -917,8 +917,10 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     )
 
     assert metadata["git"]["commit"] == GRIDBOOK_COMMIT
-    assert metadata["git"]["release_eligible"] is True
     assert metadata["git"]["source"] in {"argument", "argument+checkout"}
+    assert metadata["git"]["release_eligible"] is (
+        metadata["git"]["source"] == "argument+checkout"
+    )
     assert metadata["git"]["dirty"] in {None, False}
     assert metadata["software"]["gridbook_version"] == "0.3.0"
     assert metadata["software"]["runner_vllm_cli_probe"] == CLIENT_RUNTIME_ID

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -266,7 +266,7 @@ def _valid_result(args, *, offset=0.0):
         "request_goodput": None,
         "max_output_tokens_per_s": total_output / duration,
         "max_concurrent_requests": args.max_concurrency,
-        "rtfx": [1.0] * args.num_prompts,
+        "rtfx": 0.0,
         "ttfts": [ttft_ms / 1000] * args.num_prompts,
         "itls": [
             [itl_ms / 1000] if multi_token else [] for _ in range(args.num_prompts)
@@ -1264,6 +1264,22 @@ def test_pinned_vllm_saved_invocation_envelope_is_reconciled_exactly(tmp_path):
         with pytest.raises(bench_serve.BenchmarkError, match=field):
             bench_serve.validate_result(missing, args)
 
+    ancillary_mutations = {
+        "date": "2026-07-31",
+        "request_goodput": 1.0,
+        "generated_texts": result["generated_texts"][:-1],
+        "start_times": [-1.0, *result["start_times"][1:]],
+        "max_output_tokens_per_s": -1.0,
+        "max_concurrent_requests": True,
+        "rtfx": 0.1,
+    }
+    for field, bad_value in ancillary_mutations.items():
+        with pytest.raises(bench_serve.BenchmarkError, match=field):
+            bench_serve.validate_result({**result, field: bad_value}, args)
+
+    with pytest.raises(bench_serve.BenchmarkError, match="unexpected=metadata"):
+        bench_serve.validate_result({**result, "metadata": "not requested"}, args)
+
 
 def test_validate_result_requires_detailed_positive_streaming_arrays(tmp_path):
     args = _parse(tmp_path)
@@ -1413,6 +1429,10 @@ def test_percentile_labels_match_pinned_vllm_without_collisions(tmp_path):
     )
     assert "p1e-07_ttft_ms" in summary["metrics"]
     assert "p99.9999999_e2el_ms" in summary["metrics"]
+
+    unexpected = dict(result, p97_ttft_ms=result["p95_ttft_ms"])
+    with pytest.raises(bench_serve.BenchmarkError, match="unexpected=p97_ttft_ms"):
+        bench_serve.validate_result(unexpected, args)
 
 
 def test_itl_chunk_count_is_not_assumed_to_equal_output_tokens(tmp_path):
@@ -1891,6 +1911,13 @@ def test_non_strict_result_json_is_rejected_at_load_boundary(tmp_path, raw):
     result_path = tmp_path / "invalid.json"
     result_path.write_text(raw)
     with pytest.raises(bench_serve.BenchmarkError, match="not strict JSON"):
+        bench_serve._load_result(result_path)
+
+
+def test_result_loader_rejects_append_style_singleton_lists(tmp_path):
+    result_path = tmp_path / "unexpected-list.json"
+    result_path.write_text('[{"duration":1}]')
+    with pytest.raises(bench_serve.BenchmarkError, match="one object"):
         bench_serve._load_result(result_path)
 
 

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -96,8 +96,8 @@ def _argv(tmp_path):
         "NVIDIA-GB10:GPU-1234",
         "--driver-version",
         "580.00",
-        "--cuda-version",
-        "13.0",
+        "--accelerator-runtime",
+        "CUDA 13.0",
         "--execution-manifest",
         str(execution_path),
         "--execution-manifest-sha256",
@@ -105,6 +105,8 @@ def _argv(tmp_path):
         "--speculative-mode",
         "off",
         "--input-len",
+        "32",
+        "--observed-input-len",
         "32",
         "--output-len",
         "256",
@@ -161,7 +163,12 @@ def _valid_result(args, *, offset=0.0):
     e2el_ms = ttft_ms + itl_ms
     tpot_ms = itl_ms / (args.output_len - 1) if multi_token else 0.0
     duration = 4.0
-    total_input = args.num_prompts * args.input_len
+    observed_input_len = (
+        args.observed_input_len
+        if args.observed_input_len is not None
+        else args.observed_input_len_min
+    )
+    total_input = args.num_prompts * observed_input_len
     total_output = args.num_prompts * args.output_len
     result = {
         "duration": duration,
@@ -169,7 +176,7 @@ def _valid_result(args, *, offset=0.0):
         "failed": 0,
         "total_input_tokens": total_input,
         "total_output_tokens": total_output,
-        "input_lens": [args.input_len] * args.num_prompts,
+        "input_lens": [observed_input_len] * args.num_prompts,
         "output_lens": [args.output_len] * args.num_prompts,
         "errors": [""] * args.num_prompts,
         "ttfts": [ttft_ms / 1000] * args.num_prompts,
@@ -251,6 +258,32 @@ def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
     assert "--no-stream" not in command
 
 
+def test_requested_64_observed_63_regression_is_validated_exactly(
+    tmp_path, monkeypatch
+):
+    argv = _replace_option(_argv(tmp_path), "--input-len", "64")
+    argv = _replace_option(argv, "--observed-input-len", "63")
+    args = bench_serve.parse_args(argv)
+    command = bench_serve.build_vllm_command(
+        args, block_index=0, result_dir=tmp_path, result_filename="raw.json"
+    )
+    assert _option(command, "--random-input-len") == "64"
+
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
+    metadata = bench_serve.collect_metadata(args, {})
+    assert metadata["workload"]["requested_random_input_len"] == 64
+    assert metadata["workload"]["observed_input_length_contract"] == {
+        "mode": "exact",
+        "value": 63,
+    }
+    assert metadata["workload"]["accepted_input_length_bounds"] == [63, 63]
+
+    result = _valid_result(args)
+    assert result["input_lens"] == [63] * args.num_prompts
+    assert result["total_input_tokens"] == 63 * args.num_prompts
+    bench_serve.validate_result(result, args)
+
+
 def test_dataset_seed_and_server_sampling_are_distinct_metadata(tmp_path, monkeypatch):
     args = _parse(tmp_path, "--dataset-seed", "900")
     monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
@@ -289,6 +322,47 @@ def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
             _parse(tmp_path, "--input-range-ratio", ratio)
 
 
+def test_observed_input_contract_is_required_and_unambiguous(tmp_path):
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(_without_option(_argv(tmp_path), "--observed-input-len"))
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--observed-input-len-min", "31")
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--input-range-ratio",
+            "0.25",
+            "--observed-input-len-min",
+            "24",
+            "--observed-input-len-max",
+            "40",
+        )
+
+    range_argv = _without_option(_argv(tmp_path), "--observed-input-len")
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(
+            [
+                *range_argv,
+                "--input-range-ratio",
+                "0.25",
+                "--observed-input-len-min",
+                "24",
+            ]
+        )
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(
+            [
+                *range_argv,
+                "--input-range-ratio",
+                "0.25",
+                "--observed-input-len-min",
+                "41",
+                "--observed-input-len-max",
+                "40",
+            ]
+        )
+
+
 def test_required_identity_strings_reject_whitespace(tmp_path):
     for option in ("--model-id", "--image-id", "--run-label"):
         with pytest.raises(SystemExit):
@@ -312,7 +386,7 @@ def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
         "--server-runtime-id",
         "--gpu-id",
         "--driver-version",
-        "--cuda-version",
+        "--accelerator-runtime",
         "--execution-manifest",
         "--execution-manifest-sha256",
         "--speculative-mode",
@@ -323,6 +397,14 @@ def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
     for option in required:
         with pytest.raises(SystemExit):
             bench_serve.parse_args(_without_option(_argv(tmp_path), option))
+
+
+def test_cuda_version_remains_a_deprecated_accelerator_runtime_alias(tmp_path):
+    argv = _argv(tmp_path)
+    index = argv.index("--accelerator-runtime")
+    argv[index] = "--cuda-version"
+    args = bench_serve.parse_args(argv)
+    assert args.accelerator_runtime == "CUDA 13.0"
 
 
 def test_whole_artifact_must_fit_exact_byte_budget(tmp_path):
@@ -653,7 +735,7 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     assert identity["hardware"] == {
         "gpu_id": "NVIDIA-GB10:GPU-1234",
         "driver_version": "580.00",
-        "cuda_version": "13.0",
+        "accelerator_runtime": "CUDA 13.0",
     }
     assert metadata["server"]["recorded_args"] == ["--enforce-eager"]
     assert metadata["dispatch"]["runner_environment"] == {
@@ -676,6 +758,11 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     }
     assert metadata["workload"]["streaming"] is True
     assert metadata["workload"]["dataset_block_seeds"] == [1234, 1235, 1236]
+    assert metadata["workload"]["requested_random_input_len"] == 32
+    assert metadata["workload"]["observed_input_length_contract"] == {
+        "mode": "exact",
+        "value": 32,
+    }
 
 
 def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
@@ -750,8 +837,18 @@ def test_redaction_covers_nested_json_headers_cookies_and_url_fragments():
     ):
         assert secret not in serialized
     assert "visible" in serialized
-    assert "mode=ok" in serialized
-    assert "view=public" in serialized
+    assert "mode=ok" not in serialized
+    assert "view=public" not in serialized
+    assert serialized.count("<redacted>") >= 2
+
+
+def test_redaction_treats_every_nonempty_url_fragment_as_opaque():
+    redacted = bench_serve._redact_url(
+        "https://example.test/path?mode=fast#opaque-unkeyed-credential"
+    )
+    assert "mode=fast" in redacted
+    assert "opaque-unkeyed-credential" not in redacted
+    assert redacted.endswith("#<redacted>")
 
 
 @pytest.mark.parametrize(
@@ -982,7 +1079,18 @@ def test_single_token_prefill_explicitly_allows_empty_itl_and_zero_tpot(tmp_path
 
 
 def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
-    args = _parse(tmp_path, "--input-range-ratio", "0.25")
+    argv = _without_option(_argv(tmp_path), "--observed-input-len")
+    args = bench_serve.parse_args(
+        [
+            *argv,
+            "--input-range-ratio",
+            "0.25",
+            "--observed-input-len-min",
+            "24",
+            "--observed-input-len-max",
+            "40",
+        ]
+    )
     command = bench_serve.build_vllm_command(
         args, block_index=0, result_dir=tmp_path, result_filename="raw.json"
     )
@@ -990,14 +1098,14 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
         "input": 0.25,
         "output": 0.0,
     }
-    assert bench_serve._input_length_bounds(32, 0.25) == (1, 40)
+    assert bench_serve._observed_input_length_bounds(args) == (24, 40)
     metadata = bench_serve.collect_metadata(args, {})
     assert metadata["workload"]["input_range_ratio"] == 0.25
     assert metadata["workload"]["vllm_range_ratio"] == {
         "input": 0.25,
         "output": 0.0,
     }
-    assert metadata["workload"]["accepted_input_length_bounds"] == [1, 40]
+    assert metadata["workload"]["accepted_input_length_bounds"] == [24, 40]
 
     input_lens = [24, 26, 28, 30, 32, 34, 36, 40]
     result = _valid_result(args)
@@ -1009,8 +1117,14 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
     too_long = dict(result, input_lens=[41, *input_lens[1:]])
     too_long["total_input_tokens"] = sum(too_long["input_lens"])
     _reconcile_throughput(too_long)
-    with pytest.raises(bench_serve.BenchmarkError, match=r"range \[1, 40\]"):
+    with pytest.raises(bench_serve.BenchmarkError, match=r"range \[24, 40\]"):
         bench_serve.validate_result(too_long, args)
+
+    too_short = dict(result, input_lens=[23, *input_lens[1:]])
+    too_short["total_input_tokens"] = sum(too_short["input_lens"])
+    _reconcile_throughput(too_short)
+    with pytest.raises(bench_serve.BenchmarkError, match=r"range \[24, 40\]"):
+        bench_serve.validate_result(too_short, args)
 
     wrong_type = dict(result, input_lens=[24.0, *input_lens[1:]])
     with pytest.raises(bench_serve.BenchmarkError, match="unexpected input_lens"):
@@ -1184,7 +1298,7 @@ def test_individual_metadata_probe_failure_is_recorded_not_raised(
     )
 
 
-def test_nonfinite_raw_result_is_rejected_but_preserved_as_valid_json(
+def test_nonfinite_raw_result_is_rejected_at_strict_json_boundary(
     tmp_path, monkeypatch
 ):
     args = _parse(tmp_path)
@@ -1200,12 +1314,28 @@ def test_nonfinite_raw_result_is_rejected_but_preserved_as_valid_json(
 
     monkeypatch.setattr(bench_serve, "_run_command", fake_run)
     monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
-    with pytest.raises(bench_serve.BenchmarkError, match="NaN/Infinity"):
+    with pytest.raises(bench_serve.BenchmarkError, match="not strict JSON"):
         bench_serve.run_benchmark(args)
     report = json.loads(args.output.read_text())
-    assert report["blocks"][0]["raw_result"]["mean_ttft_ms"] == {
-        "nonfinite_float": "NaN"
-    }
+    block = report["blocks"][0]
+    assert block["raw_result"] is None
+    assert "not strict JSON" in block["validation_error"]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        '{"duration":1,"duration":2}',
+        '{"duration":NaN}',
+        '{"duration":Infinity}',
+        '{"duration":-Infinity}',
+    ),
+)
+def test_non_strict_result_json_is_rejected_at_load_boundary(tmp_path, raw):
+    result_path = tmp_path / "invalid.json"
+    result_path.write_text(raw)
+    with pytest.raises(bench_serve.BenchmarkError, match="not strict JSON"):
+        bench_serve._load_result(result_path)
 
 
 def test_existing_report_is_never_replaced_without_opt_in(tmp_path, monkeypatch):

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -17,7 +17,43 @@ import pytest
 from gridbook import bench_serve
 
 CLIENT_RUNTIME_ID = "vLLM 0.23.1rc1.dev764+g54b16d8a9.d20260703"
-GRIDBOOK_COMMIT = "d" * 40
+
+
+def _gridbook_commit_for_test_process():
+    """Use the exact checkout commit when the tests import a source tree.
+
+    Installed-wheel CI runs outside a checkout, where an explicit synthetic
+    commit is the intended provenance fixture.  A source-tree run must instead
+    agree with the checkout that actually supplied ``bench_serve.py``.
+    """
+
+    source = Path(bench_serve.__file__).resolve()
+    checkout = source.parents[1]
+    try:
+        top_level = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "d" * 40
+    if Path(top_level).resolve() != checkout or not bench_serve._GIT_COMMIT.fullmatch(
+        commit
+    ):
+        return "d" * 40
+    return commit.lower()
+
+
+GRIDBOOK_COMMIT = _gridbook_commit_for_test_process()
 
 
 def _argv(tmp_path):
@@ -866,12 +902,10 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
         {"PRISMAQUANT_CB_DECODE": "cuda", "CUDA_VISIBLE_DEVICES": "0"},
     )
 
-    assert metadata["git"] == {
-        "commit": GRIDBOOK_COMMIT,
-        "dirty": None,
-        "source": "argument",
-        "release_eligible": True,
-    }
+    assert metadata["git"]["commit"] == GRIDBOOK_COMMIT
+    assert metadata["git"]["release_eligible"] is True
+    assert metadata["git"]["source"] in {"argument", "argument+checkout"}
+    assert metadata["git"]["dirty"] in {None, False}
     assert metadata["software"]["gridbook_version"] == "0.3.0"
     assert metadata["software"]["runner_vllm_cli_probe"] == CLIENT_RUNTIME_ID
     assert metadata["artifacts"]["image_id"].endswith("sha256:abc")
@@ -971,6 +1005,8 @@ def test_git_state_only_autodetects_the_exact_clean_source_checkout(
         "source": "checkout",
         "release_eligible": True,
     }
+    with pytest.raises(bench_serve.BenchmarkError, match="disagrees"):
+        bench_serve._git_state("b" * 40)
 
     state["dirty"] = " M gridbook/bench_serve.py\n"
     with pytest.raises(bench_serve.BenchmarkError, match="checkout is dirty"):

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -559,6 +559,18 @@ def test_prefix_caching_and_server_evidence_fail_closed(tmp_path):
         bench_serve.parse_args(missing_digest)
 
 
+def test_digest_bound_inputs_are_rechecked_after_argument_parsing(
+    tmp_path, monkeypatch
+):
+    args = _parse(tmp_path)
+    Path(args.server_evidence[0]).write_text("changed after parse\n")
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="server evidence.*mismatch"):
+        bench_serve.collect_metadata(args, {})
+
+
 def test_cuda_version_remains_a_deprecated_accelerator_runtime_alias(tmp_path):
     argv = _argv(tmp_path)
     index = argv.index("--accelerator-runtime")
@@ -1037,6 +1049,52 @@ def test_git_state_requires_a_real_pyproject_source_root(tmp_path, monkeypatch):
     state = bench_serve._git_state(None)
     assert state["commit"] is None
     assert state["source"] == "unavailable-non-source-install"
+
+    explicit = bench_serve._git_state("d" * 40)
+    assert explicit["commit"] == "d" * 40
+    assert explicit["source"] == "argument"
+    assert explicit["dirty"] is None
+    assert explicit["release_eligible"] is False
+
+
+def test_generated_report_is_the_only_checkout_dirty_check_exclusion(
+    tmp_path, monkeypatch
+):
+    checkout = tmp_path / "checkout"
+    source = checkout / "gridbook" / "bench_serve.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("# clean source\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='gridbook'\n")
+    subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=checkout,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Gridbook test"], cwd=checkout, check=True
+    )
+    subprocess.run(["git", "add", "."], cwd=checkout, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=checkout, check=True)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    monkeypatch.setattr(bench_serve, "__file__", str(source))
+
+    report = checkout / "results" / "report.json"
+    report.parent.mkdir()
+    report.write_text("generated evidence\n")
+    clean = bench_serve._git_state(commit, generated_paths=(report,))
+    assert clean["dirty"] is False
+    assert clean["release_eligible"] is True
+
+    source.write_text("# changed source\n")
+    with pytest.raises(bench_serve.BenchmarkError, match="checkout is dirty"):
+        bench_serve._git_state(commit, generated_paths=(report,))
 
 
 def test_urls_commands_and_server_args_never_persist_credentials(tmp_path, monkeypatch):
@@ -1609,8 +1667,46 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
     )
     assert all("errors" not in block["raw_result"] for block in written["blocks"])
     assert written["summary"]["completed_blocks"] == 3
+    assert written["metadata"]["measurement_provenance"] == {
+        "digest_bound_inputs_verified_before_requests": True,
+        "digest_bound_inputs_verified_after_requests": True,
+        "git_state_verified_after_requests": True,
+        "client_runtime_verified_after_requests": True,
+    }
     assert written["finished_at"].endswith("Z")
     assert os.stat(args.output).st_mode & 0o777 == 0o600
+
+
+def test_evidence_mutation_during_measurement_invalidates_the_report(
+    tmp_path, monkeypatch
+):
+    args = _parse(tmp_path)
+    calls = 0
+
+    def fake_run(command):
+        nonlocal calls
+        calls += 1
+        path = Path(_option(command, "--result-dir")) / _option(
+            command, "--result-filename"
+        )
+        path.write_text(json.dumps(_valid_result(args, offset=float(calls))))
+        if calls == args.blocks:
+            Path(args.server_evidence[0]).write_text("changed during requests\n")
+        return 0
+
+    monkeypatch.setattr(bench_serve, "_run_command", fake_run)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="server evidence.*mismatch"):
+        bench_serve.run_benchmark(args)
+
+    report = json.loads(args.output.read_text())
+    assert report["status"] == "failed"
+    assert report["measurement_valid"] is False
+    provenance = report["metadata"]["measurement_provenance"]
+    assert provenance["digest_bound_inputs_verified_before_requests"] is True
+    assert provenance["digest_bound_inputs_verified_after_requests"] is False
 
 
 def test_report_omits_generated_text_and_arbitrary_server_errors():

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -5,6 +5,7 @@ fixed-shape validation, provenance capture, and the report schema without a
 vLLM install, a GPU, or a listening server.
 """
 
+import hashlib
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -16,6 +17,40 @@ from gridbook import bench_serve
 
 
 def _argv(tmp_path):
+    inventory_path = tmp_path / "artifact-inventory.json"
+    inventory = {
+        "schema": bench_serve.ARTIFACT_INVENTORY_SCHEMA,
+        "total_bytes": 800,
+        "files": [
+            {"path": "model.safetensors", "bytes": 700, "sha256": "a" * 64},
+            {"path": "config.json", "bytes": 100, "sha256": "b" * 64},
+        ],
+    }
+    inventory_raw = json.dumps(inventory, sort_keys=True).encode()
+    inventory_path.write_bytes(inventory_raw)
+    inventory_digest = hashlib.sha256(inventory_raw).hexdigest()
+
+    execution_path = tmp_path / "execution-manifest.json"
+    execution = {
+        "schema": bench_serve.EXECUTION_MANIFEST_SCHEMA,
+        "coverage": "all_serving_units",
+        "artifact_inventory_sha256": inventory_digest,
+        "tensor_parallel_size": 1,
+        "assignments": [
+            {
+                "unit": "model.*",
+                "format_rung": "FP8_CB_K36",
+                "serialized_layout": "product-codebook-indices-v1",
+                "scale_coding": "e4m3-per-block",
+                "quant_contract": "W8A8",
+                "kernel_backend": "gridbook-cuda-cb-gemv-v2",
+                "fallback_state": "none-observed",
+            }
+        ],
+    }
+    execution_raw = json.dumps(execution, sort_keys=True).encode()
+    execution_path.write_bytes(execution_raw)
+    execution_digest = hashlib.sha256(execution_raw).hexdigest()
     return [
         "--base-url",
         "http://127.0.0.1:8000/",
@@ -33,6 +68,10 @@ def _argv(tmp_path):
         "gridbook-0.6b-decode",
         "--artifact-bytes",
         "800",
+        "--artifact-inventory",
+        str(inventory_path),
+        "--artifact-inventory-sha256",
+        inventory_digest,
         "--byte-budget",
         "900",
         "--format-rung",
@@ -59,6 +98,12 @@ def _argv(tmp_path):
         "580.00",
         "--cuda-version",
         "13.0",
+        "--execution-manifest",
+        str(execution_path),
+        "--execution-manifest-sha256",
+        execution_digest,
+        "--speculative-mode",
+        "off",
         "--input-len",
         "32",
         "--output-len",
@@ -85,6 +130,27 @@ def _without_option(argv, name):
     return [*argv[:index], *argv[index + 2 :]]
 
 
+def _replace_option(argv, name, value):
+    replaced = list(argv)
+    index = replaced.index(name)
+    replaced[index + 1] = str(value)
+    return replaced
+
+
+def _write_json_digest(path, payload):
+    raw = json.dumps(payload, sort_keys=True).encode()
+    path.write_bytes(raw)
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _reconcile_throughput(result):
+    result["request_throughput"] = result["completed"] / result["duration"]
+    result["output_throughput"] = result["total_output_tokens"] / result["duration"]
+    result["total_token_throughput"] = (
+        result["total_input_tokens"] + result["total_output_tokens"]
+    ) / result["duration"]
+
+
 def _valid_result(args, *, offset=0.0):
     multi_token = args.output_len > 1
     ttft_ms = 20.0 + offset
@@ -94,22 +160,25 @@ def _valid_result(args, *, offset=0.0):
     itl_ms = 2.0 + offset if multi_token else 0.0
     e2el_ms = ttft_ms + itl_ms
     tpot_ms = itl_ms / (args.output_len - 1) if multi_token else 0.0
+    duration = 4.0
+    total_input = args.num_prompts * args.input_len
+    total_output = args.num_prompts * args.output_len
     result = {
+        "duration": duration,
         "completed": args.num_prompts,
         "failed": 0,
-        "total_input_tokens": args.num_prompts * args.input_len,
-        "total_output_tokens": args.num_prompts * args.output_len,
+        "total_input_tokens": total_input,
+        "total_output_tokens": total_output,
         "input_lens": [args.input_len] * args.num_prompts,
         "output_lens": [args.output_len] * args.num_prompts,
         "errors": [""] * args.num_prompts,
         "ttfts": [ttft_ms / 1000] * args.num_prompts,
         "itls": [
-            [itl_ms / 1000] if multi_token else []
-            for _ in range(args.num_prompts)
+            [itl_ms / 1000] if multi_token else [] for _ in range(args.num_prompts)
         ],
-        "request_throughput": 2.0 + offset,
-        "output_throughput": 500.0 + offset,
-        "total_token_throughput": 600.0 + offset,
+        "request_throughput": args.num_prompts / duration,
+        "output_throughput": total_output / duration,
+        "total_token_throughput": (total_input + total_output) / duration,
         "mean_ttft_ms": ttft_ms,
         "median_ttft_ms": ttft_ms,
         "std_ttft_ms": 0.0,
@@ -134,6 +203,24 @@ def _valid_result(args, *, offset=0.0):
             key = bench_serve._percentile_result_key(percentile, metric)
             result[key] = value
     return result
+
+
+def _add_valid_speculative_result(result, *, drafts=10, tokens=2):
+    accepted_by_position = [0.8, 0.4][:tokens]
+    if len(accepted_by_position) < tokens:
+        accepted_by_position.extend([0.0] * (tokens - len(accepted_by_position)))
+    accepted = round(sum(accepted_by_position) * drafts)
+    draft_tokens = drafts * tokens
+    result.update(
+        {
+            "spec_decode_acceptance_rate": accepted / draft_tokens * 100,
+            "spec_decode_acceptance_length": 1 + accepted / drafts,
+            "spec_decode_num_drafts": drafts,
+            "spec_decode_draft_tokens": draft_tokens,
+            "spec_decode_accepted_tokens": accepted,
+            "spec_decode_per_position_acceptance_rates": accepted_by_position,
+        }
+    )
 
 
 def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
@@ -180,9 +267,13 @@ def test_dataset_seed_and_server_sampling_are_distinct_metadata(tmp_path, monkey
 
 def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
     with pytest.raises(SystemExit):
-        _parse(tmp_path, "--blocks", "0")
+        _parse(tmp_path, "--blocks", "2")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--warmups", "3")
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--percentiles", "50,100")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--percentiles", "50,90,99")
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--request-rate", "0")
     with pytest.raises(SystemExit):
@@ -198,9 +289,17 @@ def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
             _parse(tmp_path, "--input-range-ratio", ratio)
 
 
+def test_required_identity_strings_reject_whitespace(tmp_path):
+    for option in ("--model-id", "--image-id", "--run-label"):
+        with pytest.raises(SystemExit):
+            _parse(tmp_path, option, "   ")
+
+
 def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
     required = (
         "--artifact-bytes",
+        "--artifact-inventory",
+        "--artifact-inventory-sha256",
         "--byte-budget",
         "--format-rung",
         "--serialized-layout",
@@ -214,6 +313,12 @@ def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
         "--gpu-id",
         "--driver-version",
         "--cuda-version",
+        "--execution-manifest",
+        "--execution-manifest-sha256",
+        "--speculative-mode",
+        "--model-id",
+        "--image-id",
+        "--run-label",
     )
     for option in required:
         with pytest.raises(SystemExit):
@@ -224,19 +329,252 @@ def test_whole_artifact_must_fit_exact_byte_budget(tmp_path):
     with pytest.raises(SystemExit):
         _parse(
             tmp_path,
-            "--artifact-bytes",
-            "901",
             "--byte-budget",
-            "900",
+            "799",
         )
     args = _parse(
         tmp_path,
-        "--artifact-bytes",
-        "900",
         "--byte-budget",
-        "900",
+        "800",
     )
-    assert args.artifact_bytes == args.byte_budget == 900
+    assert args.artifact_bytes == args.byte_budget == 800
+
+
+def test_artifact_inventory_digest_sum_and_paths_fail_closed(tmp_path):
+    argv = _argv(tmp_path)
+    inventory_path = Path(_option(argv, "--artifact-inventory"))
+
+    inventory_path.write_text("{}")
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(argv)
+
+    bad_sum = {
+        "schema": bench_serve.ARTIFACT_INVENTORY_SCHEMA,
+        "total_bytes": 800,
+        "files": [{"path": "model", "bytes": 799, "sha256": "a" * 64}],
+    }
+    digest = _write_json_digest(inventory_path, bad_sum)
+    bad_sum_argv = _replace_option(argv, "--artifact-inventory-sha256", digest)
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(bad_sum_argv)
+
+    unsafe = {
+        "schema": bench_serve.ARTIFACT_INVENTORY_SCHEMA,
+        "total_bytes": 800,
+        "files": [{"path": "../model", "bytes": 800, "sha256": "a" * 64}],
+    }
+    digest = _write_json_digest(inventory_path, unsafe)
+    unsafe_argv = _replace_option(argv, "--artifact-inventory-sha256", digest)
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(unsafe_argv)
+
+    unsafe["files"][0]["path"] = "weights//model"
+    digest = _write_json_digest(inventory_path, unsafe)
+    noncanonical_argv = _replace_option(argv, "--artifact-inventory-sha256", digest)
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(noncanonical_argv)
+
+
+def test_prismaquant_quant_config_inventory_is_consumed_directly(tmp_path):
+    argv = _argv(tmp_path)
+    inventory_path = Path(_option(argv, "--artifact-inventory"))
+    execution_path = Path(_option(argv, "--execution-manifest"))
+    quant_config = {
+        "quant_method": "gridbook",
+        "provenance": {
+            "artifact_inventory": {
+                "schema": bench_serve.PRISMAQUANT_ARTIFACT_INVENTORY_SCHEMA,
+                "scope": "all_regular_files_recursive",
+                "file_bytes": {
+                    "config.json": 100,
+                    "model.safetensors": 700,
+                },
+                "export_directory_bytes": 800,
+            }
+        },
+    }
+    inventory_digest = _write_json_digest(inventory_path, quant_config)
+    argv = _replace_option(argv, "--artifact-inventory-sha256", inventory_digest)
+
+    execution = json.loads(execution_path.read_text())
+    execution["artifact_inventory_sha256"] = inventory_digest
+    execution_digest = _write_json_digest(execution_path, execution)
+    argv = _replace_option(argv, "--execution-manifest-sha256", execution_digest)
+    args = bench_serve.parse_args(argv)
+    assert args.artifact_inventory_summary["schema"] == (
+        bench_serve.PRISMAQUANT_ARTIFACT_INVENTORY_SCHEMA
+    )
+    assert args.artifact_inventory_summary["source"] == "quant-config-provenance"
+    assert args.artifact_inventory_summary["computed_total_bytes"] == 800
+    assert args.artifact_inventory_summary["files"] == [
+        {"path": "config.json", "bytes": 100},
+        {"path": "model.safetensors", "bytes": 700},
+    ]
+
+    quant_config["provenance"]["artifact_inventory"]["export_directory_bytes"] = 801
+    bad_digest = _write_json_digest(inventory_path, quant_config)
+    bad_argv = _replace_option(argv, "--artifact-inventory-sha256", bad_digest)
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(bad_argv)
+
+
+def test_payload_scope_is_explicit_and_never_substitutes_for_whole_bytes(tmp_path):
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--payload-bytes", "700")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--payload-scope", "model shards only")
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--payload-bytes",
+            "801",
+            "--payload-scope",
+            "model shards only",
+        )
+    args = _parse(
+        tmp_path,
+        "--payload-bytes",
+        "700",
+        "--payload-scope",
+        "model shards plus codebook sidecar",
+    )
+    metadata = bench_serve.collect_metadata(args, {})
+    assert metadata["artifacts"]["payload"] == {
+        "bytes": 700,
+        "scope": "model shards plus codebook sidecar",
+        "is_budget_gate": False,
+    }
+    assert metadata["artifacts"]["whole_served_artifact_bytes"] == 800
+
+
+def test_execution_manifest_binds_inventory_and_mixed_assignments(tmp_path):
+    argv = _argv(tmp_path)
+    execution_path = Path(_option(argv, "--execution-manifest"))
+    inventory_digest = _option(argv, "--artifact-inventory-sha256")
+    manifest = {
+        "schema": bench_serve.EXECUTION_MANIFEST_SCHEMA,
+        "coverage": "all_serving_units",
+        "artifact_inventory_sha256": inventory_digest,
+        "tensor_parallel_size": 1,
+        "assignments": [
+            {
+                "unit": "model.layers.0",
+                "format_rung": "FP8_CB_K36",
+                "serialized_layout": "product-codebook-indices-v1",
+                "scale_coding": "e4m3-per-block",
+                "quant_contract": "W8A8",
+                "kernel_backend": "gridbook-cuda-cb-gemv-v2",
+                "fallback_state": "none-observed",
+            },
+            {
+                "unit": "model.layers.1",
+                "format_rung": "NVFP4",
+                "serialized_layout": "compressed-tensors",
+                "scale_coding": "ue4m3",
+                "quant_contract": "W4A4",
+                "kernel_backend": "vllm-cutlass",
+                "fallback_state": "none-observed",
+            },
+        ],
+    }
+    manifest_digest = _write_json_digest(execution_path, manifest)
+    mixed_argv = _replace_option(argv, "--execution-manifest-sha256", manifest_digest)
+    for option in (
+        "--format-rung",
+        "--serialized-layout",
+        "--scale-coding",
+        "--quant-contract",
+        "--kernel-backend",
+    ):
+        mixed_argv = _replace_option(mixed_argv, option, "mixed")
+    args = bench_serve.parse_args(mixed_argv)
+    assert args.execution_manifest_summary["assignment_count"] == 2
+    assert args.execution_manifest_summary["sha256"] == manifest_digest
+
+    not_declared_mixed = _replace_option(mixed_argv, "--format-rung", "FP8_CB_K36")
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(not_declared_mixed)
+
+    incomplete_manifest = dict(manifest)
+    del incomplete_manifest["coverage"]
+    incomplete_digest = _write_json_digest(execution_path, incomplete_manifest)
+    incomplete_argv = _replace_option(
+        mixed_argv, "--execution-manifest-sha256", incomplete_digest
+    )
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(incomplete_argv)
+
+    manifest["artifact_inventory_sha256"] = "0" * 64
+    wrong_binding_digest = _write_json_digest(execution_path, manifest)
+    wrong_binding = _replace_option(
+        mixed_argv, "--execution-manifest-sha256", wrong_binding_digest
+    )
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(wrong_binding)
+
+
+def test_speculative_mode_requires_structured_configuration(tmp_path):
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--speculative-mode", "on")
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--speculative-mode",
+            "on",
+            "--speculative-config",
+            '{"method":"mtp"}',
+        )
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--speculative-config",
+            '{"method":"mtp","num_speculative_tokens":2}',
+        )
+    for config in (
+        '{"num_speculative_tokens":2,"num_speculative_tokens":3}',
+        '{"num_speculative_tokens":2,"threshold":NaN}',
+    ):
+        with pytest.raises(SystemExit):
+            _parse(
+                tmp_path,
+                "--speculative-mode",
+                "on",
+                "--speculative-config",
+                config,
+            )
+
+    config = '{"method":"mtp","num_speculative_tokens":2}'
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--speculative-mode",
+            "on",
+            "--speculative-config",
+            config,
+        )
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--speculative-mode",
+            "on",
+            "--speculative-config",
+            config,
+            '--server-arg=--speculative-config={"method":"draft-model","num_speculative_tokens":2}',
+        )
+    args = _parse(
+        tmp_path,
+        "--speculative-mode",
+        "on",
+        "--speculative-config",
+        config,
+        f"--server-arg=--speculative-config={config}",
+    )
+    assert args.speculative_config["method"] == "mtp"
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            '--server-arg=--speculative-config={"method":"mtp","num_speculative_tokens":2}',
+        )
 
 
 def test_dispatch_environment_is_sorted_explicit_and_secret_safe():
@@ -295,23 +633,27 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     assert metadata["artifacts"]["byte_budget_bytes"] == 900
     assert metadata["artifacts"]["budget_headroom_bytes"] == 100
     assert metadata["artifacts"]["within_byte_budget"] is True
-    assert metadata["execution_identity"] == {
-        "format_rung": "FP8_CB_K36",
-        "serialization": {
-            "layout": "product-codebook-indices-v1",
-            "scale_coding": "e4m3-per-block",
-        },
-        "quant_contract": "W8A8",
-        "kernel_backend": "gridbook-cuda-cb-gemv-v2",
-        "tensor_parallel_size": 1,
-        "fallback_state": "none-observed",
-        "client_runtime_id": "vllm-bench@g54b16d8a9",
-        "server_runtime_id": "vllm@g54b16d8a9+gridbook-0.3.0",
-        "hardware": {
-            "gpu_id": "NVIDIA-GB10:GPU-1234",
-            "driver_version": "580.00",
-            "cuda_version": "13.0",
-        },
+    identity = metadata["execution_identity"]
+    assert identity["format_rung"] == "FP8_CB_K36"
+    assert identity["serialization"] == {
+        "layout": "product-codebook-indices-v1",
+        "scale_coding": "e4m3-per-block",
+    }
+    assert identity["quant_contract"] == "W8A8"
+    assert identity["kernel_backend"] == "gridbook-cuda-cb-gemv-v2"
+    assert identity["tensor_parallel_size"] == 1
+    assert identity["fallback_state"] == "none-observed"
+    assert identity["manifest"]["assignment_count"] == 1
+    assert (
+        identity["manifest"]["artifact_inventory_sha256"]
+        == metadata["artifacts"]["inventory"]["sha256"]
+    )
+    assert identity["client_runtime_id"] == "vllm-bench@g54b16d8a9"
+    assert identity["server_runtime_id"] == "vllm@g54b16d8a9+gridbook-0.3.0"
+    assert identity["hardware"] == {
+        "gpu_id": "NVIDIA-GB10:GPU-1234",
+        "driver_version": "580.00",
+        "cuda_version": "13.0",
     }
     assert metadata["server"]["recorded_args"] == ["--enforce-eager"]
     assert metadata["dispatch"]["runner_environment"] == {
@@ -373,6 +715,60 @@ def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
     assert _option(redacted_command, "--tokenizer") == "org/tokenizer"
 
 
+def test_redaction_covers_nested_json_headers_cookies_and_url_fragments():
+    command = [
+        "client",
+        "--extra-body",
+        json.dumps(
+            {
+                "public": "visible",
+                "nested": {
+                    "authorization": "Bearer json-secret",
+                    "items": [
+                        {"api_key": "array-secret"},
+                        "https://example.test/#access_token=fragment-secret&mode=ok",
+                    ],
+                },
+            }
+        ),
+        "--header",
+        "X-Api-Key: header-secret",
+        "-H",
+        "Cookie: session=cookie-secret; Path=/",
+        '--server-config={"refresh_token":"embedded-secret","safe":1}',
+        "https://example.test/path#token=second-fragment&view=public",
+    ]
+    serialized = json.dumps(bench_serve.redact_command(command))
+    for secret in (
+        "json-secret",
+        "array-secret",
+        "fragment-secret",
+        "header-secret",
+        "cookie-secret",
+        "embedded-secret",
+        "second-fragment",
+    ):
+        assert secret not in serialized
+    assert "visible" in serialized
+    assert "mode=ok" in serialized
+    assert "view=public" in serialized
+
+
+@pytest.mark.parametrize(
+    "header",
+    (
+        "authorization: Basic lower-secret",
+        "Proxy-Authorization: Bearer proxy-secret",
+        "Set-Cookie: SID=set-cookie-secret; HttpOnly",
+        "API-Key: api-header-secret",
+    ),
+)
+def test_inline_sensitive_header_variations_are_redacted(header):
+    redacted = bench_serve._redact_text(header)
+    assert "secret" not in redacted
+    assert "<redacted>" in redacted
+
+
 def test_secret_key_detection_does_not_confuse_tokenizer_or_monkey():
     assert bench_serve._is_sensitive_key("HF_TOKEN")
     assert bench_serve._is_sensitive_key("authorization")
@@ -391,9 +787,7 @@ def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_p
     with pytest.raises(bench_serve.BenchmarkError, match="required metrics"):
         bench_serve.validate_result(missing_itl, args)
 
-    short_decode = dict(
-        result, total_output_tokens=result["total_output_tokens"] - 1
-    )
+    short_decode = dict(result, total_output_tokens=result["total_output_tokens"] - 1)
     with pytest.raises(bench_serve.BenchmarkError, match="not completed exactly"):
         bench_serve.validate_result(short_decode, args)
 
@@ -453,12 +847,138 @@ def test_validate_result_reconciles_aggregate_and_detailed_timings(tmp_path):
         bench_serve.validate_result(bad_tpot, args)
 
 
+@pytest.mark.parametrize(
+    "metric",
+    (
+        "std_ttft_ms",
+        "p95_ttft_ms",
+        "std_itl_ms",
+        "p99_itl_ms",
+        "std_e2el_ms",
+        "p90_e2el_ms",
+        "std_tpot_ms",
+        "p95_tpot_ms",
+    ),
+)
+def test_every_dispersion_and_percentile_is_reconstructed(tmp_path, metric):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    result[metric] += 10.0
+    with pytest.raises(bench_serve.BenchmarkError, match="disagrees"):
+        bench_serve.validate_result(result, args)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    ("request_throughput", "output_throughput", "total_token_throughput"),
+)
+def test_throughput_is_reconstructed_from_duration_and_totals(tmp_path, metric):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    result[metric] += 0.1
+    with pytest.raises(bench_serve.BenchmarkError, match="duration and exact totals"):
+        bench_serve.validate_result(result, args)
+
+
+@pytest.mark.parametrize("duration", (0, -1, float("inf"), "4"))
+def test_duration_must_be_finite_positive_number(tmp_path, duration):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    result["duration"] = duration
+    if duration == float("inf"):
+        match = "NaN/Infinity"
+    else:
+        match = "duration"
+    with pytest.raises(bench_serve.BenchmarkError, match=match):
+        bench_serve.validate_result(result, args)
+
+
+def test_numpy_linear_percentile_and_population_std_are_pinned(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    ttft_ms = [10.0, 11.0, 13.0, 17.0, 23.0, 31.0, 41.0, 53.0]
+    result["ttfts"] = [value / 1000 for value in ttft_ms]
+    aggregates = bench_serve._sample_aggregates(ttft_ms, args.percentiles.split(","))
+    result["mean_ttft_ms"] = aggregates["mean"]
+    result["median_ttft_ms"] = aggregates["median"]
+    result["std_ttft_ms"] = aggregates["std"]
+    for percentile in args.percentiles.split(","):
+        result[bench_serve._percentile_result_key(percentile, "ttft")] = aggregates[
+            f"p{float(percentile):g}"
+        ]
+
+    e2el_ms = [value + 2.0 for value in ttft_ms]
+    e2el = bench_serve._sample_aggregates(e2el_ms, args.percentiles.split(","))
+    result["mean_e2el_ms"] = e2el["mean"]
+    result["median_e2el_ms"] = e2el["median"]
+    result["std_e2el_ms"] = e2el["std"]
+    for percentile in args.percentiles.split(","):
+        result[bench_serve._percentile_result_key(percentile, "e2el")] = e2el[
+            f"p{float(percentile):g}"
+        ]
+    bench_serve.validate_result(result, args)
+
+    result["std_ttft_ms"] = __import__("statistics").stdev(ttft_ms)
+    with pytest.raises(bench_serve.BenchmarkError, match="std_ttft_ms disagrees"):
+        bench_serve.validate_result(result, args)
+
+
+def test_itl_chunk_count_is_not_assumed_to_equal_output_tokens(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    assert all(len(intervals) == 1 for intervals in result["itls"])
+    assert args.output_len - 1 == 255
+    bench_serve.validate_result(result, args)
+
+
+def test_speculative_result_contract_is_required_and_reconciled(tmp_path):
+    args = _parse(
+        tmp_path,
+        "--speculative-mode",
+        "on",
+        "--speculative-config",
+        '{"method":"mtp","num_speculative_tokens":2}',
+        '--server-arg=--speculative-config={"method":"mtp","num_speculative_tokens":2}',
+    )
+    result = _valid_result(args)
+    with pytest.raises(bench_serve.BenchmarkError, match="lacks required"):
+        bench_serve.validate_result(result, args)
+
+    _add_valid_speculative_result(result)
+    bench_serve.validate_result(result, args)
+
+    mutations = {
+        "spec_decode_acceptance_rate": result["spec_decode_acceptance_rate"] + 1,
+        "spec_decode_acceptance_length": result["spec_decode_acceptance_length"] + 1,
+        "spec_decode_num_drafts": result["spec_decode_num_drafts"] + 1,
+        "spec_decode_draft_tokens": result["spec_decode_draft_tokens"] + 1,
+        "spec_decode_accepted_tokens": result["spec_decode_draft_tokens"] + 1,
+        "spec_decode_per_position_acceptance_rates": [0.8],
+    }
+    for key, bad_value in mutations.items():
+        bad = dict(result, **{key: bad_value})
+        with pytest.raises(bench_serve.BenchmarkError):
+            bench_serve.validate_result(bad, args)
+
+
+def test_non_speculative_cell_rejects_speculative_telemetry(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    _add_valid_speculative_result(result)
+    with pytest.raises(bench_serve.BenchmarkError, match="non-speculative"):
+        bench_serve.validate_result(result, args)
+
+
 def test_single_token_prefill_explicitly_allows_empty_itl_and_zero_tpot(tmp_path):
     args = _parse(tmp_path, "--output-len", "1")
     result = _valid_result(args)
     assert all(not intervals for intervals in result["itls"])
     assert result["mean_itl_ms"] == result["mean_tpot_ms"] == 0.0
     bench_serve.validate_result(result, args)
+
+    unexpected_itl = dict(result, itls=[[0.001], *result["itls"][1:]])
+    with pytest.raises(bench_serve.BenchmarkError, match="single-token"):
+        bench_serve.validate_result(unexpected_itl, args)
 
 
 def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
@@ -483,10 +1003,12 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
     result = _valid_result(args)
     result["input_lens"] = input_lens
     result["total_input_tokens"] = sum(input_lens)
+    _reconcile_throughput(result)
     bench_serve.validate_result(result, args)
 
     too_long = dict(result, input_lens=[41, *input_lens[1:]])
     too_long["total_input_tokens"] = sum(too_long["input_lens"])
+    _reconcile_throughput(too_long)
     with pytest.raises(bench_serve.BenchmarkError, match=r"range \[1, 40\]"):
         bench_serve.validate_result(too_long, args)
 
@@ -494,9 +1016,7 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
     with pytest.raises(bench_serve.BenchmarkError, match="unexpected input_lens"):
         bench_serve.validate_result(wrong_type, args)
 
-    wrong_output_type = dict(
-        result, output_lens=[256.0, *result["output_lens"][1:]]
-    )
+    wrong_output_type = dict(result, output_lens=[256.0, *result["output_lens"][1:]])
     with pytest.raises(bench_serve.BenchmarkError, match="unexpected output_lens"):
         bench_serve.validate_result(wrong_output_type, args)
 
@@ -542,6 +1062,8 @@ def test_summary_keeps_independent_values_and_sample_dispersion(tmp_path):
     assert ttft["values"] == [20.0, 21.0, 22.0]
     assert ttft["mean"] == pytest.approx(21.0)
     assert ttft["median"] == pytest.approx(21.0)
+    assert ttft["block_p05"] == pytest.approx(20.1)
+    assert ttft["block_p95"] == pytest.approx(21.9)
     assert ttft["sample_stdev"] == pytest.approx(1.0)
     assert summary["metrics"]["p99_itl_ms"]["values"] == [2.0, 3.0, 4.0]
 
@@ -656,9 +1178,10 @@ def test_individual_metadata_probe_failure_is_recorded_not_raised(
     monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
     metadata = bench_serve.collect_metadata(args, {})
     assert metadata["software"]["gridbook_version"] is None
-    assert "package metadata unavailable" in metadata["collection_errors"][
-        "gridbook_version"
-    ]
+    assert (
+        "package metadata unavailable"
+        in metadata["collection_errors"]["gridbook_version"]
+    )
 
 
 def test_nonfinite_raw_result_is_rejected_but_preserved_as_valid_json(

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -1731,6 +1731,35 @@ def test_evidence_mutation_during_measurement_invalidates_the_report(
     assert provenance["digest_bound_inputs_verified_after_requests"] is False
 
 
+def test_client_runtime_change_during_measurement_invalidates_the_report(
+    tmp_path, monkeypatch
+):
+    args = _parse(tmp_path)
+
+    def fake_run(command):
+        path = Path(_option(command, "--result-dir")) / _option(
+            command, "--result-filename"
+        )
+        path.write_text(json.dumps(_valid_result(args)))
+        return 0
+
+    runtime_probes = iter((CLIENT_RUNTIME_ID, CLIENT_RUNTIME_ID + "-changed"))
+    monkeypatch.setattr(bench_serve, "_run_command", fake_run)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: next(runtime_probes)
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="runtime identity changed"):
+        bench_serve.run_benchmark(args)
+
+    report = json.loads(args.output.read_text())
+    assert report["status"] == "failed"
+    assert report["measurement_valid"] is False
+    provenance = report["metadata"]["measurement_provenance"]
+    assert provenance["digest_bound_inputs_verified_after_requests"] is True
+    assert provenance["git_state_verified_after_requests"] is True
+    assert provenance["client_runtime_verified_after_requests"] is False
+
+
 def test_report_omits_generated_text_and_arbitrary_server_errors():
     result = {
         "completed": 2,

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -1,0 +1,260 @@
+"""CPU-only tests for the reproducible online parity harness.
+
+The real client is ``vllm bench serve``.  These tests pin command construction,
+fixed-shape validation, provenance capture, and the report schema without a
+vLLM install, a GPU, or a listening server.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gridbook import bench_serve
+
+
+def _parse(tmp_path, *extra):
+    argv = [
+        "--base-url",
+        "http://127.0.0.1:8000/",
+        "--model",
+        "org/tokenizer",
+        "--served-model-name",
+        "served",
+        "--model-id",
+        "org/artifact@0123456",
+        "--image-id",
+        "registry/vllm@sha256:abc",
+        "--git-commit",
+        "deadbeef",
+        "--run-label",
+        "gridbook-0.6b-decode",
+        "--input-len",
+        "32",
+        "--output-len",
+        "256",
+        "--num-prompts",
+        "8",
+        "--max-concurrency",
+        "1",
+        "--output",
+        str(tmp_path / "report.json"),
+        *extra,
+    ]
+    return bench_serve.parse_args(argv)
+
+
+def _option(command, name):
+    return command[command.index(name) + 1]
+
+
+def _valid_result(args, *, offset=0.0):
+    return {
+        "completed": args.num_prompts,
+        "failed": 0,
+        "total_input_tokens": args.num_prompts * args.input_len,
+        "total_output_tokens": args.num_prompts * args.output_len,
+        "input_lens": [args.input_len] * args.num_prompts,
+        "output_lens": [args.output_len] * args.num_prompts,
+        "request_throughput": 2.0 + offset,
+        "output_throughput": 500.0 + offset,
+        "total_token_throughput": 600.0 + offset,
+        "mean_ttft_ms": 20.0 + offset,
+        "median_ttft_ms": 19.0 + offset,
+        "std_ttft_ms": 1.0,
+        "p99_ttft_ms": 22.0 + offset,
+        "mean_tpot_ms": 2.0 + offset,
+        "median_tpot_ms": 1.9 + offset,
+        "std_tpot_ms": 0.1,
+        "p99_tpot_ms": 2.2 + offset,
+        "mean_itl_ms": 2.1 + offset,
+        "median_itl_ms": 2.0 + offset,
+        "std_itl_ms": 0.2,
+        "p99_itl_ms": 2.5 + offset,
+        "mean_e2el_ms": 530.0 + offset,
+        "median_e2el_ms": 525.0 + offset,
+        "std_e2el_ms": 5.0,
+        "p99_e2el_ms": 540.0 + offset,
+    }
+
+
+def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
+    args = _parse(tmp_path, "--warmups", "4", "--seed", "900")
+    command = bench_serve.build_vllm_command(
+        args,
+        block_index=2,
+        result_dir=tmp_path,
+        result_filename="block.json",
+    )
+
+    assert command[:3] == ["vllm", "bench", "serve"]
+    assert _option(command, "--base-url") == "http://127.0.0.1:8000"
+    assert _option(command, "--served-model-name") == "served"
+    assert _option(command, "--dataset-name") == "random"
+    assert _option(command, "--random-input-len") == "32"
+    assert _option(command, "--random-output-len") == "256"
+    assert _option(command, "--random-range-ratio") == "0"
+    assert _option(command, "--num-warmups") == "4"
+    assert _option(command, "--seed") == "902"
+    assert _option(command, "--percentile-metrics") == "ttft,tpot,itl,e2el"
+    assert "--ignore-eos" in command
+    assert "--save-detailed" in command
+    assert "--no-stream" not in command
+
+
+def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--blocks", "0")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--percentiles", "50,100")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--request-rate", "0")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--max-concurrency", "9")
+
+
+def test_dispatch_environment_is_sorted_explicit_and_secret_safe():
+    env = {
+        "PRISMAQUANT_CB_DECODE": "cuda",
+        "PRISMAQUANT_API_TOKEN": "do-not-save",
+        "CUDA_VISIBLE_DEVICES": "0",
+        "UNRELATED": "ignored",
+    }
+    captured = bench_serve.capture_dispatch_environment(
+        env, ["CUDA_VISIBLE_DEVICES", "MISSING"], ["PRISMAQUANT_"]
+    )
+    assert list(captured) == [
+        "CUDA_VISIBLE_DEVICES",
+        "MISSING",
+        "PRISMAQUANT_API_TOKEN",
+        "PRISMAQUANT_CB_DECODE",
+    ]
+    assert captured["CUDA_VISIBLE_DEVICES"] == "0"
+    assert captured["MISSING"] is None
+    assert captured["PRISMAQUANT_API_TOKEN"] == "<redacted>"
+    assert captured["PRISMAQUANT_CB_DECODE"] == "cuda"
+
+
+def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monkeypatch):
+    args = _parse(
+        tmp_path,
+        "--server-arg=--enforce-eager",
+        "--dispatch-env",
+        "CUDA_VISIBLE_DEVICES",
+    )
+    monkeypatch.setattr(bench_serve, "_package_version", lambda: "0.3.0")
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM 1.2")
+    metadata = bench_serve.collect_metadata(
+        args,
+        {"PRISMAQUANT_CB_DECODE": "cuda", "CUDA_VISIBLE_DEVICES": "0"},
+    )
+
+    assert metadata["git"] == {
+        "commit": "deadbeef",
+        "dirty": None,
+        "source": "argument",
+    }
+    assert metadata["software"]["gridbook_version"] == "0.3.0"
+    assert metadata["software"]["vllm_cli_version"] == "vLLM 1.2"
+    assert metadata["artifacts"]["image_id"].endswith("sha256:abc")
+    assert metadata["artifacts"]["model_id"] == "org/artifact@0123456"
+    assert metadata["server"]["recorded_args"] == ["--enforce-eager"]
+    assert metadata["dispatch"]["environment"] == {
+        "CUDA_VISIBLE_DEVICES": "0",
+        "PRISMAQUANT_CB_DECODE": "cuda",
+    }
+    assert metadata["workload"]["streaming"] is True
+    assert metadata["workload"]["block_seeds"] == [1234, 1235, 1236]
+
+
+def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+    bench_serve.validate_result(result, args)
+
+    missing_itl = dict(result)
+    del missing_itl["mean_itl_ms"]
+    with pytest.raises(bench_serve.BenchmarkError, match="streaming metrics"):
+        bench_serve.validate_result(missing_itl, args)
+
+    short_decode = dict(
+        result, total_output_tokens=result["total_output_tokens"] - 1
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="not completed exactly"):
+        bench_serve.validate_result(short_decode, args)
+
+    uneven = dict(result, output_lens=[255, 257] + [256] * 6)
+    with pytest.raises(bench_serve.BenchmarkError, match="unexpected output_lens"):
+        bench_serve.validate_result(uneven, args)
+
+
+def test_summary_keeps_independent_values_and_sample_dispersion(tmp_path):
+    args = _parse(tmp_path)
+    blocks = [
+        {"result": _valid_result(args, offset=0.0)},
+        {"result": _valid_result(args, offset=1.0)},
+        {"result": _valid_result(args, offset=2.0)},
+    ]
+    summary = bench_serve.summarize_blocks(blocks)
+    ttft = summary["metrics"]["mean_ttft_ms"]
+
+    assert summary["completed_blocks"] == 3
+    assert ttft["values"] == [20.0, 21.0, 22.0]
+    assert ttft["mean"] == pytest.approx(21.0)
+    assert ttft["median"] == pytest.approx(21.0)
+    assert ttft["sample_stdev"] == pytest.approx(1.0)
+    assert summary["metrics"]["p99_itl_ms"]["values"] == [2.5, 3.5, 4.5]
+
+
+def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypatch):
+    args = _parse(tmp_path, "--blocks", "3")
+    calls = []
+
+    def fake_run(command):
+        calls.append(command)
+        result_dir = Path(_option(command, "--result-dir"))
+        filename = _option(command, "--result-filename")
+        block_index = int(_option(command, "--seed")) - args.seed
+        (result_dir / filename).write_text(
+            json.dumps(_valid_result(args, offset=float(block_index)))
+        )
+        return 0
+
+    monkeypatch.setattr(bench_serve, "_run_command", fake_run)
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    report = bench_serve.run_benchmark(args)
+    written = json.loads(args.output.read_text())
+
+    assert len(calls) == 3
+    assert report["status"] == "success"
+    assert written["schema"] == bench_serve.SCHEMA
+    assert written["status"] == "success"
+    assert [block["seed"] for block in written["blocks"]] == [1234, 1235, 1236]
+    assert written["summary"]["completed_blocks"] == 3
+    assert written["finished_at"].endswith("Z")
+
+
+def test_failed_block_leaves_a_structured_failure_report(tmp_path, monkeypatch):
+    args = _parse(tmp_path)
+    monkeypatch.setattr(bench_serve, "_run_command", lambda command: 7)
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+
+    with pytest.raises(bench_serve.BenchmarkError, match="exit code 7"):
+        bench_serve.run_benchmark(args)
+    report = json.loads(args.output.read_text())
+    assert report["status"] == "failed"
+    assert report["blocks"] == []
+    assert "exit code 7" in report["error"]
+
+
+def test_existing_report_is_never_replaced_without_opt_in(tmp_path, monkeypatch):
+    args = _parse(tmp_path)
+    args.output.write_text("keep me")
+    monkeypatch.setattr(
+        bench_serve,
+        "_run_command",
+        lambda command: pytest.fail("benchmark must not start"),
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="already exists"):
+        bench_serve.run_benchmark(args)
+    assert args.output.read_text() == "keep me"

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -6,6 +6,8 @@ vLLM install, a GPU, or a listening server.
 """
 
 import json
+import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -49,13 +51,18 @@ def _option(command, name):
 
 
 def _valid_result(args, *, offset=0.0):
-    return {
+    multi_token = args.output_len > 1
+    result = {
         "completed": args.num_prompts,
         "failed": 0,
         "total_input_tokens": args.num_prompts * args.input_len,
         "total_output_tokens": args.num_prompts * args.output_len,
         "input_lens": [args.input_len] * args.num_prompts,
         "output_lens": [args.output_len] * args.num_prompts,
+        "errors": [""] * args.num_prompts,
+        "ttfts": [0.020 + offset / 1000] * args.num_prompts,
+        "itls": [[0.002 + offset / 1000] if multi_token else []
+                 for _ in range(args.num_prompts)],
         "request_throughput": 2.0 + offset,
         "output_throughput": 500.0 + offset,
         "total_token_throughput": 600.0 + offset,
@@ -63,23 +70,31 @@ def _valid_result(args, *, offset=0.0):
         "median_ttft_ms": 19.0 + offset,
         "std_ttft_ms": 1.0,
         "p99_ttft_ms": 22.0 + offset,
-        "mean_tpot_ms": 2.0 + offset,
-        "median_tpot_ms": 1.9 + offset,
+        "mean_tpot_ms": 2.0 + offset if multi_token else 0.0,
+        "median_tpot_ms": 1.9 + offset if multi_token else 0.0,
         "std_tpot_ms": 0.1,
-        "p99_tpot_ms": 2.2 + offset,
-        "mean_itl_ms": 2.1 + offset,
-        "median_itl_ms": 2.0 + offset,
+        "mean_itl_ms": 2.1 + offset if multi_token else 0.0,
+        "median_itl_ms": 2.0 + offset if multi_token else 0.0,
         "std_itl_ms": 0.2,
-        "p99_itl_ms": 2.5 + offset,
         "mean_e2el_ms": 530.0 + offset,
         "median_e2el_ms": 525.0 + offset,
         "std_e2el_ms": 5.0,
-        "p99_e2el_ms": 540.0 + offset,
     }
+    percentile_values = {
+        "ttft": 22.0 + offset,
+        "tpot": 2.2 + offset if multi_token else 0.0,
+        "itl": 2.5 + offset if multi_token else 0.0,
+        "e2el": 540.0 + offset,
+    }
+    for percentile in args.percentiles.split(","):
+        for metric, value in percentile_values.items():
+            key = bench_serve._percentile_result_key(percentile, metric)
+            result[key] = value
+    return result
 
 
 def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
-    args = _parse(tmp_path, "--warmups", "4", "--seed", "900")
+    args = _parse(tmp_path, "--warmups", "4", "--dataset-seed", "900")
     command = bench_serve.build_vllm_command(
         args,
         block_index=2,
@@ -96,10 +111,25 @@ def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
     assert _option(command, "--random-range-ratio") == "0"
     assert _option(command, "--num-warmups") == "4"
     assert _option(command, "--seed") == "902"
+    assert _option(command, "--temperature") == "0"
     assert _option(command, "--percentile-metrics") == "ttft,tpot,itl,e2el"
     assert "--ignore-eos" in command
     assert "--save-detailed" in command
     assert "--no-stream" not in command
+
+
+def test_dataset_seed_and_server_sampling_are_distinct_metadata(tmp_path, monkeypatch):
+    args = _parse(tmp_path, "--dataset-seed", "900")
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
+    metadata = bench_serve.collect_metadata(args, {})
+    workload = metadata["workload"]
+    assert workload["dataset_base_seed"] == 900
+    assert workload["dataset_block_seeds"] == [900, 901, 902]
+    assert workload["sampling"] == {
+        "strategy": "greedy",
+        "temperature": 0.0,
+        "sampling_seed": None,
+    }
 
 
 def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
@@ -111,12 +141,19 @@ def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
         _parse(tmp_path, "--request-rate", "0")
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--max-concurrency", "9")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--backend", "vllm")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--server-env", "MISSING_EQUALS")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--server-env", "MODE=a", "--server-env", "MODE=b")
 
 
 def test_dispatch_environment_is_sorted_explicit_and_secret_safe():
     env = {
         "PRISMAQUANT_CB_DECODE": "cuda",
         "PRISMAQUANT_API_TOKEN": "do-not-save",
+        "PRISMAQUANT_AUTH_COOKIE": "also-secret",
         "CUDA_VISIBLE_DEVICES": "0",
         "UNRELATED": "ignored",
     }
@@ -127,11 +164,13 @@ def test_dispatch_environment_is_sorted_explicit_and_secret_safe():
         "CUDA_VISIBLE_DEVICES",
         "MISSING",
         "PRISMAQUANT_API_TOKEN",
+        "PRISMAQUANT_AUTH_COOKIE",
         "PRISMAQUANT_CB_DECODE",
     ]
     assert captured["CUDA_VISIBLE_DEVICES"] == "0"
     assert captured["MISSING"] is None
     assert captured["PRISMAQUANT_API_TOKEN"] == "<redacted>"
+    assert captured["PRISMAQUANT_AUTH_COOKIE"] == "<redacted>"
     assert captured["PRISMAQUANT_CB_DECODE"] == "cuda"
 
 
@@ -139,8 +178,12 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     args = _parse(
         tmp_path,
         "--server-arg=--enforce-eager",
-        "--dispatch-env",
+        "--runner-env",
         "CUDA_VISIBLE_DEVICES",
+        "--server-env",
+        "PRISMAQUANT_CB_DECODE=v2",
+        "--server-env",
+        "HF_TOKEN=never-record",
     )
     monkeypatch.setattr(bench_serve, "_package_version", lambda: "0.3.0")
     monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM 1.2")
@@ -159,12 +202,60 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     assert metadata["artifacts"]["image_id"].endswith("sha256:abc")
     assert metadata["artifacts"]["model_id"] == "org/artifact@0123456"
     assert metadata["server"]["recorded_args"] == ["--enforce-eager"]
-    assert metadata["dispatch"]["environment"] == {
+    assert metadata["dispatch"]["runner_environment"] == {
+        "source": "benchmark process",
+        "values": {
+            "CUDA_VISIBLE_DEVICES": "0",
+            "PRISMAQUANT_CB_DECODE": "cuda",
+        },
+    }
+    assert metadata["dispatch"]["server_environment"] == {
+        "source": "explicit --server-env arguments",
+        "values": {
+            "HF_TOKEN": "<redacted>",
+            "PRISMAQUANT_CB_DECODE": "v2",
+        },
+    }
+    assert metadata["dispatch"]["runner_environment"]["values"] == {
         "CUDA_VISIBLE_DEVICES": "0",
         "PRISMAQUANT_CB_DECODE": "cuda",
     }
     assert metadata["workload"]["streaming"] is True
-    assert metadata["workload"]["block_seeds"] == [1234, 1235, 1236]
+    assert metadata["workload"]["dataset_block_seeds"] == [1234, 1235, 1236]
+
+
+def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
+    secret_url = (
+        "https://alice:password@example.test:8443/v1?api_key=topsecret&mode=fast"
+    )
+    args = _parse(
+        tmp_path,
+        "--base-url",
+        secret_url,
+        "--server-arg=--hf-token supersecret",
+        "--server-arg=Authorization: Bearer abc123",
+        "--server-arg=MONKEY=visible",
+    )
+    metadata = bench_serve.collect_metadata(args, {})
+    command = bench_serve.build_vllm_command(
+        args, block_index=0, result_dir=tmp_path, result_filename="raw.json"
+    )
+    redacted_command = bench_serve.redact_command(command)
+    serialized = json.dumps({"metadata": metadata, "command": redacted_command})
+
+    for secret in ("alice", "password", "topsecret", "supersecret", "abc123"):
+        assert secret not in serialized
+    assert "mode=fast" in metadata["server"]["base_url"]
+    assert "MONKEY=visible" in serialized
+    assert _option(redacted_command, "--tokenizer") == "org/tokenizer"
+
+
+def test_secret_key_detection_does_not_confuse_tokenizer_or_monkey():
+    assert bench_serve._is_sensitive_key("HF_TOKEN")
+    assert bench_serve._is_sensitive_key("authorization")
+    assert bench_serve._is_sensitive_key("AWS_SECRET_ACCESS_KEY")
+    assert not bench_serve._is_sensitive_key("tokenizer")
+    assert not bench_serve._is_sensitive_key("MONKEY")
 
 
 def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_path):
@@ -174,7 +265,7 @@ def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_p
 
     missing_itl = dict(result)
     del missing_itl["mean_itl_ms"]
-    with pytest.raises(bench_serve.BenchmarkError, match="streaming metrics"):
+    with pytest.raises(bench_serve.BenchmarkError, match="required metrics"):
         bench_serve.validate_result(missing_itl, args)
 
     short_decode = dict(
@@ -188,12 +279,69 @@ def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_p
         bench_serve.validate_result(uneven, args)
 
 
+def test_validate_result_requires_detailed_positive_streaming_arrays(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+
+    without_ttfts = dict(result)
+    del without_ttfts["ttfts"]
+    with pytest.raises(bench_serve.BenchmarkError, match="ttfts must cover"):
+        bench_serve.validate_result(without_ttfts, args)
+
+    zero_ttft = dict(result, ttfts=[0.0] + result["ttfts"][1:])
+    with pytest.raises(bench_serve.BenchmarkError, match="TTFT"):
+        bench_serve.validate_result(zero_ttft, args)
+
+    zero_e2el = dict(result, mean_e2el_ms=0.0)
+    with pytest.raises(bench_serve.BenchmarkError, match="non-positive"):
+        bench_serve.validate_result(zero_e2el, args)
+
+    missing_itl = dict(result, itls=[[]] + result["itls"][1:])
+    with pytest.raises(bench_serve.BenchmarkError, match="no inter-token"):
+        bench_serve.validate_result(missing_itl, args)
+
+    zero_itl = dict(result, itls=[[0.0]] + result["itls"][1:])
+    with pytest.raises(bench_serve.BenchmarkError, match="ITL"):
+        bench_serve.validate_result(zero_itl, args)
+
+
+def test_single_token_prefill_explicitly_allows_empty_itl_and_zero_tpot(tmp_path):
+    args = _parse(tmp_path, "--output-len", "1")
+    result = _valid_result(args)
+    assert all(not intervals for intervals in result["itls"])
+    assert result["mean_itl_ms"] == result["mean_tpot_ms"] == 0.0
+    bench_serve.validate_result(result, args)
+
+
+def test_validate_result_requires_throughput_percentiles_and_finite_numbers(tmp_path):
+    args = _parse(tmp_path)
+    result = _valid_result(args)
+
+    no_throughput = dict(result)
+    del no_throughput["output_throughput"]
+    with pytest.raises(bench_serve.BenchmarkError, match="output_throughput"):
+        bench_serve.validate_result(no_throughput, args)
+
+    no_requested_percentile = dict(result)
+    del no_requested_percentile["p95_e2el_ms"]
+    with pytest.raises(bench_serve.BenchmarkError, match="p95_e2el_ms"):
+        bench_serve.validate_result(no_requested_percentile, args)
+
+    nonfinite = dict(result, mean_ttft_ms=float("nan"))
+    with pytest.raises(bench_serve.BenchmarkError, match="NaN/Infinity"):
+        bench_serve.validate_result(nonfinite, args)
+
+    infinity_in_detail = dict(result, itls=[[float("inf")]] + result["itls"][1:])
+    with pytest.raises(bench_serve.BenchmarkError, match="NaN/Infinity"):
+        bench_serve.validate_result(infinity_in_detail, args)
+
+
 def test_summary_keeps_independent_values_and_sample_dispersion(tmp_path):
     args = _parse(tmp_path)
     blocks = [
-        {"result": _valid_result(args, offset=0.0)},
-        {"result": _valid_result(args, offset=1.0)},
-        {"result": _valid_result(args, offset=2.0)},
+        {"raw_result": _valid_result(args, offset=0.0)},
+        {"raw_result": _valid_result(args, offset=1.0)},
+        {"raw_result": _valid_result(args, offset=2.0)},
     ]
     summary = bench_serve.summarize_blocks(blocks)
     ttft = summary["metrics"]["mean_ttft_ms"]
@@ -212,9 +360,13 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
 
     def fake_run(command):
         calls.append(command)
+        checkpoint = json.loads(args.output.read_text())
+        assert checkpoint["status"] == "running"
+        assert checkpoint["blocks"][-1]["status"] == "running"
+        assert checkpoint["blocks"][-1]["returncode"] is None
         result_dir = Path(_option(command, "--result-dir"))
         filename = _option(command, "--result-filename")
-        block_index = int(_option(command, "--seed")) - args.seed
+        block_index = int(_option(command, "--seed")) - args.dataset_seed
         (result_dir / filename).write_text(
             json.dumps(_valid_result(args, offset=float(block_index)))
         )
@@ -229,9 +381,16 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
     assert report["status"] == "success"
     assert written["schema"] == bench_serve.SCHEMA
     assert written["status"] == "success"
-    assert [block["seed"] for block in written["blocks"]] == [1234, 1235, 1236]
+    assert [block["dataset_seed"] for block in written["blocks"]] == [
+        1234,
+        1235,
+        1236,
+    ]
+    assert all(block["status"] == "success" for block in written["blocks"])
+    assert all(block["returncode"] == 0 for block in written["blocks"])
     assert written["summary"]["completed_blocks"] == 3
     assert written["finished_at"].endswith("Z")
+    assert os.stat(args.output).st_mode & 0o777 == 0o600
 
 
 def test_failed_block_leaves_a_structured_failure_report(tmp_path, monkeypatch):
@@ -243,8 +402,95 @@ def test_failed_block_leaves_a_structured_failure_report(tmp_path, monkeypatch):
         bench_serve.run_benchmark(args)
     report = json.loads(args.output.read_text())
     assert report["status"] == "failed"
-    assert report["blocks"] == []
+    assert len(report["blocks"]) == 1
+    block = report["blocks"][0]
+    assert block["status"] == "failed"
+    assert block["returncode"] == 7
+    assert block["raw_result"] is None
+    assert block["validation_error"] is None
+    assert block["command"][:3] == ["vllm", "bench", "serve"]
     assert "exit code 7" in report["error"]
+
+
+def test_validation_failure_retains_raw_result_and_error(tmp_path, monkeypatch):
+    args = _parse(tmp_path)
+
+    def fake_run(command):
+        result = _valid_result(args)
+        result["total_output_tokens"] -= 1
+        path = Path(_option(command, "--result-dir")) / _option(
+            command, "--result-filename"
+        )
+        path.write_text(json.dumps(result))
+        return 0
+
+    monkeypatch.setattr(bench_serve, "_run_command", fake_run)
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    with pytest.raises(bench_serve.BenchmarkError, match="not completed exactly"):
+        bench_serve.run_benchmark(args)
+
+    report = json.loads(args.output.read_text())
+    block = report["blocks"][0]
+    assert block["returncode"] == 0
+    assert block["raw_result"]["total_output_tokens"] > 0
+    assert "not completed exactly" in block["validation_error"]
+
+
+def test_metadata_failure_is_captured_after_output_reservation(tmp_path, monkeypatch):
+    args = _parse(tmp_path)
+
+    def fail_metadata(_args):
+        raise RuntimeError("metadata probe exploded")
+
+    monkeypatch.setattr(bench_serve, "collect_metadata", fail_metadata)
+    with pytest.raises(RuntimeError, match="metadata probe exploded"):
+        bench_serve.run_benchmark(args)
+    report = json.loads(args.output.read_text())
+    assert report["status"] == "failed"
+    assert report["metadata"] is None
+    assert report["blocks"] == []
+    assert "metadata probe exploded" in report["error"]
+
+
+def test_individual_metadata_probe_failure_is_recorded_not_raised(
+    tmp_path, monkeypatch
+):
+    args = _parse(tmp_path)
+
+    def fail_version():
+        raise RuntimeError("package metadata unavailable")
+
+    monkeypatch.setattr(bench_serve, "_package_version", fail_version)
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
+    metadata = bench_serve.collect_metadata(args, {})
+    assert metadata["software"]["gridbook_version"] is None
+    assert "package metadata unavailable" in metadata["collection_errors"][
+        "gridbook_version"
+    ]
+
+
+def test_nonfinite_raw_result_is_rejected_but_preserved_as_valid_json(
+    tmp_path, monkeypatch
+):
+    args = _parse(tmp_path)
+
+    def fake_run(command):
+        result = _valid_result(args)
+        result["mean_ttft_ms"] = float("nan")
+        path = Path(_option(command, "--result-dir")) / _option(
+            command, "--result-filename"
+        )
+        path.write_text(json.dumps(result))
+        return 0
+
+    monkeypatch.setattr(bench_serve, "_run_command", fake_run)
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    with pytest.raises(bench_serve.BenchmarkError, match="NaN/Infinity"):
+        bench_serve.run_benchmark(args)
+    report = json.loads(args.output.read_text())
+    assert report["blocks"][0]["raw_result"]["mean_ttft_ms"] == {
+        "nonfinite_float": "NaN"
+    }
 
 
 def test_existing_report_is_never_replaced_without_opt_in(tmp_path, monkeypatch):
@@ -258,3 +504,27 @@ def test_existing_report_is_never_replaced_without_opt_in(tmp_path, monkeypatch)
     with pytest.raises(bench_serve.BenchmarkError, match="already exists"):
         bench_serve.run_benchmark(args)
     assert args.output.read_text() == "keep me"
+
+
+def test_output_reservation_has_exactly_one_concurrent_winner(tmp_path):
+    output = tmp_path / "shared.json"
+
+    def reserve(_index):
+        try:
+            bench_serve._reserve_output(output, overwrite=False)
+            return "won"
+        except bench_serve.BenchmarkError:
+            return "lost"
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        outcomes = list(pool.map(reserve, range(16)))
+    assert outcomes.count("won") == 1
+    assert outcomes.count("lost") == 15
+    assert json.loads(output.read_text())["status"] == "reserved"
+    assert os.stat(output).st_mode & 0o777 == 0o600
+
+
+def test_atomic_json_writer_refuses_nonstandard_nan(tmp_path):
+    output = tmp_path / "report.json"
+    with pytest.raises(ValueError, match="JSON compliant"):
+        bench_serve._atomic_write_json(output, {"bad": float("nan")})

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -1221,6 +1221,27 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
     assert os.stat(args.output).st_mode & 0o777 == 0o600
 
 
+def test_report_omits_generated_text_and_arbitrary_server_errors():
+    result = {
+        "completed": 2,
+        "generated_texts": ["private completion", "https://host/#raw-secret"],
+        "errors": [None, "Authorization: Bearer unstructured-secret"],
+        "model_url": "https://user:password@example.test/model#fragment-secret",
+    }
+
+    sanitized = bench_serve._sanitize_result_for_report(result)
+    serialized = json.dumps(sanitized)
+
+    assert "generated_texts" not in sanitized
+    assert sanitized["generated_texts_omitted"]["count"] == 2
+    assert sanitized["errors"] == [None, "<redacted-server-error>"]
+    assert "private completion" not in serialized
+    assert "unstructured-secret" not in serialized
+    assert "raw-secret" not in serialized
+    assert "fragment-secret" not in serialized
+    assert "password" not in serialized
+
+
 def test_failed_block_leaves_a_structured_failure_report(tmp_path, monkeypatch):
     args = _parse(tmp_path)
     monkeypatch.setattr(bench_serve, "_run_command", lambda command: 7)

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -8,12 +8,16 @@ vLLM install, a GPU, or a listening server.
 import hashlib
 import json
 import os
+import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
 from gridbook import bench_serve
+
+CLIENT_RUNTIME_ID = "vLLM 0.23.1rc1.dev764+g54b16d8a9.d20260703"
+GRIDBOOK_COMMIT = "d" * 40
 
 
 def _argv(tmp_path):
@@ -38,7 +42,7 @@ def _argv(tmp_path):
         "tensor_parallel_size": 1,
         "assignments": [
             {
-                "unit": "model.*",
+                "unit": "model.layers.0.self_attn.q_proj",
                 "format_rung": "FP8_CB_K36",
                 "serialized_layout": "product-codebook-indices-v1",
                 "scale_coding": "e4m3-per-block",
@@ -51,6 +55,11 @@ def _argv(tmp_path):
     execution_raw = json.dumps(execution, sort_keys=True).encode()
     execution_path.write_bytes(execution_raw)
     execution_digest = hashlib.sha256(execution_raw).hexdigest()
+
+    server_evidence_path = tmp_path / "server-startup.log"
+    server_evidence_raw = b"dispatch=gridbook-cuda-cb-gemv-v2 fallback=none\n"
+    server_evidence_path.write_bytes(server_evidence_raw)
+    server_evidence_digest = hashlib.sha256(server_evidence_raw).hexdigest()
     return [
         "--base-url",
         "http://127.0.0.1:8000/",
@@ -58,12 +67,19 @@ def _argv(tmp_path):
         "org/tokenizer",
         "--served-model-name",
         "served",
+        "--prefix-caching",
+        "off",
+        "--server-arg=--no-enable-prefix-caching",
+        "--server-evidence",
+        str(server_evidence_path),
+        "--server-evidence-sha256",
+        server_evidence_digest,
         "--model-id",
         "org/artifact@0123456",
         "--image-id",
         "registry/vllm@sha256:abc",
         "--git-commit",
-        "deadbeef",
+        GRIDBOOK_COMMIT,
         "--run-label",
         "gridbook-0.6b-decode",
         "--artifact-bytes",
@@ -89,7 +105,7 @@ def _argv(tmp_path):
         "--fallback-state",
         "none-observed",
         "--client-runtime-id",
-        "vllm-bench@g54b16d8a9",
+        CLIENT_RUNTIME_ID,
         "--server-runtime-id",
         "vllm@g54b16d8a9+gridbook-0.3.0",
         "--gpu-id",
@@ -145,6 +161,24 @@ def _write_json_digest(path, payload):
     return hashlib.sha256(raw).hexdigest()
 
 
+def _range_argv(tmp_path, input_lens, *, ratio="0.25", lower=24, upper=40):
+    argv = _without_option(_argv(tmp_path), "--observed-input-len")
+    digest = bench_serve._canonical_input_lens_sha256(input_lens)
+    argv.extend(
+        [
+            "--input-range-ratio",
+            ratio,
+            "--observed-input-len-min",
+            str(lower),
+            "--observed-input-len-max",
+            str(upper),
+        ]
+    )
+    for _ in range(3):
+        argv.extend(["--expected-input-lens-sha256", digest])
+    return argv
+
+
 def _reconcile_throughput(result):
     result["request_throughput"] = result["completed"] / result["duration"]
     result["output_throughput"] = result["total_output_tokens"] / result["duration"]
@@ -171,6 +205,18 @@ def _valid_result(args, *, offset=0.0):
     total_input = args.num_prompts * observed_input_len
     total_output = args.num_prompts * args.output_len
     result = {
+        "date": "20260731-120000",
+        "endpoint_type": args.backend,
+        "backend": args.backend,
+        "label": args.run_label,
+        "model_id": args.model,
+        "tokenizer_id": args.tokenizer or args.model,
+        "num_prompts": args.num_prompts,
+        "request_rate": (
+            "inf" if args.request_rate == "inf" else float(args.request_rate)
+        ),
+        "burstiness": 1.0,
+        "max_concurrency": args.max_concurrency,
         "duration": duration,
         "completed": args.num_prompts,
         "failed": 0,
@@ -179,6 +225,12 @@ def _valid_result(args, *, offset=0.0):
         "input_lens": [observed_input_len] * args.num_prompts,
         "output_lens": [args.output_len] * args.num_prompts,
         "errors": [""] * args.num_prompts,
+        "generated_texts": ["synthetic output"] * args.num_prompts,
+        "start_times": [float(index) for index in range(args.num_prompts)],
+        "request_goodput": None,
+        "max_output_tokens_per_s": total_output / duration,
+        "max_concurrent_requests": args.max_concurrency,
+        "rtfx": [1.0] * args.num_prompts,
         "ttfts": [ttft_ms / 1000] * args.num_prompts,
         "itls": [
             [itl_ms / 1000] if multi_token else [] for _ in range(args.num_prompts)
@@ -269,7 +321,9 @@ def test_requested_64_observed_63_regression_is_validated_exactly(
     )
     assert _option(command, "--random-input-len") == "64"
 
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     metadata = bench_serve.collect_metadata(args, {})
     assert metadata["workload"]["requested_random_input_len"] == 64
     assert metadata["workload"]["observed_input_length_contract"] == {
@@ -286,7 +340,9 @@ def test_requested_64_observed_63_regression_is_validated_exactly(
 
 def test_dataset_seed_and_server_sampling_are_distinct_metadata(tmp_path, monkeypatch):
     args = _parse(tmp_path, "--dataset-seed", "900")
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     metadata = bench_serve.collect_metadata(args, {})
     workload = metadata["workload"]
     assert workload["dataset_base_seed"] == 900
@@ -317,6 +373,11 @@ def test_parser_rejects_ranges_that_break_a_comparable_workload(tmp_path):
         _parse(tmp_path, "--server-env", "MISSING_EQUALS")
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--server-env", "MODE=a", "--server-env", "MODE=b")
+    for prefix in ("", "A_", "___", "NO-DASH_"):
+        with pytest.raises(SystemExit):
+            _parse(tmp_path, "--runner-env-prefix", prefix)
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--runner-env-prefix", "PRISMAQUANT_")
     for ratio in ("-0.01", "1", "nan", "not-a-number"):
         with pytest.raises(SystemExit):
             _parse(tmp_path, "--input-range-ratio", ratio)
@@ -327,6 +388,8 @@ def test_observed_input_contract_is_required_and_unambiguous(tmp_path):
         bench_serve.parse_args(_without_option(_argv(tmp_path), "--observed-input-len"))
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--observed-input-len-min", "31")
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--expected-input-lens-sha256", "a" * 64)
     with pytest.raises(SystemExit):
         _parse(
             tmp_path,
@@ -339,6 +402,18 @@ def test_observed_input_contract_is_required_and_unambiguous(tmp_path):
         )
 
     range_argv = _without_option(_argv(tmp_path), "--observed-input-len")
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(
+            [
+                *range_argv,
+                "--input-range-ratio",
+                "0.25",
+                "--observed-input-len-min",
+                "24",
+                "--observed-input-len-max",
+                "40",
+            ]
+        )
     with pytest.raises(SystemExit):
         bench_serve.parse_args(
             [
@@ -369,6 +444,18 @@ def test_required_identity_strings_reject_whitespace(tmp_path):
             _parse(tmp_path, option, "   ")
 
 
+def test_git_commit_and_run_label_are_safe_exact_identifiers(tmp_path):
+    for commit in ("deadbeef", "g" * 40, "a" * 39, "a" * 41, "a" * 65):
+        with pytest.raises(SystemExit):
+            _parse(tmp_path, "--git-commit", commit)
+    args = _parse(tmp_path, "--git-commit", "A" * 64)
+    assert args.git_commit == "a" * 64
+
+    for label in ("has space", "../escape", "slash/value", "line\nbreak", "x" * 129):
+        with pytest.raises(SystemExit):
+            _parse(tmp_path, "--run-label", label)
+
+
 def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
     required = (
         "--artifact-bytes",
@@ -387,6 +474,9 @@ def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
         "--gpu-id",
         "--driver-version",
         "--accelerator-runtime",
+        "--prefix-caching",
+        "--server-evidence",
+        "--server-evidence-sha256",
         "--execution-manifest",
         "--execution-manifest-sha256",
         "--speculative-mode",
@@ -397,6 +487,38 @@ def test_execution_identity_and_whole_artifact_bytes_are_required(tmp_path):
     for option in required:
         with pytest.raises(SystemExit):
             bench_serve.parse_args(_without_option(_argv(tmp_path), option))
+
+
+def test_prefix_caching_and_server_evidence_fail_closed(tmp_path):
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--prefix-caching", "on")
+    with pytest.raises(SystemExit):
+        _parse(
+            tmp_path,
+            "--prefix-caching",
+            "on",
+            "--server-arg=--enable-prefix-caching",
+        )
+    with pytest.raises(SystemExit):
+        _parse(tmp_path, "--server-arg=--enable-prefix-caching")
+
+    on_argv = [
+        "--server-arg=--enable-prefix-caching"
+        if item == "--server-arg=--no-enable-prefix-caching"
+        else item
+        for item in _replace_option(_argv(tmp_path), "--prefix-caching", "on")
+    ]
+    assert bench_serve.parse_args(on_argv).prefix_caching == "on"
+
+    argv = _argv(tmp_path)
+    evidence_path = Path(_option(argv, "--server-evidence"))
+    evidence_path.write_text("mutated after digest declaration")
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(argv)
+
+    missing_digest = _without_option(_argv(tmp_path), "--server-evidence-sha256")
+    with pytest.raises(SystemExit):
+        bench_serve.parse_args(missing_digest)
 
 
 def test_cuda_version_remains_a_deprecated_accelerator_runtime_alias(tmp_path):
@@ -500,7 +622,9 @@ def test_prismaquant_quant_config_inventory_is_consumed_directly(tmp_path):
         bench_serve.parse_args(bad_argv)
 
 
-def test_payload_scope_is_explicit_and_never_substitutes_for_whole_bytes(tmp_path):
+def test_payload_scope_is_explicit_and_never_substitutes_for_whole_bytes(
+    tmp_path, monkeypatch
+):
     with pytest.raises(SystemExit):
         _parse(tmp_path, "--payload-bytes", "700")
     with pytest.raises(SystemExit):
@@ -519,6 +643,9 @@ def test_payload_scope_is_explicit_and_never_substitutes_for_whole_bytes(tmp_pat
         "700",
         "--payload-scope",
         "model shards plus codebook sidecar",
+    )
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
     )
     metadata = bench_serve.collect_metadata(args, {})
     assert metadata["artifacts"]["payload"] == {
@@ -593,6 +720,41 @@ def test_execution_manifest_binds_inventory_and_mixed_assignments(tmp_path):
     )
     with pytest.raises(SystemExit):
         bench_serve.parse_args(wrong_binding)
+
+
+def test_execution_manifest_requires_concrete_nonoverlapping_assignments(tmp_path):
+    argv = _argv(tmp_path)
+    execution_path = Path(_option(argv, "--execution-manifest"))
+    base = json.loads(execution_path.read_text())
+
+    invalid_manifests = []
+    bool_tp = json.loads(json.dumps(base))
+    bool_tp["tensor_parallel_size"] = True
+    invalid_manifests.append(bool_tp)
+
+    wildcard = json.loads(json.dumps(base))
+    wildcard["assignments"][0]["unit"] = "model.layers.*"
+    invalid_manifests.append(wildcard)
+
+    overlap = json.loads(json.dumps(base))
+    overlap["assignments"].append(
+        {
+            **overlap["assignments"][0],
+            "unit": overlap["assignments"][0]["unit"] + ".weight",
+        }
+    )
+    invalid_manifests.append(overlap)
+
+    for field in bench_serve._EXECUTION_ASSIGNMENT_FIELDS:
+        literal_mixed = json.loads(json.dumps(base))
+        literal_mixed["assignments"][0][field] = "mixed"
+        invalid_manifests.append(literal_mixed)
+
+    for manifest in invalid_manifests:
+        digest = _write_json_digest(execution_path, manifest)
+        candidate = _replace_option(argv, "--execution-manifest-sha256", digest)
+        with pytest.raises(SystemExit):
+            bench_serve.parse_args(candidate)
 
 
 def test_speculative_mode_requires_structured_configuration(tmp_path):
@@ -696,19 +858,22 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
         "HF_TOKEN=never-record",
     )
     monkeypatch.setattr(bench_serve, "_package_version", lambda: "0.3.0")
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM 1.2")
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     metadata = bench_serve.collect_metadata(
         args,
         {"PRISMAQUANT_CB_DECODE": "cuda", "CUDA_VISIBLE_DEVICES": "0"},
     )
 
     assert metadata["git"] == {
-        "commit": "deadbeef",
+        "commit": GRIDBOOK_COMMIT,
         "dirty": None,
         "source": "argument",
+        "release_eligible": True,
     }
     assert metadata["software"]["gridbook_version"] == "0.3.0"
-    assert metadata["software"]["runner_vllm_cli_probe"] == "vLLM 1.2"
+    assert metadata["software"]["runner_vllm_cli_probe"] == CLIENT_RUNTIME_ID
     assert metadata["artifacts"]["image_id"].endswith("sha256:abc")
     assert metadata["artifacts"]["model_id"] == "org/artifact@0123456"
     assert metadata["artifacts"]["whole_served_artifact_bytes"] == 800
@@ -730,14 +895,25 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
         identity["manifest"]["artifact_inventory_sha256"]
         == metadata["artifacts"]["inventory"]["sha256"]
     )
-    assert identity["client_runtime_id"] == "vllm-bench@g54b16d8a9"
+    assert identity["client_runtime_id"] == CLIENT_RUNTIME_ID
     assert identity["server_runtime_id"] == "vllm@g54b16d8a9+gridbook-0.3.0"
     assert identity["hardware"] == {
         "gpu_id": "NVIDIA-GB10:GPU-1234",
         "driver_version": "580.00",
         "accelerator_runtime": "CUDA 13.0",
     }
-    assert metadata["server"]["recorded_args"] == ["--enforce-eager"]
+    assert metadata["server"]["recorded_args"] == [
+        "--no-enable-prefix-caching",
+        "--enforce-eager",
+    ]
+    assert metadata["server"]["prefix_caching"] == "off"
+    assert metadata["server"]["evidence"]["attachments"][0]["sha256"] == _option(
+        _argv(tmp_path), "--server-evidence-sha256"
+    )
+    assert (
+        "verifies bytes, not semantic backend claims"
+        in metadata["server"]["evidence"]["scope"]
+    )
     assert metadata["dispatch"]["runner_environment"] == {
         "source": "benchmark process",
         "values": {
@@ -765,7 +941,67 @@ def test_metadata_captures_supplied_artifact_and_server_identity(tmp_path, monke
     }
 
 
-def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
+def test_git_state_only_autodetects_the_exact_clean_source_checkout(
+    tmp_path, monkeypatch
+):
+    checkout = tmp_path / "checkout"
+    source = checkout / "gridbook" / "bench_serve.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("# source\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='gridbook'\n")
+    monkeypatch.setattr(bench_serve, "__file__", str(source))
+
+    state = {"top_level": str(checkout), "dirty": ""}
+
+    def fake_git(command, **kwargs):
+        if command[-1] == "--show-toplevel":
+            output = state["top_level"]
+        elif command[-1] == "HEAD":
+            output = "a" * 40
+        elif command[1:3] == ["status", "--porcelain"]:
+            output = state["dirty"]
+        else:  # pragma: no cover - protects the test contract itself
+            raise AssertionError(command)
+        return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(bench_serve.subprocess, "run", fake_git)
+    assert bench_serve._git_state(None) == {
+        "commit": "a" * 40,
+        "dirty": False,
+        "source": "checkout",
+        "release_eligible": True,
+    }
+
+    state["dirty"] = " M gridbook/bench_serve.py\n"
+    with pytest.raises(bench_serve.BenchmarkError, match="checkout is dirty"):
+        bench_serve._git_state(None)
+    dirty = bench_serve._git_state(None, allow_dirty=True)
+    assert dirty["dirty"] is True
+    assert dirty["release_eligible"] is False
+
+    state["top_level"] = str(tmp_path)
+    mismatch = bench_serve._git_state(None)
+    assert mismatch["commit"] is None
+    assert mismatch["source"] == "unavailable-root-mismatch"
+
+    explicit = bench_serve._git_state(GRIDBOOK_COMMIT, allow_dirty=True)
+    assert explicit["commit"] == GRIDBOOK_COMMIT
+    assert explicit["release_eligible"] is False
+    with pytest.raises(bench_serve.BenchmarkError, match="not exact"):
+        bench_serve._git_state("deadbeef")
+
+
+def test_git_state_requires_a_real_pyproject_source_root(tmp_path, monkeypatch):
+    source = tmp_path / "site-packages" / "gridbook" / "bench_serve.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("# installed source without project root\n")
+    monkeypatch.setattr(bench_serve, "__file__", str(source))
+    state = bench_serve._git_state(None)
+    assert state["commit"] is None
+    assert state["source"] == "unavailable-non-source-install"
+
+
+def test_urls_commands_and_server_args_never_persist_credentials(tmp_path, monkeypatch):
     secret_url = (
         "https://alice:password@example.test:8443/v1?api_key=topsecret&mode=fast"
     )
@@ -779,6 +1015,9 @@ def test_urls_commands_and_server_args_never_persist_credentials(tmp_path):
         "--server-arg=--hf-token",
         "--server-arg=split-secret",
         "--server-arg=MONKEY=visible",
+    )
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
     )
     metadata = bench_serve.collect_metadata(args, {})
     command = bench_serve.build_vllm_command(
@@ -897,6 +1136,38 @@ def test_validate_result_requires_true_streaming_metrics_and_exact_lengths(tmp_p
         bench_serve.validate_result(uneven_input, args)
 
 
+def test_pinned_vllm_saved_invocation_envelope_is_reconciled_exactly(tmp_path):
+    args = _parse(tmp_path, "--request-rate", "2.5")
+    result = _valid_result(args)
+    assert result["date"] == "20260731-120000"
+    assert result["endpoint_type"] == result["backend"] == "openai"
+    assert result["model_id"] == args.model
+    assert result["tokenizer_id"] == (args.tokenizer or args.model)
+    assert result["request_rate"] == 2.5
+    assert isinstance(result["request_rate"], float)
+    bench_serve.validate_result(result, args)
+
+    mutations = {
+        "backend": "other",
+        "endpoint_type": args.endpoint,
+        "label": "other-label",
+        "model_id": args.model_id,
+        "tokenizer_id": "other/tokenizer",
+        "num_prompts": True,
+        "request_rate": "2.5",
+        "max_concurrency": 1.0,
+    }
+    for field, bad_value in mutations.items():
+        with pytest.raises(bench_serve.BenchmarkError, match=field):
+            bench_serve.validate_result({**result, field: bad_value}, args)
+
+    for field in mutations:
+        missing = dict(result)
+        del missing[field]
+        with pytest.raises(bench_serve.BenchmarkError, match=field):
+            bench_serve.validate_result(missing, args)
+
+
 def test_validate_result_requires_detailed_positive_streaming_arrays(tmp_path):
     args = _parse(tmp_path)
     result = _valid_result(args)
@@ -1001,7 +1272,7 @@ def test_numpy_linear_percentile_and_population_std_are_pinned(tmp_path):
     result["std_ttft_ms"] = aggregates["std"]
     for percentile in args.percentiles.split(","):
         result[bench_serve._percentile_result_key(percentile, "ttft")] = aggregates[
-            f"p{float(percentile):g}"
+            f"p{bench_serve._percentile_label(percentile)}"
         ]
 
     e2el_ms = [value + 2.0 for value in ttft_ms]
@@ -1011,13 +1282,40 @@ def test_numpy_linear_percentile_and_population_std_are_pinned(tmp_path):
     result["std_e2el_ms"] = e2el["std"]
     for percentile in args.percentiles.split(","):
         result[bench_serve._percentile_result_key(percentile, "e2el")] = e2el[
-            f"p{float(percentile):g}"
+            f"p{bench_serve._percentile_label(percentile)}"
         ]
     bench_serve.validate_result(result, args)
 
     result["std_ttft_ms"] = __import__("statistics").stdev(ttft_ms)
     with pytest.raises(bench_serve.BenchmarkError, match="std_ttft_ms disagrees"):
         bench_serve.validate_result(result, args)
+
+
+def test_percentile_labels_match_pinned_vllm_without_collisions(tmp_path):
+    args = _parse(
+        tmp_path,
+        "--percentiles",
+        "1e-7,50,90,95,95.00001,95.00002,99.9999999",
+    )
+    assert args.percentiles.split(",") == [
+        "1e-07",
+        "50",
+        "90",
+        "95",
+        "95.00001",
+        "95.00002",
+        "99.9999999",
+    ]
+    assert bench_serve._percentile_result_key("95.00001", "ttft") != (
+        bench_serve._percentile_result_key("95.00002", "ttft")
+    )
+    result = _valid_result(args)
+    bench_serve.validate_result(result, args)
+    summary = bench_serve.summarize_blocks(
+        [{"raw_result": dict(result)} for _ in range(3)]
+    )
+    assert "p1e-07_ttft_ms" in summary["metrics"]
+    assert "p99.9999999_e2el_ms" in summary["metrics"]
 
 
 def test_itl_chunk_count_is_not_assumed_to_equal_output_tokens(tmp_path):
@@ -1078,19 +1376,11 @@ def test_single_token_prefill_explicitly_allows_empty_itl_and_zero_tpot(tmp_path
         bench_serve.validate_result(unexpected_itl, args)
 
 
-def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
-    argv = _without_option(_argv(tmp_path), "--observed-input-len")
-    args = bench_serve.parse_args(
-        [
-            *argv,
-            "--input-range-ratio",
-            "0.25",
-            "--observed-input-len-min",
-            "24",
-            "--observed-input-len-max",
-            "40",
-        ]
-    )
+def test_input_range_ratio_requires_the_exact_block_vector_digest(
+    tmp_path, monkeypatch
+):
+    input_lens = [24, 26, 28, 30, 32, 34, 36, 40]
+    args = bench_serve.parse_args(_range_argv(tmp_path, input_lens))
     command = bench_serve.build_vllm_command(
         args, block_index=0, result_dir=tmp_path, result_filename="raw.json"
     )
@@ -1099,6 +1389,9 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
         "output": 0.0,
     }
     assert bench_serve._observed_input_length_bounds(args) == (24, 40)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     metadata = bench_serve.collect_metadata(args, {})
     assert metadata["workload"]["input_range_ratio"] == 0.25
     assert metadata["workload"]["vllm_range_ratio"] == {
@@ -1106,13 +1399,24 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
         "output": 0.0,
     }
     assert metadata["workload"]["accepted_input_length_bounds"] == [24, 40]
+    assert [
+        item["sha256"]
+        for item in metadata["workload"]["expected_input_lens_sha256_by_block"]
+    ] == args.expected_input_lens_sha256
 
-    input_lens = [24, 26, 28, 30, 32, 34, 36, 40]
     result = _valid_result(args)
     result["input_lens"] = input_lens
     result["total_input_tokens"] = sum(input_lens)
     _reconcile_throughput(result)
     bench_serve.validate_result(result, args)
+
+    different_but_in_bounds = dict(result, input_lens=[25, 26, 28, 30, 32, 34, 36, 39])
+    different_but_in_bounds["total_input_tokens"] = sum(
+        different_but_in_bounds["input_lens"]
+    )
+    _reconcile_throughput(different_but_in_bounds)
+    with pytest.raises(bench_serve.BenchmarkError, match="input_lens SHA-256"):
+        bench_serve.validate_result(different_but_in_bounds, args)
 
     too_long = dict(result, input_lens=[41, *input_lens[1:]])
     too_long["total_input_tokens"] = sum(too_long["input_lens"])
@@ -1137,6 +1441,40 @@ def test_input_range_ratio_is_passed_and_validated_as_input_only(tmp_path):
     wrong_total = dict(result, total_input_tokens=sum(input_lens) + 1)
     with pytest.raises(bench_serve.BenchmarkError, match="do not reconcile"):
         bench_serve.validate_result(wrong_total, args)
+
+
+def test_range_input_vector_digests_are_bound_in_block_order(tmp_path):
+    vectors = [
+        [24, 25, 26, 27, 28, 29, 30, 31],
+        [25, 26, 27, 28, 29, 30, 31, 32],
+        [26, 27, 28, 29, 30, 31, 32, 33],
+    ]
+    argv = _without_option(_argv(tmp_path), "--observed-input-len")
+    argv.extend(
+        [
+            "--input-range-ratio",
+            "0.25",
+            "--observed-input-len-min",
+            "24",
+            "--observed-input-len-max",
+            "40",
+        ]
+    )
+    for vector in vectors:
+        argv.extend(
+            [
+                "--expected-input-lens-sha256",
+                bench_serve._canonical_input_lens_sha256(vector),
+            ]
+        )
+    args = bench_serve.parse_args(argv)
+    result = _valid_result(args)
+    result["input_lens"] = vectors[1]
+    result["total_input_tokens"] = sum(vectors[1])
+    _reconcile_throughput(result)
+    bench_serve.validate_result(result, args, block_index=1)
+    with pytest.raises(bench_serve.BenchmarkError, match="block 1"):
+        bench_serve.validate_result(result, args, block_index=0)
 
 
 def test_validate_result_requires_throughput_percentiles_and_finite_numbers(tmp_path):
@@ -1183,7 +1521,7 @@ def test_summary_keeps_independent_values_and_sample_dispersion(tmp_path):
 
 
 def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypatch):
-    args = _parse(tmp_path, "--blocks", "3")
+    args = _parse(tmp_path, "--blocks", "3", "--allow-dirty")
     calls = []
 
     def fake_run(command):
@@ -1201,7 +1539,9 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
         return 0
 
     monkeypatch.setattr(bench_serve, "_run_command", fake_run)
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     report = bench_serve.run_benchmark(args)
     written = json.loads(args.output.read_text())
 
@@ -1209,6 +1549,11 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
     assert report["status"] == "success"
     assert written["schema"] == bench_serve.SCHEMA
     assert written["status"] == "success"
+    assert written["evidence_scope"] == "single-arm-serving-measurement"
+    assert written["measurement_valid"] is True
+    assert written["parity_acceptance"] is False
+    assert written["release_acceptance"] is False
+    assert written["release_eligible"] is False
     assert [block["dataset_seed"] for block in written["blocks"]] == [
         1234,
         1235,
@@ -1216,6 +1561,14 @@ def test_run_writes_a_complete_report_without_vllm_or_server(tmp_path, monkeypat
     ]
     assert all(block["status"] == "success" for block in written["blocks"])
     assert all(block["returncode"] == 0 for block in written["blocks"])
+    assert all(
+        block["expected_input_lens_sha256"] is None for block in written["blocks"]
+    )
+    assert all(block["observed_input_lens_sha256"] for block in written["blocks"])
+    assert all(
+        "generated_texts" not in block["raw_result"] for block in written["blocks"]
+    )
+    assert all("errors" not in block["raw_result"] for block in written["blocks"])
     assert written["summary"]["completed_blocks"] == 3
     assert written["finished_at"].endswith("Z")
     assert os.stat(args.output).st_mode & 0o777 == 0o600
@@ -1234,23 +1587,42 @@ def test_report_omits_generated_text_and_arbitrary_server_errors():
 
     assert "generated_texts" not in sanitized
     assert sanitized["generated_texts_omitted"]["count"] == 2
-    assert sanitized["errors"] == [None, "<redacted-server-error>"]
+    assert "errors" not in sanitized
+    assert sanitized["errors_omitted"]["count"] == 2
     assert "private completion" not in serialized
     assert "unstructured-secret" not in serialized
     assert "raw-secret" not in serialized
     assert "fragment-secret" not in serialized
     assert "password" not in serialized
 
+    for malformed_errors in (
+        "Authorization: Bearer scalar-secret",
+        {"message": "mapping-secret"},
+        17,
+    ):
+        malformed = bench_serve._sanitize_result_for_report(
+            {"errors": malformed_errors}
+        )
+        assert "errors" not in malformed
+        assert malformed["errors_omitted"]["count"] is None
+        assert "secret" not in json.dumps(malformed)
+
 
 def test_failed_block_leaves_a_structured_failure_report(tmp_path, monkeypatch):
     args = _parse(tmp_path)
     monkeypatch.setattr(bench_serve, "_run_command", lambda command: 7)
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
 
     with pytest.raises(bench_serve.BenchmarkError, match="exit code 7"):
         bench_serve.run_benchmark(args)
     report = json.loads(args.output.read_text())
     assert report["status"] == "failed"
+    assert report["measurement_valid"] is False
+    assert report["parity_acceptance"] is False
+    assert report["release_acceptance"] is False
+    assert report["release_eligible"] is False
     assert len(report["blocks"]) == 1
     block = report["blocks"][0]
     assert block["status"] == "failed"
@@ -1274,7 +1646,9 @@ def test_validation_failure_retains_raw_result_and_error(tmp_path, monkeypatch):
         return 0
 
     monkeypatch.setattr(bench_serve, "_run_command", fake_run)
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     with pytest.raises(bench_serve.BenchmarkError, match="not completed exactly"):
         bench_serve.run_benchmark(args)
 
@@ -1310,13 +1684,37 @@ def test_individual_metadata_probe_failure_is_recorded_not_raised(
         raise RuntimeError("package metadata unavailable")
 
     monkeypatch.setattr(bench_serve, "_package_version", fail_version)
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: "vLLM")
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     metadata = bench_serve.collect_metadata(args, {})
     assert metadata["software"]["gridbook_version"] is None
     assert (
         "package metadata unavailable"
         in metadata["collection_errors"]["gridbook_version"]
     )
+
+
+def test_client_runtime_probe_must_succeed_and_match_exactly(tmp_path, monkeypatch):
+    args = _parse(tmp_path)
+    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    with pytest.raises(bench_serve.BenchmarkError, match="version probe failed"):
+        bench_serve.collect_metadata(args, {})
+
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID + "-other"
+    )
+    with pytest.raises(bench_serve.BenchmarkError, match="disagrees"):
+        bench_serve.collect_metadata(args, {})
+
+
+def test_allow_dirty_marks_report_provenance_release_ineligible(tmp_path, monkeypatch):
+    args = _parse(tmp_path, "--allow-dirty")
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
+    metadata = bench_serve.collect_metadata(args, {})
+    assert metadata["git"]["release_eligible"] is False
 
 
 def test_nonfinite_raw_result_is_rejected_at_strict_json_boundary(
@@ -1334,7 +1732,9 @@ def test_nonfinite_raw_result_is_rejected_at_strict_json_boundary(
         return 0
 
     monkeypatch.setattr(bench_serve, "_run_command", fake_run)
-    monkeypatch.setattr(bench_serve, "_vllm_version", lambda executable: None)
+    monkeypatch.setattr(
+        bench_serve, "_vllm_version", lambda executable: CLIENT_RUNTIME_ID
+    )
     with pytest.raises(bench_serve.BenchmarkError, match="not strict JSON"):
         bench_serve.run_benchmark(args)
     report = json.loads(args.output.read_text())

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -338,6 +338,8 @@ def test_command_uses_official_streaming_fixed_shape_semantics(tmp_path):
         "output": 0.0,
     }
     assert _option(command, "--num-warmups") == "4"
+    assert _option(command, "--request-rate") == "inf"
+    assert _option(command, "--burstiness") == "1.0"
     assert _option(command, "--seed") == "902"
     assert _option(command, "--temperature") == "0"
     assert _option(command, "--percentile-metrics") == "ttft,tpot,itl,e2el"
@@ -1191,6 +1193,7 @@ def test_pinned_vllm_saved_invocation_envelope_is_reconciled_exactly(tmp_path):
         "tokenizer_id": "other/tokenizer",
         "num_prompts": True,
         "request_rate": "2.5",
+        "burstiness": 2.0,
         "max_concurrency": 1.0,
     }
     for field, bad_value in mutations.items():


### PR DESCRIPTION
## Summary

- adds a reproducible streaming vLLM serving harness with exact whole-artifact byte inventories
- binds execution manifests, server evidence, software/runtime identity, request shapes, seeds, and detailed latency metrics
- records complete format, activation, backend, TP, and fallback contracts instead of trusting format labels
- documents the hard constrained quality-under-byte-and-phase-SLO policy and the current 0.6B non-match
- corrects historical benchmark language so batch-1 and body-byte observations are not presented as formal parity

A successful report is deliberately a single-arm measurement only. It never declares parity, release acceptance, or quality by itself.

## Validation

- focused source suite: 80 passed
- independently reviewed installed-wheel suite: 80 passed
- wider file-isolated non-HIP suite: zero failing modules
- source distribution and wheel build successfully
- compileall and diff checks pass

## Scope

No Strix Halo, HIP, or ROCm implementation or hardware result is included. Live native-versus-CB NVIDIA measurement remains a post-merge validation step.