### PR TITLE
runtime: serialize concurrent cold CUDA extension loads

### DIFF
--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -32,9 +32,24 @@ from __future__ import annotations
 import os
 import sys
 import threading
+from functools import wraps
+
+
+def _serialized_loader(lock, is_complete):
+    """Hold ``lock`` across one loader's cold build and state publication."""
+    def decorate(loader):
+        @wraps(loader)
+        def serialized():
+            if is_complete():
+                return loader()
+            with lock:
+                return loader()
+        return serialized
+    return decorate
 
 _ext = None
 _tried = False
+_ext_lock = threading.Lock()
 
 _NVCC_HINT = (
     "install a CUDA toolchain matching your torch build (distro `cuda-toolkit` "
@@ -201,12 +216,12 @@ _EXT_SYMBOLS = (
 )
 
 
+@_serialized_loader(_ext_lock, lambda: _tried)
 def get_ext():
     """The compiled extension module, or None if unavailable."""
     global _ext, _tried
     if _tried:
         return _ext
-    _tried = True
     try:
         import torch  # noqa: F401  (must import before cpp_extension)
         from torch.utils.cpp_extension import load
@@ -251,6 +266,8 @@ def get_ext():
               f"get the CUDA path: {_NVCC_HINT}.",
               file=sys.stderr, flush=True)
         _ext = None
+    finally:
+        _tried = True
     return _ext
 
 
@@ -336,6 +353,7 @@ def get_ext_v2():
 
 _fused = None
 _fused_tried = False
+_fused_lock = threading.Lock()
 
 
 def _find_cutlass_include() -> str:
@@ -359,24 +377,26 @@ def _find_cutlass_include() -> str:
 
 _ptc = None
 _ptc_tried = False
+_ptc_lock = threading.Lock()
 
 # ops.cb_prefill_persistent_tc dereferences this straight after the None check
 # (it has no probe), and it is the only binding cb_persistent_tc.cu exports.
 _PTC_SYMBOLS = ("cb_prefill_persistent_tc",)
 
 
+@_serialized_loader(_ptc_lock, lambda: _ptc_tried)
 def get_persistent_ext():
     """JIT build/load of the persistent-N tensor-core prefill kernel
     (gridbook/csrc/cb_persistent_tc.cu, #4b v1). Fail-soft like the fused ext."""
     global _ptc, _ptc_tried
     if _ptc_tried:
         return _ptc
-    _ptc_tried = True
     # QUARANTINE (2026-07-23): a boot wedged minutes after this kernel's
     # bench container exited; until the canary ladder clears it, the ext
     # builds only on explicit opt-in.
     if os.environ.get("PRISMAQUANT_ENABLE_PTC") != "1":
         _ptc = None
+        _ptc_tried = True
         return None
     try:
         import torch  # noqa: F401
@@ -411,11 +431,14 @@ def get_persistent_ext():
         import warnings
         warnings.warn(f"persistent-TC ext unavailable: {exc}")
         _ptc = None
+    finally:
+        _ptc_tried = True
     return _ptc
 
 
 _fused_fp4 = None
 _fused_fp4_tried = False
+_fused_fp4_lock = threading.Lock()
 
 
 # Both families are guarded independently at their call sites
@@ -428,6 +451,7 @@ _FUSED_FP4_SYMBOL_FAMILIES = (
 )
 
 
+@_serialized_loader(_fused_fp4_lock, lambda: _fused_fp4_tried)
 def get_fused_fp4_ext():
     """The NVFP4_CB fused BLOCK-SCALED prefill extension
     (cb_fused_fp4_gemm.cu), or None. Separate module from the fp8 fused ext
@@ -441,7 +465,6 @@ def get_fused_fp4_ext():
     global _fused_fp4, _fused_fp4_tried
     if _fused_fp4_tried:
         return _fused_fp4
-    _fused_fp4_tried = True
     try:
         import torch
         from torch.utils.cpp_extension import load
@@ -490,6 +513,8 @@ def get_fused_fp4_ext():
               f"on the Triton/transient paths (expected off Blackwell or "
               f"without nvcc).", file=sys.stderr, flush=True)
         _fused_fp4 = None
+    finally:
+        _fused_fp4_tried = True
     return _fused_fp4
 
 
@@ -500,6 +525,7 @@ def get_fused_fp4_ext():
 _FUSED_SYMBOLS = ("cb_fused_prefill_mm_scaled",)
 
 
+@_serialized_loader(_fused_lock, lambda: _fused_tried)
 def get_fused_ext():
     """The CUTLASS decode-in-prologue prefill extension (cb_fused_gemm.cu),
     or None. Separate module from the GEMV ext: it needs the CUTLASS headers
@@ -508,7 +534,6 @@ def get_fused_ext():
     global _fused, _fused_tried
     if _fused_tried:
         return _fused
-    _fused_tried = True
     try:
         import torch  # noqa: F401
         from torch.utils.cpp_extension import load
@@ -549,4 +574,6 @@ def get_fused_ext():
               f"non-sm_120 GPUs and without nvcc).",
               file=sys.stderr, flush=True)
         _fused = None
+    finally:
+        _fused_tried = True
     return _fused

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -32,20 +32,6 @@ from __future__ import annotations
 import os
 import sys
 import threading
-from functools import wraps
-
-
-def _serialized_loader(lock, is_complete):
-    """Hold ``lock`` across one loader's cold build and state publication."""
-    def decorate(loader):
-        @wraps(loader)
-        def serialized():
-            if is_complete():
-                return loader()
-            with lock:
-                return loader()
-        return serialized
-    return decorate
 
 _ext = None
 _tried = False
@@ -216,12 +202,19 @@ _EXT_SYMBOLS = (
 )
 
 
-@_serialized_loader(_ext_lock, lambda: _tried)
 def get_ext():
     """The compiled extension module, or None if unavailable."""
-    global _ext, _tried
     if _tried:
         return _ext
+    with _ext_lock:
+        if _tried:
+            return _ext
+        return _load_ext_locked()
+
+
+def _load_ext_locked():
+    """Build and publish the main extension with ``_ext_lock`` held."""
+    global _ext, _tried
     try:
         import torch  # noqa: F401  (must import before cpp_extension)
         from torch.utils.cpp_extension import load
@@ -384,13 +377,20 @@ _ptc_lock = threading.Lock()
 _PTC_SYMBOLS = ("cb_prefill_persistent_tc",)
 
 
-@_serialized_loader(_ptc_lock, lambda: _ptc_tried)
 def get_persistent_ext():
     """JIT build/load of the persistent-N tensor-core prefill kernel
     (gridbook/csrc/cb_persistent_tc.cu, #4b v1). Fail-soft like the fused ext."""
-    global _ptc, _ptc_tried
     if _ptc_tried:
         return _ptc
+    with _ptc_lock:
+        if _ptc_tried:
+            return _ptc
+        return _load_persistent_ext_locked()
+
+
+def _load_persistent_ext_locked():
+    """Build and publish the persistent extension with ``_ptc_lock`` held."""
+    global _ptc, _ptc_tried
     # QUARANTINE (2026-07-23): a boot wedged minutes after this kernel's
     # bench container exited; until the canary ladder clears it, the ext
     # builds only on explicit opt-in.
@@ -451,7 +451,6 @@ _FUSED_FP4_SYMBOL_FAMILIES = (
 )
 
 
-@_serialized_loader(_fused_fp4_lock, lambda: _fused_fp4_tried)
 def get_fused_fp4_ext():
     """The NVFP4_CB fused BLOCK-SCALED prefill extension
     (cb_fused_fp4_gemm.cu), or None. Separate module from the fp8 fused ext
@@ -462,9 +461,17 @@ def get_fused_fp4_ext():
     arch-specific target — the block-scaled MMA is an arch-'a' instruction,
     so the build pins the current device's compute_XYa. Fail-soft: serving
     falls back to the Triton/transient fp4 paths."""
-    global _fused_fp4, _fused_fp4_tried
     if _fused_fp4_tried:
         return _fused_fp4
+    with _fused_fp4_lock:
+        if _fused_fp4_tried:
+            return _fused_fp4
+        return _load_fused_fp4_ext_locked()
+
+
+def _load_fused_fp4_ext_locked():
+    """Build and publish fused FP4 with ``_fused_fp4_lock`` held."""
+    global _fused_fp4, _fused_fp4_tried
     try:
         import torch
         from torch.utils.cpp_extension import load
@@ -525,15 +532,22 @@ def get_fused_fp4_ext():
 _FUSED_SYMBOLS = ("cb_fused_prefill_mm_scaled",)
 
 
-@_serialized_loader(_fused_lock, lambda: _fused_tried)
 def get_fused_ext():
     """The CUTLASS decode-in-prologue prefill extension (cb_fused_gemm.cu),
     or None. Separate module from the GEMV ext: it needs the CUTLASS headers
     (taken from the vLLM install's bundled copy) and a longer JIT build.
     Fail-soft like get_ext — serving falls back to the transient-expand path."""
-    global _fused, _fused_tried
     if _fused_tried:
         return _fused
+    with _fused_lock:
+        if _fused_tried:
+            return _fused
+        return _load_fused_ext_locked()
+
+
+def _load_fused_ext_locked():
+    """Build and publish fused FP8 with ``_fused_lock`` held."""
+    global _fused, _fused_tried
     try:
         import torch  # noqa: F401
         from torch.utils.cpp_extension import load

--- a/tests/test_ext_symbols.py
+++ b/tests/test_ext_symbols.py
@@ -80,20 +80,21 @@ def _prepare_fp4_loader(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "loader_name,value_name,tried_name,symbols,prepare",
+    "loader_name,value_name,tried_name,lock_name,symbols,prepare",
     [
-        ("get_ext", "_ext", "_tried", "_EXT_SYMBOLS", "main"),
-        ("get_persistent_ext", "_ptc", "_ptc_tried", "_PTC_SYMBOLS",
-         "ptc"),
+        ("get_ext", "_ext", "_tried", "_ext_lock", "_EXT_SYMBOLS",
+         "main"),
+        ("get_persistent_ext", "_ptc", "_ptc_tried", "_ptc_lock",
+         "_PTC_SYMBOLS", "ptc"),
         ("get_fused_fp4_ext", "_fused_fp4", "_fused_fp4_tried",
-         "_FUSED_FP4_SYMBOL_FAMILIES", "fp4"),
-        ("get_fused_ext", "_fused", "_fused_tried", "_FUSED_SYMBOLS",
-         "fused"),
+         "_fused_fp4_lock", "_FUSED_FP4_SYMBOL_FAMILIES", "fp4"),
+        ("get_fused_ext", "_fused", "_fused_tried", "_fused_lock",
+         "_FUSED_SYMBOLS", "fused"),
     ],
 )
 def test_cold_load_is_published_once_to_concurrent_callers(
-        monkeypatch, tmp_path, loader_name, value_name, tried_name, symbols,
-        prepare):
+        monkeypatch, tmp_path, loader_name, value_name, tried_name, lock_name,
+        symbols, prepare):
     """No caller may observe the in-progress loader's initial ``None``.
 
     Model construction can ask several layers for the same extension at once.
@@ -116,7 +117,23 @@ def test_cold_load_is_published_once_to_concurrent_callers(
     good = _stub(loader_name, declared)
     started = threading.Event()
     release = threading.Event()
+    waiter_blocked = threading.Event()
     calls = []
+
+    raw_lock = threading.Lock()
+
+    class ObservedLock:
+        def __enter__(self):
+            if raw_lock.locked():
+                waiter_blocked.set()
+            raw_lock.acquire()
+            return self
+
+        def __exit__(self, *_args):
+            raw_lock.release()
+            return False
+
+    monkeypatch.setattr(cuda_ext, lock_name, ObservedLock())
 
     pytest.importorskip("torch")
     cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
@@ -138,6 +155,8 @@ def test_cold_load_is_published_once_to_concurrent_callers(
         # if the second worker happens to start late on a loaded CI host.
         assert getattr(cuda_ext, tried_name) is False
         second = pool.submit(loader)
+        assert waiter_blocked.wait(timeout=10), \
+            "second caller did not wait for the cold loader"
         release.set()
         assert first.result(timeout=10) is good
         assert second.result(timeout=10) is good
@@ -179,7 +198,18 @@ def test_concurrent_failed_load_is_memoized_once(monkeypatch, capsys,
     assert "deliberate cold-build failure" in capsys.readouterr().err
 
 
-def test_completed_loader_fast_path_does_not_take_mutex():
+@pytest.mark.parametrize(
+    "loader_name,value_name,tried_name,lock_name",
+    [
+        ("get_ext", "_ext", "_tried", "_ext_lock"),
+        ("get_persistent_ext", "_ptc", "_ptc_tried", "_ptc_lock"),
+        ("get_fused_fp4_ext", "_fused_fp4", "_fused_fp4_tried",
+         "_fused_fp4_lock"),
+        ("get_fused_ext", "_fused", "_fused_tried", "_fused_lock"),
+    ],
+)
+def test_completed_loader_fast_path_does_not_take_mutex(
+        monkeypatch, loader_name, value_name, tried_name, lock_name):
     class ExplodingLock:
         def __enter__(self):
             raise AssertionError("memoized loader acquired the cold-path lock")
@@ -188,12 +218,11 @@ def test_completed_loader_fast_path_does_not_take_mutex():
             return False
 
     sentinel = object()
+    setattr(cuda_ext, value_name, sentinel)
+    setattr(cuda_ext, tried_name, True)
+    monkeypatch.setattr(cuda_ext, lock_name, ExplodingLock())
 
-    @cuda_ext._serialized_loader(ExplodingLock(), lambda: True)
-    def completed_loader():
-        return sentinel
-
-    assert completed_loader() is sentinel
+    assert getattr(cuda_ext, loader_name)() is sentinel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ext_symbols.py
+++ b/tests/test_ext_symbols.py
@@ -6,9 +6,11 @@ also checked against the packaged ``m.def`` bindings.
 """
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import re
 import sys
+import threading
 import types
 
 import pytest
@@ -75,6 +77,123 @@ def _prepare_fp4_loader(monkeypatch, tmp_path):
     cutlass = _prepare_cutlass(monkeypatch, tmp_path)
     monkeypatch.setenv("PRISMAQUANT_CUTLASS_INCLUDE", str(cutlass))
     monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (12, 1))
+
+
+@pytest.mark.parametrize(
+    "loader_name,value_name,tried_name,symbols,prepare",
+    [
+        ("get_ext", "_ext", "_tried", "_EXT_SYMBOLS", "main"),
+        ("get_persistent_ext", "_ptc", "_ptc_tried", "_PTC_SYMBOLS",
+         "ptc"),
+        ("get_fused_fp4_ext", "_fused_fp4", "_fused_fp4_tried",
+         "_FUSED_FP4_SYMBOL_FAMILIES", "fp4"),
+        ("get_fused_ext", "_fused", "_fused_tried", "_FUSED_SYMBOLS",
+         "fused"),
+    ],
+)
+def test_cold_load_is_published_once_to_concurrent_callers(
+        monkeypatch, tmp_path, loader_name, value_name, tried_name, symbols,
+        prepare):
+    """No caller may observe the in-progress loader's initial ``None``.
+
+    Model construction can ask several layers for the same extension at once.
+    The first cold JIT is deliberately held in ``load`` while a second caller
+    arrives; both must receive the one validated module and compilation must
+    happen once.
+    """
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    if prepare == "ptc":
+        monkeypatch.setenv("PRISMAQUANT_ENABLE_PTC", "1")
+        _prepare_cutlass(monkeypatch, tmp_path)
+    elif prepare == "fp4":
+        _prepare_fp4_loader(monkeypatch, tmp_path)
+    elif prepare == "fused":
+        _prepare_cutlass(monkeypatch, tmp_path)
+
+    declared = getattr(cuda_ext, symbols)
+    if symbols == "_FUSED_FP4_SYMBOL_FAMILIES":
+        declared = declared[0][1]
+    good = _stub(loader_name, declared)
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    pytest.importorskip("torch")
+    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
+
+    def blocking_load(*args, **kwargs):
+        calls.append((args, kwargs))
+        started.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("test did not release the cold JIT")
+        return good
+
+    monkeypatch.setattr(cpp_extension, "load", blocking_load)
+    loader = getattr(cuda_ext, loader_name)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(loader)
+        assert started.wait(timeout=10), "cold loader never reached JIT load"
+        # Terminal state is published after load and symbol validation, not at
+        # entry. This also makes the test distinguish the historical race even
+        # if the second worker happens to start late on a loaded CI host.
+        assert getattr(cuda_ext, tried_name) is False
+        second = pool.submit(loader)
+        release.set()
+        assert first.result(timeout=10) is good
+        assert second.result(timeout=10) is good
+
+    assert getattr(cuda_ext, value_name) is good
+    assert getattr(cuda_ext, tried_name) is True
+    assert len(calls) == 1
+
+
+def test_concurrent_failed_load_is_memoized_once(monkeypatch, capsys,
+                                                   tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    pytest.importorskip("torch")
+    cpp_extension = pytest.importorskip("torch.utils.cpp_extension")
+
+    def failing_load(*args, **kwargs):
+        calls.append((args, kwargs))
+        started.set()
+        if not release.wait(timeout=10):
+            raise TimeoutError("test did not release the cold JIT")
+        raise RuntimeError("deliberate cold-build failure")
+
+    monkeypatch.setattr(cpp_extension, "load", failing_load)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(cuda_ext.get_ext)
+        assert started.wait(timeout=10), "cold loader never reached JIT load"
+        assert cuda_ext._tried is False
+        second = pool.submit(cuda_ext.get_ext)
+        release.set()
+        assert first.result(timeout=10) is None
+        assert second.result(timeout=10) is None
+
+    assert cuda_ext._tried is True
+    assert len(calls) == 1
+    assert "deliberate cold-build failure" in capsys.readouterr().err
+
+
+def test_completed_loader_fast_path_does_not_take_mutex():
+    class ExplodingLock:
+        def __enter__(self):
+            raise AssertionError("memoized loader acquired the cold-path lock")
+
+        def __exit__(self, *_args):
+            return False
+
+    sentinel = object()
+
+    @cuda_ext._serialized_loader(ExplodingLock(), lambda: True)
+    def completed_loader():
+        return sentinel
+
+    assert completed_loader() is sentinel
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- prevents concurrent model layers from observing the temporary None state while a CUDA extension is still JIT compiling
- serializes each of the main, persistent-TC, fused FP4, and fused FP8 cold loaders independently
- publishes success or memoized failure only after build and symbol validation complete
- retains the original lock-free completed hot path

Without this fix, a second layer can permanently cache a slow fallback merely because it reached the loader during the first layer cold build.

## Validation

- loader suite: 44 passed
- deterministic observed-waiter race: 10 of 10 repeated runs passed
- isolated non-HIP CPU suite: 444 passed, 153 skipped across 30 files
- Python 3.10 through 3.13 grammar checks pass
- measured completed lookup: about 17.7 ns, restored from the rejected decorator prototype at about 48.7 ns

No Strix Halo, HIP, or ROCm implementation or hardware result is included.