### PR TITLE
Add canonical kernel work TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ arch-specific — this table separates what was **measured** from what is
 | **GB10 / DGX Spark, `sm_121`** | CUDA GEMV | expand → stock W8A8 GEMM | CUTLASS `sm120` | **MEASURED.** Every published number comes from this box. |
 | **RTX 5090, `sm_120`** | same | same | same | **USER-REPORTED** working (vLLM 0.25.1, 27B artifact, [issue #1](https://github.com/RobTand/gridbook/issues/1)) after that issue's memory patches. No speed numbers published; the exact `nvcc` arch flag (`sm_120` vs the measured `sm_121`) is untested here. |
 | **H100 `sm_90`, RTX 4090 / L40S `sm_89`** | expected to work — the decode kernel contains no arch guards, no inline PTX and no `-arch` flag | expected to work (needs `sm_89+` fp8 support) | **fails, fail-softs** to the expand path with a warning (the fused kernel is `sm_120`-family only) | **INFERRED, UNTESTED.** Also gated by whatever the artifact's non-CB groups need (e.g. the 27B vision tower's NVFP4). |
-| **A100 `sm_80`** | expected to work | **expected to fail**: the dense FP8-CB prefill calls `cutlass_scaled_mm` on fp8 with no capability guard and no fallback | n/a | **NOT RECOMMENDED.** The declared capability floor is 8.0, but a prompt longer than 16 tokens is expected to error. INFERRED from code; no A100 was tested. |
+| **A100 `sm_80`** | expected to work for FP4-CB | **rejected at load**: FP8-CB requires `sm_89+` for its shipping prefill path | n/a | **UNTESTED.** Gridbook fails early with the hardware requirement instead of loading a serve that will fail above 16 tokens; FP4-CB retains its BF16 fallback. |
 | **Supported NVIDIA GPU, no `nvcc`** | Triton fallback | Triton/stock fallback | n/a | **Correct, slow.** Use for numerics verification and CI, not for serving. |
 | **Non-NVIDIA** | unsupported | unsupported | unsupported | **UNSUPPORTED / UNQUALIFIED.** The canceled ROCm prototype is not shipped or dispatched. |
 
@@ -246,12 +246,13 @@ arithmetic band and the single-seed noise band.
   shipped artifact scored 88/100 (130/148) on the ship config, against 87 for the
   GGUF IQ build and 86 for GGUF k-quant, with a measured single-seed churn band of
   ±2–3 points across serving configs.
-- **MoE prefill is solved and on by default.** Measured on Laguna-S-2.1 (117B
-  MoE): 293 → **1,821 tok/s** at 8k and 207 → **1,822 tok/s** at 63k after the
-  CUDA chunk-expander landed (commit `8829c16`); the current default is a
-  measured per-layer path selection. Docs that still describe MoE prefill as a
-  per-expert loop are stale — see [`ROADMAP.md`](ROADMAP.md) for what is actually
-  open.
+- **FP8-CB MoE prefill auto-selection is shipped.** Its transient CUDA
+  candidate measured 293 → **1,821 tok/s** at 8k and 207 → **1,822 tok/s** at
+  63k on Laguna-S-2.1 (117B MoE) after the chunk-expander landed (commit
+  `8829c16`); the default measures candidates per layer rather than always
+  choosing that one. FP4-CB still defaults to its conservative loop, and
+  activation-preserving fused large-M MoE remains open — see the canonical
+  [`kernel TODO`](ROADMAP.md#kernel-todo-canonical).
 - **Large-M dense prefill is the honest remaining gap**: ~1.44× the native GEMM's
   TTFT on the 27B.
 
@@ -269,7 +270,7 @@ arithmetic band and the single-seed noise band.
 | [`docs/PLUGIN.md`](docs/PLUGIN.md) | Operator reference for the plugin itself: dispatch, kernel set, environment switches. |
 | [`docs/DELEGATED-NVFP4-MOE.md`](docs/DELEGATED-NVFP4-MOE.md) | Version-scoped backend selection for a **non-CB** NVFP4 MoE group on GB10 (`sm_121`), including Marlin's generic weight-only warning and a fail/unknown preflight policy. |
 | [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) | The measured results with full hardware/protocol context and caveats. |
-| [`ROADMAP.md`](ROADMAP.md) | What is done, what is open, and what was measured and rejected. |
+| [`ROADMAP.md`](ROADMAP.md) | Canonical kernel TODO, completed work, and measured-negative experiments. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to run the tests, what a good bug report contains, and what is in scope. |
 
 ---
@@ -304,10 +305,10 @@ separate research pipeline that *produces* gridbook artifacts —
   MTP drafters) whose loaders map MoE experts at the top level and would
   otherwise not recognise stacked codebook expert tensors. That wrap is inert for
   non-CB checkpoints. Nothing in `vllm/` is modified.
-- This repository **serves** the format; it does not yet **produce** artifacts.
-  A reference encoder is a roadmap item — until then, artifacts come from the
-  authors' pipeline, and the [spec](docs/SPEC.md) is published so an encoder can
-  be written independently.
+- This repository **serves** the format; it does not produce artifacts.
+  [PrismaQuant](https://github.com/RobTand/prismaquant) is the one canonical
+  producer, while the [spec](docs/SPEC.md) and conformance fixtures keep the
+  format independently implementable without maintaining a second encoder here.
 - Every number in this repo comes from a measurement on the hardware named beside
   it. Where something is inferred rather than measured, it says so.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,14 @@
 # Roadmap
 
 What is done, what is open, and what was tried and rejected. Nothing here is a
-commitment to a date. Kernel statuses below track the internal kernel/format
-standard; a path is **DEFAULT** (on, no flag), **OPT-IN** (behind an environment
-switch), or **MEASURED NEGATIVE** (built, measured, and kept off).
+commitment to a date. This is the **canonical queue for kernel work and its
+enablement dependencies**;
+[`docs/KERNELS.md`](docs/KERNELS.md) explains the design,
+[`docs/PLUGIN.md`](docs/PLUGIN.md) documents the shipped controls, and dated
+audits preserve evidence rather than maintaining parallel TODO lists. Kernel
+statuses below track the internal kernel/format standard; a path is **DEFAULT**
+(on, no flag), **OPT-IN** (behind an environment switch), or **MEASURED
+NEGATIVE** (built, measured, and kept off).
 
 ---
 
@@ -35,22 +40,142 @@ still describe some of them as future work.
 - **Packaging.** The CUDA sources ship inside the Python package, so a
   non-editable `pip install` produces a working CUDA path. Previously any
   non-editable install silently degraded to the Triton fallback.
+- **FP8-CB hardware floor.** An FP8-CB artifact now fails early with a clear
+  `sm_89+` requirement rather than loading on `sm_80` and failing at its first
+  large-M prefill.
 
 ---
 
 ## Open
 
-### Reference encoder
+### Kernel TODO (canonical)
 
-This repository defines and **serves** the format; it does not yet **produce**
-artifacts. They come from the authors' offline research pipeline
-([PrismaQuant](https://github.com/RobTand/prismaquant)), which is not part of
-this repo. A standalone, documented reference encoder is planned — codebook
-construction, the weighted product-VQ search, the two-tier scale encoder and the
-safetensors exporter — so that anyone can turn a BF16 model into a gridbook
-artifact using only this repository and [`docs/SPEC.md`](docs/SPEC.md). Until it
-lands, the spec is deliberately complete enough to implement an encoder
-independently.
+Priority means dependency order: **P0** blocks a fused-NVFP4 promotion decision,
+**P1** is the next native-parity work, and **P2** is useful but not on the
+critical path. A checked item requires merged code, regression tests, and the
+applicable evidence gate; a fast standalone kernel is not sufficient served
+evidence.
+
+The implementation rule is one payload, one activation quantizer, one weight
+decoder, and one GEMM/grouped-GEMM per execution contract. New policies and
+backends must compose those pieces; they must not introduce a second packer,
+resident weight copy, decoder, or matmul merely to create another route.
+
+#### P0 — decide fused NVFP4 safely
+
+- [ ] **K0.1 — Align the producer and consumer releases.** In PrismaQuant, bump
+  the immutable Gridbook runtime pin from 0.4.1 (`59cebf9`) to 0.4.2
+  (`1634210`), rerun cross-repository contract/provenance CI, and publish the
+  resulting patch release. Do not copy the Gridbook runtime back into the
+  producer.
+- [ ] **K0.2 — Produce a valid routed-MoE validation artifact.** Re-export a
+  manageable representative model with producer-attested, stage-specific
+  `input_global_scale` values for both `w13` and `w2`. The existing partial LFM
+  artifact has no such payload, so all fused attempts correctly fail closed;
+  inventing a runtime scale is not an acceptable workaround.
+- [ ] **K0.3 — Finish shared fused-JIT attestation and fail-fast loading.** The
+  fused-FP4 source/header/ABI identity and strict two-module preload validation
+  shipped in 0.4.2. Extract that facility and apply it to every header-bearing
+  fused extension, including FP8, so packaged sources/headers, target
+  architecture, Python/Torch/CUDA/compiler ABI, and external CUTLASS sentinels
+  key every affected module and cache. Reject non-`sm_120`/`sm_121` targets
+  before either fused build starts, and make required validation fail when the
+  requested call route—not merely its module—does not execute.
+- [ ] **K0.4 — Finish grouped-MoE routing and telemetry.** Replace the manual
+  TileM128/256 choice with a CUDA-graph-safe selector that accounts for routed
+  token counts, padding, both stages' shapes, and occupancy. Emit the requested
+  activation policy, actual kernel symbol, TileM, shape, activation contract,
+  fallback state, and exact fallback reason for dense and MoE calls.
+- [ ] **K0.5 — Profile and close the fused-NVFP4 raw operator gap.** Split
+  activation quantization, packed-B decode, synchronization, MMA, epilogue,
+  and launch costs and compare against the matching stock
+  `sm120_nvf4_mm_scaled` execution contract. Optimize from that profile while
+  retaining the shared quantizer, packed payload, decoder collective, and
+  concrete GEMM runners.
+- [ ] **K0.6 — Run the promotion gate and make an explicit decision.** In one
+  pinned serving session, compare fused and current paths on a dense model of
+  at least 4B plus a representative routed MoE. Cover full-vocabulary teacher
+  KL/PPL/tasks, prompt-length distribution, concurrency, chunked prefill,
+  plain and shipped batched/speculative decode, and routed-token histograms.
+  Keep the flags default-off unless every
+  [fused-NVFP4 reconsideration gate](docs/audits/fused_nvfp4_enablement_2026-07-31.md#reconsideration-gates)
+  passes, including the p95 TTFT win, per-cell regression limit, zero
+  unexplained fallback, and supported-runtime revalidation.
+
+#### P1 — close the remaining native-parity gaps
+
+- [ ] **K1.1 — Build large-M grouped MoE decode-in-mainloop.** Decode an expert
+  weight tile once, stream its routed/padded M rows through it, and time the
+  whole routed operator. It must preserve the selected activation payload,
+  avoid an expanded `[E,N,K]` HBM tile, handle empty/uneven routing, and remain
+  stream- and graph-safe. This is a new MoE schedule, not a revival of the
+  measured-negative dense persistent-N kernel.
+- [ ] **K1.2 — Cover the complete FP8-CB mid-M production rung surface.** The
+  fused kernel currently instantiates only K28/32/36/40/44/48 while production
+  permits every K28 through K48. Either instantiate and test every product rung
+  or encode the concrete route/fallback in the candidate identity and timing
+  surface so the allocator cannot price an unbacked fast path.
+- [ ] **K1.3 — Reassess large-M dense FP8-CB from a fresh roofline.** The
+  transient path remains about 1.44x native, but the existing persistent-N
+  implementation was 2–5.7x slower. Profile current traffic and synchronization
+  first; only build a replacement schedule if the model shows a realizable win.
+  Do not continue or enable the quarantined implementation as unfinished work.
+- [ ] **K1.4 — Complete graph and alternate-schedule qualification.** Run the
+  exact-byte 27B streaming gate for `FULL_DECODE_ONLY` CUDA graphs, and qualify
+  `cb_gemv_v2` on `sm_120` with same-session quality, telemetry, long prefill,
+  concurrency, and soak coverage before considering a default change.
+
+#### P2 — completeness and wider qualification
+
+- [ ] **K2.1 — Resolve FP4-v1 MoE explicitly.** Either implement its transient
+  and grouped path with the existing v1 decoder, or reject v1 expert artifacts
+  at load with a precise support error. Production FP4-CB v2 remains the
+  priority.
+- [ ] **K2.2 — Revisit k24 long-K `cb_gemv_v2` staging only with evidence.** A
+  double-buffered row stage is optional; implement it only if profiling predicts
+  and an interleaved benchmark confirms a win over the safe compiled fallback.
+- [ ] **K2.3 — Automate hardware qualification.** Add self-hosted CUDA compile,
+  SASS, wheel-install, custom-op, non-default-stream, graph, and fail-if-skipped
+  tests. Qualify both `sm_120` and `sm_121`, then extend only the paths that are
+  legal on Ada/Hopper.
+
+#### Blocked or deferred
+
+- [ ] **KB.1 — Add approved W4A16 support when AMD validation hardware is
+  available.** Gridbook should own one exact pack/schema/metadata/profile/loader
+  and delegation path, initially reusing vLLM's upstream
+  `RDNAHybridW4A16` execution backend. Do not author a duplicate W4A16 kernel
+  or packer. The prior Strix Halo results are arithmetic bring-up evidence, not
+  served validation, and no gfx1151/HIP kernel work is active while hardware
+  access is unavailable.
+
+#### Before DSV4 Flash (integration, not new kernels)
+
+- [ ] **D0.1 — Establish the exact serving contract.** Verify the released
+  model's vLLM architecture, tensor-parallel requirement, expert layout, and
+  backend legality before promising support. Gridbook does not currently
+  register `deepseek_v4` and rejects TP greater than one; add only the runtime,
+  sharding, and export support the inspected model actually requires.
+- [ ] **D0.2 — Complete packed-expert native delegation if the assignment needs
+  it.** Reuse Gridbook's existing top-level expert-loader path, canonical
+  producer packers/metadata, and a version-attested upstream vLLM backend for
+  rank-3 stock NVFP4/FP8 experts. Do not create another packer, loader, or
+  native kernel. Fail closed if a selected backend drops activation scales and
+  changes a declared W4A4 unit into W4A16.
+- [ ] **D0.3 — Close the exact-rate evidence gap.** Rerun exact-byte
+  0.6B/4B/27B endpoints and optimized menus over the representative workload
+  matrix. At 4.5 bpp compare native NVFP4 with FP8-CB K36 using exact
+  whole-artifact bytes; below 4.5 bpp evaluate byte-neutral assignments whose
+  NVFP4 promotions are funded by lower CB rungs elsewhere. Record format/rung,
+  layout, activation quantization, concrete backend, GPU/runtime identity, TP,
+  and fallback state. This is an empirical release gate, not a reason to build
+  another byte accountant or unconstrained allocator; follow
+  [`docs/NATIVE-PARITY.md`](docs/NATIVE-PARITY.md).
+
+Do not reopen a measured-negative schedule without new profiling evidence. In
+particular, the dense persistent-N implementation, blanket `grouped_fused` MoE
+default, w2 rowpack, decode-contract-v2 hoist, L2-pinned pipeline, and naive
+inline CUDA-graph capture remain in [Measured and rejected](#measured-and-rejected).
 
 ### Conformance fixtures for independent implementers
 
@@ -83,23 +208,6 @@ practice rather than in principle.
   [`docs/CONTAINER.md`](docs/CONTAINER.md); no image is published to a registry
   yet.
 
-### Widening measured hardware coverage
-
-Every published number is from one GB10 / DGX Spark (`sm_121`, arm64). The
-decode kernel is architecture-generic by construction and *should* run from
-`sm_80` up, but that is inferred, not measured — see the
-[hardware matrix](docs/INSTALL.md#hardware-matrix). Two concrete code items would
-make the wider claim safe:
-
-- **A capability guard on the dense FP8-CB prefill.** It calls a CUTLASS fp8 GEMM
-  that needs `sm_89+` with no guard and no fallback, while the declared
-  capability floor is 8.0 — so an A100 is told it is supported and then expected
-  to fail on the first real prompt. The Triton path is already a correct
-  fallback; it just is not selected.
-- **An architecture precheck before the fused CUTLASS build**, so a non-Blackwell
-  GPU skips a doomed multi-minute compile inside the user's first request instead
-  of failing soft after it.
-
 ### vLLM compatibility preflight
 
 The plugin imports vLLM internals (fused-MoE classes, `_custom_ops`, the
@@ -108,14 +216,6 @@ logs-and-continues when a plugin fails to load — so drift surfaces as an
 unrelated "invalid quantization method" at model load. A symbol canary that fails
 with one actionable sentence naming the missing symbol and the tested vLLM
 version is the intended fix.
-
-### Large-M fused MoE prefill
-
-The remaining kernel target. On a Laguna-class MoE the transient expand is ~35%
-of MoE layer time, so a persistent/grouped decode-in-mainloop schedule — decode
-each expert weight tile once and stream M through it — is where the next real
-prefill win is. This is the MoE analog of the dense experiment below, which
-failed for a reason that does not apply here.
 
 ### Speculative decode throughput
 
@@ -137,8 +237,13 @@ published artifact.
 
 ### Not planned
 
-- **Tensor parallel.** No `tp > 1` support exists and none is planned. Open an
-  issue if you need it.
+- **A second artifact encoder.** PrismaQuant is the canonical producer;
+  Gridbook owns the serving contract, decoder, and conformance fixtures. Copying
+  the producer's search, packer, or exporter here would create two sources of
+  truth.
+- **General tensor parallel.** No `tp > 1` support exists today and broad TP
+  support is not committed. D0.1 must establish whether DSV4 needs a narrowly
+  scoped implementation before that work is accepted.
 - **A vLLM fork or core patches.** Running on stock vLLM is the point.
 
 ---

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -333,8 +333,8 @@ discrete GPU with its own VRAM, ordinary vLLM utilization guidance applies.
   it improved a close-rate 0.6B canary by 20.1%. Keep eager for published
   recipes until that graph setup clears their own streaming gate; see
   [`KERNELS.md`](KERNELS.md#cuda-graph-safety-rules).
-- **This repo serves the format; it does not produce artifacts.** A reference
-  encoder is a [roadmap](../ROADMAP.md) item.
+- **This repo serves the format; it does not produce artifacts.** PrismaQuant is
+  the canonical producer; Gridbook does not maintain a duplicate encoder.
 - **vLLM internals coupling.** gridbook imports fused-MoE and quantization
   internals that are not part of any stability contract. Pin a vLLM version you
   have tested.

--- a/docs/KERNELS.md
+++ b/docs/KERNELS.md
@@ -2,7 +2,9 @@
 
 This document describes how a `gridbook` artifact is served fast. It is a design and
 status document, not an API reference; the normative decode semantics are in
-[`SPEC.md`](SPEC.md).
+[`SPEC.md`](SPEC.md). The single live implementation checklist is the
+[`ROADMAP.md` kernel TODO](../ROADMAP.md#kernel-todo-canonical); status prose
+here is evidence and design context, not a second backlog.
 
 Terminology used below: **GEMM** = matrix-matrix multiply (prefill / large batch);
 **GEMV** = matrix-vector multiply (decode / batch-1 or small batch); **M** = the
@@ -144,10 +146,12 @@ collective, packed-B TMA load + consumer-side smem decode). Its honest status:
 - It **loses at large M** (≈0.22× at M≈1400). This is *structural, not a bug*:
   every M-tile CTA re-decodes the same weight (B) tiles, so decode work scales with
   `ceil(M / tile)` while the transient path expands each tile exactly once.
-- Large-M parity therefore requires a **weight-stationary / persistent-N schedule**
-  (decode each weight tile once, loop M inside the CTA) — a kernel-layer
-  restructure beyond the collective fork. Until that lands, the serial transient
-  path is the default for large-M prefill.
+- Large-M parity therefore requires some **weight-stationary/no-HBM-
+  materialization design** that amortizes weight decode across M. The first
+  persistent-N implementation landed, passed parity, and measured 2–5.7×
+  slower than transient expand at 27B shapes; it is rejected. Any replacement
+  starts from the fresh roofline in the canonical TODO, while the serial
+  transient path remains the large-M default.
 
 A **baseline-parity gate** precedes all fork work: a plain `sm_120` block-scaled
 GEMM built from vendored CUTLASS headers matches the runtime's native
@@ -228,7 +232,8 @@ bytes were never read (bit-identical output, verified with
 
 The remaining MoE prefill target is an activation-contract-preserving
 persistent/grouped decode-in-mainloop schedule (the expand is ~35% of MoE
-layer time at Laguna scale) — see [`ROADMAP.md`](../ROADMAP.md).
+layer time at Laguna scale) — see
+[`K1.1` in the kernel TODO](../ROADMAP.md#kernel-todo-canonical).
 
 ---
 
@@ -302,7 +307,7 @@ too.
 | MoE grouped decode GEMV | **Shipped**: fp8 66–95% of peak; fp4-v2 w2 schedule redesigned (+50%, 37–47% of peak; reassociation served-gated with an env-switched legacy path). A rowpack variant measured NEGATIVE and stays opt-in-off as a documented result |
 | MoE grouped decode GEMV, smem-resident dictionary | **Opt-in** (`PRISMAQUANT_CB_GEMV=v2`), never a default. Wins 1.13–1.58× on k13/k16/k20 in a 16-cell GB10 sweep; loses on k24 at K≥2048 (occupancy wall), where a compiled predicate routes the cell back to the shipped kernel. Reassociation-class output difference vs the default schedule (9/204 synthetic cells, worst `max_rel` 5.88e-03) — **not** bit-exact. Live GB10 validation on Jason Wong's 117B Laguna release dispatched all 94 expert stacks to v2 with no fallback and measured 24.993 vs 23.585 tok/s (+5.97%); long-prefill, concurrency, and soak requests completed without Gridbook errors |
 | Transient-expand prefill (dense) | **Shipped**; ~1.44× native at large M (traffic-bound) |
-| FP8-CB fused decode-in-prologue prefill | **Bit-exact, wins M∈(16,128], loses large M** — persistent-N is the answer |
+| FP8-CB fused decode-in-prologue prefill | **Bit-exact, wins M∈(16,128], loses large M** — the first dense persistent-N replacement was measured negative; a fresh design study remains open |
 | NVFP4-CB fused native-FP4 prefill (dense) | **Explicit opt-in**: shared `static_lsq` activation policy, optimized v2 scale decode, and occupancy-aware TileM routing. Short exact K24 quality/performance passed; long-context evidence is mixed; raw native parity, >=4B, task, and p95 served gates remain open |
 | Persistent-N large-M dense prefill | **Built and MEASURED NEGATIVE**: parity-green, but 2–5.7× *slower* than expand-then-GEMM at 27B shapes — the CUDA expander had already cut the dense expand tax to ~10%, removing the opportunity. Quarantined behind `PRISMAQUANT_ENABLE_PTC=1` as a schedule reference; do not enable it. The equivalent idea for **MoE** is still open and is the roadmap's next kernel |
 | MoE prefill | **Shipped**: CUDA chunk-expander into vLLM's fused-MoE grouped kernel; fp8-CB default is `auto` (measured per-layer path selection). Laguna-S-2.1 117B: 293 → 1,821 tok/s @8k, 207 → 1,822 @63k. fp4-CB defaults to conservative `loop`; native fused-FP4 and its shared `static_lsq` policy remain explicit A/B opt-ins without MoE quality qualification. Explicit `stock` uses a byte-budgeted expert chunk (1,184 MiB vs 4,736 MiB measured transient on a 192-expert band) and no pad copy |

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -129,8 +129,8 @@ prefill expander:
   - **`rowpack`** — round-3 experiment: one block owns `RPB` rows of one pair,
     staging the pair's activation in smem once and running `RPB` independent
     decode streams (targets the low K14/K16 rungs). Further-reassociated (same
-    tolerance contract), pending its own served check. `PRISMAQUANT_CB_W2_ROWS`
-    tunes `RPB ∈ {4,8,16}`.
+    tolerance contract), but measured negative and retained only for
+    reproducibility. `PRISMAQUANT_CB_W2_ROWS` tunes `RPB ∈ {4,8,16}`.
   All schedule/double-buffer switches are read host-side in the launcher
   (CUDA-graph-capture-safe; no device reads, no new syncs).
 - **`cb_expand_fp8`** — transient prefill expander: decodes the packed stream to
@@ -175,7 +175,8 @@ build. **Verdict: measured negative for dense prefill** — parity-green but 2�
 slower than expand-then-GEMM at 27B shapes, because the CUDA expander had already
 cut the dense expand tax to ~10%. Retained as a schedule reference and quarantined
 behind `PRISMAQUANT_ENABLE_PTC=1`; **do not enable it**. The MoE analog of the
-idea is still open — see [`ROADMAP.md`](../ROADMAP.md).
+idea is tracked only in the canonical
+[`kernel TODO`](../ROADMAP.md#kernel-todo-canonical).
 
 ## Environment switches
 

--- a/gridbook/csrc/cb_fused_gemm.cu
+++ b/gridbook/csrc/cb_fused_gemm.cu
@@ -15,11 +15,12 @@
 //   * fused at M<=128 (ONE M-tile -> no redundancy): WINS — 1.04x / 1.26x /
 //     1.45x vs serial at M=32/64/128. This is the fused kernel's honest
 //     serving niche today: the mid-M band (17..128) between the decode GEMV
-//     and the transient path. Serving dispatch not yet wired (default path
-//     unchanged); see tests/test_fused_prefill.py for the bit-exact gates.
-//   * The large-M endgame requires a weight-stationary/persistent-N
-//     schedule (decode each B tile ONCE, loop M inside the CTA) — a
-//     kernel-layer restructure, not a collective fork.
+//     and the transient path. Serving dispatch is on by default with an
+//     explicit opt-out; see tests/test_fused_prefill.py for the bit-exact gates.
+//   * Large-M needs a weight-stationary/no-HBM-materialization design that
+//     amortizes each B decode across M. The first dense persistent-N build
+//     measured negative (2-5.7x slower than transient at 27B shapes), so any
+//     replacement starts from a fresh roofline rather than this collective.
 //
 // Entry points:
 //  - sm120_fp8_mm_fork:  128x128x128 passthrough through the UNCHANGED forked

--- a/gridbook/csrc/cutlass_fork/sm120_cb_persistent_mma.hpp
+++ b/gridbook/csrc/cutlass_fork/sm120_cb_persistent_mma.hpp
@@ -1,9 +1,12 @@
 /***************************************************************************************************
  * PrismaQuant FP8_CB PERSISTENT-N fused mainloop for sm120 (GB10) — §4b DRAFT.
  *
- * STATUS: design-complete draft, NOT yet compiled (authored 2026-07-23 during
- * the driver-mismatch GPU outage; iterate in the next GPU window). Derived
- * from sm120_cb_fused_mma.hpp (the mid-M decode-in-prologue collective).
+ * STATUS: ARCHIVED SCHEDULE REFERENCE. The later dense persistent-N build was
+ * parity-green but measured 2--5.7x slower than transient expand + GEMM at 27B
+ * shapes and is quarantined behind PRISMAQUANT_ENABLE_PTC=1. This header is not
+ * an active implementation plan; the distinct grouped-MoE schedule is tracked
+ * in ROADMAP.md. Derived from sm120_cb_fused_mma.hpp (the mid-M
+ * decode-in-prologue collective).
  *
  * The schedule (docs/lanes/nvfp4-cb/persistent-n-prefill.md §4/§7):
  *   - Grid = one CTA per (N-tile stream); CTA c owns N-tiles {c, c+G, ...}

--- a/gridbook/linear.py
+++ b/gridbook/linear.py
@@ -867,7 +867,8 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
         # Mid-M fused decode-in-prologue (task 7's measured WIN niche): at
         # M in (16, 128] ONE M-tile covers the batch, so decoding B inside
         # the CUTLASS prologue has no redundancy and beats expand+GEMM by
-        # 1.04-1.45x (M=32/64/128, GB10). OPT-IN (PRISMAQUANT_CB_FUSED_MIDM=1).
+        # 1.04-1.45x (M=32/64/128, GB10). DEFAULT; set
+        # PRISMAQUANT_CB_FUSED_MIDM=0 to opt out.
         # Numerics: the _scaled entry applies BOTH the per-token activation
         # scale and the per-channel weight scale inside its fp32 EVT epilogue
         # and rounds once to bf16 — the same rounding ORDER as


### PR DESCRIPTION
## Summary

- make `ROADMAP.md` the single canonical queue for kernel work and enablement dependencies
- order fused-NVFP4 work from producer/runtime alignment through raw profiling and served promotion gates
- track remaining FP8-CB/native-parity, grouped-MoE, CUDA graph, hardware CI, and deferred W4A16 work
- separate DSV4 Flash runtime/export prerequisites from kernel implementation
- codify the no-duplication rule and move a second Gridbook encoder to not-planned
- retire stale claims about the FP8 hardware guard, dense persistent-N, mid-M dispatch, rowpack, and MoE auto-selection

## Validation

- `git diff --check`
- new local documentation links/anchors verified
- `python3 -m pytest tests -q` — 722 passed, 174 skipped

No runtime behavior changes; Python/CUDA edits are comment-only.
