### PR TITLE
release: Gridbook 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,39 @@
 # Changelog
 
-## Unreleased
+## 0.4.0 — 2026-07-31
 
-- Restore dense and MoE fused NVFP4 prefill to explicit opt-in while its
-  different activation bucket awaits a served quality A/B. This also avoids
-  the grouped MoE kernel's severe padding amplification immediately above its
-  16-token dispatch boundary.
+- Keep dense and grouped-MoE fused native-FP4 prefill behind explicit opt-in
+  gates while its different activation contract awaits a served quality A/B.
+  The conservative default also avoids the grouped kernel's severe padding
+  amplification immediately above its 16-token dispatch boundary.
+- Fail closed during model construction on unsupported serving contracts:
+  Gridbook now advertises the BF16 dtype its native bindings actually accept,
+  rejects FP8-CB below `sm_89`, rejects tensor parallelism above one, validates
+  `PRISMAQUANT_CB_PREFILL`, and freezes that selector for the process lifetime.
+- Deduplicate exact shared codebook references in fused dense layers, while
+  routing layouts with distinct or offset codebooks away from kernels that
+  cannot represent them.
+- Release unloaded model layers from the compiled-dispatch registry with weak
+  ownership and monotonic IDs, and serialize concurrent cold CUDA extension
+  loads without adding locks to completed hot-path lookups.
+- Reduce avoidable MoE-prefill selection/allocation overhead without changing
+  quantization, routing, or kernel arithmetic.
+- Require a dotted child boundary when resolving MoE targets, so sibling
+  modules such as `experts2` cannot be mistaken for the live expert stack.
+  This fix was extracted from Jason Wong's contribution series
+  ([@jsconsultancy](https://github.com/jsconsultancy)).
+- Add a fail-closed streaming native-parity harness that binds whole-artifact
+  bytes, installed software and runtime identity, server evidence, workload,
+  phase-specific latency, activation/backend/fallback contracts, and paired
+  quality evidence. A successful single-arm report is measurement evidence,
+  not by itself a parity or release claim.
 - Revalidate `FULL_DECODE_ONLY` CUDA graphs with the opaque default dispatch:
   changed inputs replay exactly against eager at capture sizes 1 and 4, and a
-  close-rate 0.6B canary narrows Gridbook decode to 5.9% of native.
+  close-rate 0.6B canary narrows Gridbook decode to 5.9% of native. This remains
+  approximate evidence: the CB artifact is 0.154% larger and compares W8A8
+  against native W4A4 rather than isolating weight encoding alone.
+
+[Full diff](https://github.com/RobTand/gridbook/compare/v0.3.0...v0.4.0)
 
 ## 0.3.0 — 2026-07-31
 

--- a/gridbook/__init__.py
+++ b/gridbook/__init__.py
@@ -13,7 +13,7 @@ falls back to a correct-but-slow Triton path.
 # Single source of truth for package and release metadata. This file is synced
 # from PrismaQuant's development tree into the standalone Gridbook release repo;
 # release tags are cut only from the latter and must match this value exactly.
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 def register() -> None:


### PR DESCRIPTION
## Release value

Gridbook 0.4.0 packages the ten reviewed post-0.3.0 PRs:

- keeps contract-changing native-FP4 prefill explicitly opt-in
- fails closed on unsupported dtype, GPU capability, TP, and mutable/invalid prefill selectors
- deduplicates shared fused codebooks while rejecting offset-incompatible fast paths
- releases unloaded compiled-dispatch layers and serializes cold CUDA JIT loaders without adding completed-hot-path locking
- reduces host/allocation overhead in MoE prefill and fixes dotted expert-prefix resolution
- adds the exact-byte, execution-contract-bound served validation harness used for native-parity work

The changelog preserves the evidence boundary: the 0.6B result is approximate because CB is 0.154% larger and compares an A8 CB contract with native W4A4.

Jason Wong extracted prefix-boundary finding remains credited to [@jsconsultancy](https://github.com/jsconsultancy).

## Release gates

- [x] authoritative producer-to-release sync is exact; held HIP paths remain excluded by policy
- [x] version bumped from the published 0.3.0 to 0.4.0
- [x] producer version-source PR merged with green CI
- [x] pull-request packaging/install/CPU CI green on Python 3.10-3.13
- [x] clean sdist/wheel, strict Twine, installed-wheel CUDA compile, and 10/10 image runtime checks green
- [x] six-cell GB10 validation against `JasonW2025/Laguna-S-2.1-PrismaQuant-gridbook-2.6bit-vllm@1ae37c430f905b02da3367e5ee309c684196e513`
- [x] exact tested commit `777dcc46f99c4914c4d2c50dd084c5df7fc31b05` tagged and released as `v0.4.0`
- [x] PyPI and GitHub release asset SHA-256 digests match; clean PyPI install verified

## Final validation

- [Release workflow](https://github.com/RobTand/gridbook/actions/runs/30679618687): all jobs passed
- [GitHub release](https://github.com/RobTand/gridbook/releases/tag/v0.4.0)
- [PyPI 0.4.0](https://pypi.org/project/gridbook/0.4.0/)
- 6 reports / 18 measured blocks / 492 measured requests / 0 failures
- 659,868 measured input tokens and 86,076 measured output tokens
- evidence validator: `0f7f71bdbacaf3d2fefc99a145706ac7f3ccdbd27a6cba7824a501bbbf7629c5`
- immutable validator verdict: `6ce5c72f80a62c7ec27bb199e757282cb67b5882e8089134c1a00ae5e196beae` (`ok=true`, `release_eligible=true`)
- pre-stop server log: `4e7a9023aa96eb0dfb97de9f77b31d81ccd1fb5c158b9e0f9384afd4f1356cfd`

The Jason run validates release compatibility and shipped performance paths only. It does not claim native parity, same-rate quality, speculative-decode coverage, or served KL/PPL.

No Strix Halo, gfx1151, HIP, or ROCm work is included or used. The dedicated validation service was stopped after the immutable pre-stop evidence was captured.