### PR TITLE
Register DeepSeek-V4 for the top-level stacked-CB expert wrap

### DIFF
--- a/gridbook/plugin.py
+++ b/gridbook/plugin.py
@@ -33,7 +33,13 @@ from .runtime_contract import load_runtime_contract
 
 
 _TOPLEVEL_CLASS_SUFFIXES = ("ForCausalLM", "ForCausalLMBase",
-                            "ForConditionalGeneration", "MTP")
+                            "ForConditionalGeneration", "MTP",
+                            # DeepSeek-V4 names its DSpark drafter class
+                            # ``DeepSeekV4DSpark`` -- it matches none of the
+                            # suffixes above, so without this the drafter
+                            # loads UNWRAPPED and its CB expert tensors are
+                            # handed to the arch's own loader.
+                            "DSpark")
 
 
 def _install_on_module_classes(module_path: str) -> None:

--- a/gridbook/runtime_contract.json
+++ b/gridbook/runtime_contract.json
@@ -152,7 +152,8 @@
       "laguna",
       "qwen3",
       "qwen3_5",
-      "qwen3_5_dense"
+      "qwen3_5_dense",
+      "deepseek_v4"
     ],
     "top_level_loader_modules": [
       "vllm.model_executor.models.hy_v3",
@@ -160,7 +161,13 @@
       "vllm.model_executor.models.laguna",
       "vllm.model_executor.models.qwen3_5",
       "vllm.model_executor.models.qwen3_5_mtp",
-      "vllm.model_executor.models.lfm2_moe"
+      "vllm.model_executor.models.lfm2_moe",
+      "vllm.models.deepseek_v4.nvidia.model",
+      "vllm.models.deepseek_v4.nvidia.mtp",
+      "vllm.models.deepseek_v4.nvidia.dspark",
+      "vllm.models.deepseek_v4.amd.model",
+      "vllm.models.deepseek_v4.amd.mtp",
+      "vllm.models.deepseek_v4.amd.dspark"
     ]
   }
 }


### PR DESCRIPTION
DeepSeek-V4-Flash is a 43-layer, 256-expert top-6 MoE whose experts are mapped top-level via `get_expert_mapping` — exactly the shape this wrap exists for.

The tree already anticipated it: `plugin.py` carried a commented-out placeholder pointing at `vllm.model_executor.models.deepseek_v4`. That path is wrong for the shipped build, in two ways that both fail **silently**:

1. The DSv4 package lives at **`vllm.models.deepseek_v4`**, not under `model_executor.models` where every other arch sits.
2. Its `__init__` only **re-exports** from the hardware-specific submodule, so the classes carry `__module__ == "...nvidia.model"`. Registering the package path no-ops against the `__module__` guard in `_install_on_module_classes` — which deliberately installs only on classes a module *defines*. The leaf modules have to be named.

Also adds `"DSpark"` to `_TOPLEVEL_CLASS_SUFFIXES`: `DeepSeekV4DSpark` matches none of the four existing suffixes, so without it the spec-decode drafter loads unwrapped and its CB expert tensors go to the arch's own loader.

The `amd.*` paths are harmless no-ops on an NVIDIA build and vice versa — a missing module degrades to a no-op by construction, which is why naming both is safe.

## Validation

The equivalent change was verified **end-to-end against v0.4.0** by serving a real DeepSeek-V4-Flash-0731 CB artifact (C16, 91.93 GiB, 23 shards, 6355 tensors) on a single GB10:

- `Application startup complete`, GPU KV cache 649,590 tokens
- `17*23 = 391`, and coherent prose
- dispatch log showing CB-GEMV-v2 selected on **both** expert stacks:
  `cb_gemv_kernel model.layers.N.ffn.experts.w13 k=16 n_sub=2 type_size=73 K=4096 -> v2 (mode=auto)` and `...w2 ... K=2048 -> v2`, plus `decode=grouped-cuda`

**Caveat, stated plainly:** this commit expresses that change through v0.4.1's new runtime-contract mechanism (`supported_ids` + `top_level_loader_modules` moved out of the Python tuple into `runtime_contract.json`). The re-serve on the contract form has **not** been repeated, and the unit suite was not run locally — that box is a source checkout with no CUDA venv.

## Related

DSv4 also needs #(the block-FP8 delegation PR) to load its attention weights; the two are complementary and independent (different files).