### PR TITLE
Make the no-Triton ratchet staging-layout agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- Make the no-Triton ratchet independent of the directory the suite is staged
+  in. `release.yml`'s `verify installed wheel` job copies `tests` to
+  `$RUNNER_TEMP/gbtests` — so the checkout cannot shadow the installed wheel —
+  and failed there on the ratchet itself (`gbtests/test_no_triton_runtime.py:89
+  [mention] executable definition _is_triton_module`, and 23 more across it and
+  `test_delegated_preflight.py`) on a tree CI had just passed. The `mention`
+  exemptions were keyed on a literal `tests/` prefix, so under any other
+  staging name the two files that name Triton *because* they are the
+  anti-Triton machinery stopped being exempt. Those keys are now anchors —
+  resolved inside the scanned package and inside the ratchet's own directory,
+  matched by resolved path rather than by a rendered string. The same three
+  files are exempt, from the `mention` rules only, and the meta-test that an
+  exemption can never hide a reaching import now runs on all three under
+  staging instead of silently skipping two. Scan-root discovery treats a staged
+  tree with no sibling `scripts/` as a smaller scan rather than a failed one,
+  and a new test reproduces the release job's layout exactly: copy the suite
+  into a `gbtests/`, load the copy, make it scan itself.
+
 ## 0.6.0 — 2026-08-02
 
 - **K1.2 — the FP8-CB fused mid-M rung surface, and why it is already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Stop the CPU suite needing NumPy. `test_validate_fused_nvfp4_ab.py`'s K0.2
+  fixture writer built its artifact with `safetensors.torch.save_file`, whose
+  **write** path imports NumPy — which Gridbook deliberately does not depend on
+  (`gridbook/cb_digest.py`), so it is absent from the one environment that
+  matters here: the wheel's own closure, which is what `cpu-tests` and
+  `release.yml`'s `verify` install the suite into from outside the checkout.
+  The fixture therefore passed on every developer host and failed all four CI
+  legs on master — `ModuleNotFoundError: No module named 'numpy'` from
+  `safetensors/torch.py`, 4 failed / 49 passed. It now serializes its two F32
+  scalars directly, exactly as `test_codebook_digest.py` has always done for
+  its F16 sidecar and for the same written reason, and a scan asserts no test
+  or script reaches for `save_file` again. Nothing in the wheel changes: the
+  read path, which is all Gridbook ever uses, was never NumPy-bound.
 - Make the no-Triton ratchet independent of the directory the suite is staged
   in. `release.yml`'s `verify installed wheel` job copies `tests` to
   `$RUNNER_TEMP/gbtests` — so the checkout cannot shadow the installed wheel —

--- a/tests/test_no_triton_runtime.py
+++ b/tests/test_no_triton_runtime.py
@@ -10,6 +10,10 @@ Three layers, in increasing strength:
    rules (external GEMM fallbacks) stay package-only on purpose: a test that
    compares a CUDA kernel against ``F.linear`` is using the reference oracle
    the kernel is supposed to match, which is the opposite of a fallback.
+   Both directories are found by *layout*, not by name — CI and the release
+   job stage the suite under ``gbtests/`` so the checkout cannot shadow the
+   installed wheel, and a scanner whose rules turn on the spelling of the
+   directory it was copied into is a scanner that reports on its own path.
 3. **The dynamic edge.** ``plugin.py`` calls ``importlib.import_module`` over
    the model-module list in ``runtime_contract.json``, which no AST scan can
    see. That list is pinned here against an explicit allow-list, so a new
@@ -29,6 +33,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 
@@ -61,6 +66,18 @@ _DISPATCH = "dispatch"
 # ``reach`` rules apply to every file with no exceptions: an entry here buys
 # the right to NAME the banned lane, never to import or call it — which is
 # asserted separately below, so an exemption cannot quietly widen.
+#
+# The keys are ANCHORS, not path prefixes: ``gridbook/`` resolves inside the
+# package actually under scan and ``tests/`` inside the directory *this file*
+# lives in. That distinction is the whole of the bug this table once had: CI
+# stages the suite outside the checkout under a directory named ``gbtests/``,
+# and matching a literal ``tests/`` prefix meant the exemptions silently
+# stopped applying there — the ratchet flagged itself and
+# ``test_delegated_preflight.py`` — the two files that name Triton *because*
+# they are the anti-Triton machinery — and the release job's
+# `verify installed wheel` failed on a tree CI had just passed. Anchoring makes
+# the table say what it always meant ("this scanner, and the test of the policy
+# it enforces") in any layout, without naming one more file than before.
 _MENTION_EXEMPT: dict[str, str] = {
     "gridbook/delegated_preflight.py":
         "Defines the fail-closed D0.2 policy that REFUSES a delegated backend "
@@ -75,6 +92,35 @@ _MENTION_EXEMPT: dict[str, str] = {
         "builds stub backend classes to be refused and asserts the refusal "
         "names them; a test that could not spell the name could not check it.",
 }
+
+
+def _exempt_path(key: str) -> Path:
+    """Resolve one ``_MENTION_EXEMPT`` key against the layout in front of us."""
+
+    anchor, _, rest = key.partition("/")
+    if anchor == "gridbook":
+        base = PACKAGE      # the package under scan, wherever it was found
+    elif anchor == "tests":
+        base = TESTS_DIR    # this ratchet's own directory, whatever its name
+    else:
+        raise AssertionError(
+            f"_MENTION_EXEMPT key {key!r} has no known anchor: keys are "
+            "'gridbook/<...>' (resolved inside the scanned package) or "
+            "'tests/<...>' (resolved inside this file's own directory)")
+    return base.joinpath(*rest.split("/")).resolve()
+
+
+#: Anchored keys, resolved once. Matching is by identity of the resolved path,
+#: never by a rendered string, so the name of the directory the suite happens to
+#: be staged in cannot decide whether a rule applies.
+_MENTION_EXEMPT_PATHS: dict[Path, str] = {
+    _exempt_path(key): key for key in _MENTION_EXEMPT
+}
+
+
+def _mention_exemption(path: Path) -> str | None:
+    key = _MENTION_EXEMPT_PATHS.get(path.resolve())
+    return None if key is None else _MENTION_EXEMPT[key]
 
 
 def _display(path: Path) -> str:
@@ -104,8 +150,7 @@ def _runtime_violations(path: Path, *,
                         kinds: frozenset[str]) -> list[str]:
     """Rule hits in *path* restricted to *kinds*, formatted for an assert."""
 
-    exemption = _MENTION_EXEMPT.get(_display(path).replace(os.sep, "/"))
-    if exemption is not None:
+    if _mention_exemption(path) is not None:
         kinds = kinds - {_MENTION}
     tree = ast.parse(path.read_text(), filename=str(path))
     violations: set[tuple[int, str, str]] = set()
@@ -191,6 +236,28 @@ _ALL_KINDS = frozenset({_REACH, _MENTION, _DISPATCH})
 _REACH_ONLY = frozenset({_REACH, _MENTION})
 
 
+def _scan_roots() -> list[Path]:
+    """Directories the reach rules cover, in whichever layout is present.
+
+    Three are real and all three must work:
+
+    * a full checkout — ``scripts/`` and this file's directory are siblings;
+    * ``ci.yml``'s ``cpu-tests`` and ``release.yml``'s ``verify`` — the suite is
+      copied to ``$RUNNER_TEMP/gbtests`` so the checkout cannot shadow the
+      installed wheel, and there is no ``scripts/`` beside it.
+
+    A staged copy with no ``scripts/`` is not a broken scan, it is a smaller
+    one: scanning what is there is the correct behavior, and the assert below is
+    for the one case that would pass vacuously — nothing scannable at all.
+    """
+
+    roots: list[Path] = []
+    for directory in (TEST_ROOT / "scripts", TESTS_DIR):
+        if directory.is_dir() and directory not in roots:
+            roots.append(directory)
+    return roots
+
+
 def test_packaged_runtime_contains_no_triton_code():
     retired = [
         PACKAGE / "kernels.py",
@@ -219,9 +286,10 @@ def test_repository_scripts_and_tests_reach_no_triton():
     ship in the source distribution and run in CI.
     """
 
-    roots = [directory for directory in (TEST_ROOT / "scripts", TESTS_DIR)
-             if directory.is_dir()]
-    assert roots, "neither scripts/ nor tests/ is present to scan"
+    roots = _scan_roots()
+    assert roots, (
+        "nothing to scan: no sibling scripts/ and not even this file's own "
+        f"directory ({TESTS_DIR}) is readable as one")
     violations = [
         violation
         for directory in roots
@@ -235,17 +303,77 @@ def test_repository_scripts_and_tests_reach_no_triton():
 def test_mention_exemptions_never_hide_a_reaching_import():
     """An exemption buys the right to name Triton, never to reach it."""
 
-    for relative, reason in _MENTION_EXEMPT.items():
-        assert reason.strip(), f"{relative} is exempt with no written reason"
-        path = ROOT / relative
-        if not path.is_file():
-            path = TEST_ROOT / relative
-        if not path.is_file():
-            continue          # staged-tests layout; the package scan covers it
+    for key, reason in _MENTION_EXEMPT.items():
+        assert reason.strip(), f"{key} is exempt with no written reason"
+        path = _exempt_path(key)
+        # Anchored resolution means every entry is checkable in every layout.
+        # It used to fall through to `continue` when a literal `tests/` prefix
+        # missed, which quietly dropped two of the three checks under staging.
+        assert path.is_file(), (
+            f"{key} is exempt but resolves to {path}, which is not a file: a "
+            "standing exemption for a file that is not there is a stale entry, "
+            "not a policy")
         reaching = _runtime_violations(path, kinds=frozenset({_REACH}))
         assert not reaching, (
-            f"{relative} is exempt from the name rules only, but it reaches "
+            f"{key} is exempt from the name rules only, but it reaches "
             "Triton:\n" + "\n".join(reaching))
+
+
+def test_mention_exemptions_are_anchored_not_matched_by_name():
+    """The exemptions name three files, and widen to no fourth.
+
+    Basename matching would have fixed the staging bug too, and would have
+    handed the exemption to any future ``scripts/test_no_triton_runtime.py`` or
+    ``tests/delegated_preflight.py`` for free. Anchoring does not.
+    """
+
+    assert len(_MENTION_EXEMPT_PATHS) == len(_MENTION_EXEMPT) == 3
+    assert _mention_exemption(TESTS_DIR / "test_no_triton_runtime.py")
+    assert _mention_exemption(TESTS_DIR / "test_delegated_preflight.py")
+    assert _mention_exemption(PACKAGE / "delegated_preflight.py")
+
+    for impostor in (TEST_ROOT / "scripts" / "test_no_triton_runtime.py",
+                     TESTS_DIR / "delegated_preflight.py",
+                     PACKAGE / "test_delegated_preflight.py",
+                     TESTS_DIR.parent / "test_no_triton_runtime.py"):
+        assert _mention_exemption(impostor) is None, (
+            f"{impostor} inherited an exemption by name alone")
+
+
+def test_scan_is_agnostic_to_the_staging_directorys_name(tmp_path):
+    """The release job's own layout, reproduced: staged under ``gbtests/``.
+
+    ``release.yml``'s `verify installed wheel` job copies ``tests`` to
+    ``$RUNNER_TEMP/gbtests`` and runs pytest from ``$RUNNER_TEMP``. With the
+    exemptions keyed on a literal ``tests/`` prefix that job failed on this very
+    file — ``gbtests/test_no_triton_runtime.py:89 [mention] executable
+    definition _is_triton_module`` and 23 more — while the identical tree passed
+    in CI. Copy the suite under that name, load the copy so its own
+    ``TESTS_DIR`` is the staged directory, and make it scan itself.
+    """
+
+    staged = tmp_path.resolve() / "gbtests"
+    shutil.copytree(TESTS_DIR, staged,
+                    ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+
+    spec = util.spec_from_file_location(
+        "_staged_no_triton_ratchet", staged / "test_no_triton_runtime.py")
+    ratchet = util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+
+    assert ratchet.TESTS_DIR == staged, "the copy did not adopt the staged dir"
+    assert ratchet._scan_roots() == [staged], (
+        "a staged layout has no sibling scripts/; scanning what is present is "
+        f"the whole job, and it found {ratchet._scan_roots()}")
+    assert set(ratchet._MENTION_EXEMPT_PATHS) == {
+        staged / "test_no_triton_runtime.py",
+        staged / "test_delegated_preflight.py",
+        ratchet.PACKAGE / "delegated_preflight.py",
+    }
+
+    # The assertion the release job makes, from where the release job makes it.
+    ratchet.test_repository_scripts_and_tests_reach_no_triton()
+    ratchet.test_mention_exemptions_never_hide_a_reaching_import()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -17,6 +17,7 @@ are published, while these tests run in both places the suite runs --
   serving sources arrived and the sdist-only ones did not.
 """
 
+import ast
 from pathlib import Path
 import re
 
@@ -143,3 +144,44 @@ def test_installed_wheel_carries_serving_sources_and_no_sdist_only_ones():
     assert not orig, (
         f"pristine CUTLASS diff baselines {orig} are sdist-only and must not "
         f"be installed")
+
+
+def test_suite_needs_nothing_the_wheel_does_not_declare():
+    """No test or script may write safetensors: that path imports NumPy.
+
+    ``cpu-tests`` and ``release.yml``'s ``verify`` run this suite against the
+    installed wheel, in the wheel's own dependency closure. NumPy is not in it
+    — deliberately (``gridbook/cb_digest.py``) — but it is on every developer
+    host, so a fixture built with ``safetensors.torch.save_file`` passes
+    locally and fails all four CI legs plus the release gate. That is what
+    happened, and a text-level ban is not enough: the F16 fixture writer in
+    ``test_codebook_digest.py`` documents the rule in prose and must stay
+    legal, so the ban is on the *call*, not the word.
+    """
+
+    roots = [directory
+             for directory in (Path(__file__).resolve().parent,
+                               ROOT / "scripts")
+             if directory.is_dir()]
+    assert roots, "no suite directory to scan"
+
+    banned: list[str] = []
+    for directory in roots:
+        for path in sorted(directory.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"),
+                             filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) \
+                        and (node.module or "").startswith("safetensors") \
+                        and any(a.name == "save_file" for a in node.names):
+                    banned.append(f"{path.name}:{node.lineno}: imports it")
+                elif isinstance(node, ast.Call):
+                    func = node.func
+                    name = func.attr if isinstance(func, ast.Attribute) else \
+                        getattr(func, "id", "")
+                    if name == "save_file":
+                        banned.append(f"{path.name}:{node.lineno}: calls it")
+    assert not banned, (
+        "safetensors' write path imports NumPy, which the wheel does not "
+        "depend on; serialize the fixture directly instead (see "
+        "test_codebook_digest.py::_write):\n  " + "\n  ".join(banned))

--- a/tests/test_validate_fused_nvfp4_ab.py
+++ b/tests/test_validate_fused_nvfp4_ab.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import math
 import os
+import struct
 import subprocess
 import sys
 from pathlib import Path
@@ -1829,11 +1830,40 @@ _K02_W2 = "model.layers.0.feed_forward.experts.down_proj"
 _K02_MODULE = "model.layers.0.feed_forward.experts"
 
 
-def _write_k02_artifact(root, *, scales, attest=None, contract=True):
-    """Write a synthetic artifact: quant_config plus serialized F32 scalars."""
+def _write_f32_scalars(path, values: dict) -> None:
+    """Serialize ``{name: float}`` as F32 scalars, without NumPy.
+
+    ``safetensors.torch.save_file`` imports NumPy on its **write** path, and
+    NumPy is deliberately not a Gridbook dependency (``gridbook/cb_digest.py``),
+    so it is absent from the environment CI runs the suite in: the wheel's own
+    closure, installed from outside the checkout. Writing a fixture through
+    ``save_file`` therefore makes the suite need a package the package does not
+    — passing on any developer host, failing every CI leg. Emit the container
+    directly instead, as ``tests/test_codebook_digest.py`` already does for its
+    F16 sidecar. Gridbook only ever *reads* these, and the read path is
+    NumPy-free.
+    """
 
     import torch
-    from safetensors.torch import save_file
+
+    header: dict[str, object] = {}
+    payload = bytearray()
+    for name in sorted(values):
+        tensor = torch.tensor([values[name]], dtype=torch.float32)
+        start = len(payload)
+        payload.extend(bytes(tensor.view(torch.uint8).reshape(-1).tolist()))
+        header[name] = {
+            "dtype": "F32",
+            "shape": list(tensor.shape),
+            "data_offsets": [start, len(payload)],
+        }
+    encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    encoded += b" " * (-len(encoded) % 8)
+    path.write_bytes(struct.pack("<Q", len(encoded)) + encoded + payload)
+
+
+def _write_k02_artifact(root, *, scales, attest=None, contract=True):
+    """Write a synthetic artifact: quant_config plus serialized F32 scalars."""
 
     from gridbook import nvfp4_activation_contract as gc
 
@@ -1891,14 +1921,10 @@ def _write_k02_artifact(root, *, scales, attest=None, contract=True):
     (root / "quant_config.json").write_text(
         json.dumps(quant_config, indent=2, sort_keys=True), encoding="utf-8"
     )
-    save_file(
-        {
-            f"{target}.{gc.TENSOR_SUFFIX}": torch.tensor(
-                [value], dtype=torch.float32
-            )
-            for target, value in scales.items()
-        },
-        str(root / "model.safetensors"),
+    _write_f32_scalars(
+        root / "model.safetensors",
+        {f"{target}.{gc.TENSOR_SUFFIX}": value
+         for target, value in scales.items()},
     )
     return root
 


### PR DESCRIPTION
## The failure

`release.yml`'s `verify installed wheel` job failed on `tests/test_no_triton_runtime.py` while `ci.yml`'s `cpu-tests` passed the identical tree:

```
gbtests/test_delegated_preflight.py:42: [mention] executable reference `TritonExperts`
gbtests/test_delegated_preflight.py:134: [mention] executable definition `test_triton_backed_moe_backend_is_rejected`
gbtests/test_delegated_preflight.py:144: [mention] executable literal 'Triton'
gbtests/test_no_triton_runtime.py:89: [mention] executable definition `_is_triton_module`
gbtests/test_no_triton_runtime.py:90: [mention] executable literal 'triton'
...
24 violations, all `mention`, all in the two files that name Triton BECAUSE
they are the anti-Triton machinery
```

Both jobs stage the suite outside the checkout so `./gridbook` cannot shadow the installed wheel, and both stage it as `$RUNNER_TEMP/gbtests`:

```yaml
- name: Stage tests outside the checkout
  run: cp -r tests "${RUNNER_TEMP}/gbtests"
```

The scan-root discovery follows the *file* — it scans the directory the ratchet module lives in, under whatever name — but the `mention` exemptions did not:

```python
exemption = _MENTION_EXEMPT.get(_display(path).replace(os.sep, "/"))
```

`_display()` renders a scanned file relative to the staging **parent**, so under that staging it produced `gbtests/test_no_triton_runtime.py` against a table keyed `tests/test_no_triton_runtime.py`. Every exemption missed and the ratchet reported on its own path. (The `"neither scripts/ nor tests/ is present to scan"` assert visible in the same log region is the failing test's source echoed by pytest, not a second fault — but its message named a literal `tests/` that the discovery had already stopped requiring.)

## The fix

The keys become **anchors**, not path prefixes: `gridbook/` resolves inside the package actually under scan, `tests/` inside this file's own directory, and matching is by resolved-path identity rather than a rendered string.

```python
def _exempt_path(key: str) -> Path:
    anchor, _, rest = key.partition("/")
    if anchor == "gridbook":
        base = PACKAGE      # the package under scan, wherever it was found
    elif anchor == "tests":
        base = TESTS_DIR    # this ratchet's own directory, whatever its name
    ...
    return base.joinpath(*rest.split("/")).resolve()
```

The semantics do not widen: the same three files, exempt from the `mention` rules only, `reach` untouched. Basename matching would also have fixed the symptom while handing the exemption to any future `scripts/test_no_triton_runtime.py` or `tests/delegated_preflight.py`, so `test_mention_exemptions_are_anchored_not_matched_by_name` pins that it does not.

Two things anchoring also fixes:

- `test_mention_exemptions_never_hide_a_reaching_import` — the meta-test that an exemption can never conceal a reaching import — used to `continue` when neither `ROOT/<key>` nor `TEST_ROOT/<key>` existed, which under staging is **two of its three entries**. It now resolves all three in every layout and asserts each is really present. It still holds and still passes.
- `_scan_roots()` states the three supported layouts and that a staged tree with no sibling `scripts/` is a smaller scan, not a failed one. The assert is left for the only vacuous case — nothing scannable at all.

## The regression test

`test_scan_is_agnostic_to_the_staging_directorys_name` is the release job's layout in-process: copy the suite into a directory named `gbtests/`, load the copy so its own `TESTS_DIR` *is* the staged directory, and make it run its own scan and its own meta-test. CPU-only, ~0.2 s. Against the pre-fix matching it fails with the 24 violations above — this is what would have caught it.

## Verification

**(a) in-repo**

```
$ python3 -m pytest tests/test_no_triton_runtime.py -q
7 passed, 1 skipped in 0.70s          # was 5 passed, 1 skipped
```

**(b) the release layout, exactly** — `dist/gridbook-0.6.0-py3-none-any.whl` installed `--no-deps` into a venv (`gridbook` resolves from that venv's site-packages), `tests/` copied to a temp dir named `gbtests/`, pytest run from its parent:

```
$ python -m pytest gbtests/test_no_triton_runtime.py gbtests/test_delegated_preflight.py -q
22 passed, 1 skipped in 0.64s         # before: 1 failed, 19 passed, 1 skipped
```

The whole release gate over that staging is green too — `run_cpu_tests.sh` against the same staged dir with `GITHUB_WORKSPACE` set as the job sets it: `ran 47 test file(s) / CPU test suite OK`.

**(c) full host suite**, run on the committed tree:

```
$ python3 -m pytest tests/ -q
861 passed, 118 skipped, 1 warning in 7.02s    # baseline 859/118, +2 new tests
```

No tag machinery, no workflow files, and no runtime code touched: the change is `tests/test_no_triton_runtime.py` plus one CHANGELOG bullet.

---

# Second commit: keep the CPU suite inside the wheel's dependency closure

`cpu-tests` was failing on all four legs with `ModuleNotFoundError: No module named 'numpy'` from `safetensors/torch.py`. **Not a dependency drift, and not from this branch** — master is red at `8c43ffe` with the same four failures (run `30740373262`), and the resolved sets are byte-identical between the last green master run and the red one:

| | green `30726921261` (`e1fee7f`, 01:22Z) | red `30740912411` (PR 33, 09:01Z) |
|---|---|---|
| runner python | 3.12.13 | 3.12.13 |
| torch | `2.13.0+cpu` | `2.13.0+cpu` |
| safetensors | `0.8.0` | `0.8.0` |
| huggingface-hub / pytest | `1.26.0` / `9.1.1` | `1.26.0` / `9.1.1` |
| numpy | **absent** | **absent** |
| gridbook | `0.5.1` | `0.6.0` |

numpy was already absent when master was green — that run logs torch's identical `Failed to initialize NumPy` warning on every file. The only difference is the gridbook version, which is the cause: 0.6.0 added `test_validate_fused_nvfp4_ab.py`'s K0.2 fixture writer, which builds its artifact with `safetensors.torch.save_file`. That **write** path imports numpy (0.7.0 does too, so it is not a safetensors regression), and numpy is deliberately not a Gridbook dependency. `tests/test_codebook_digest.py::_write` has said so in the tree the whole time:

> Gridbook only reads sidecars, and NumPy is deliberately absent from its runtime dependencies. Building fixtures through `save_file` would make this suite stricter than the installed package: safetensors currently imports NumPy only on its write path.

**So the fix is the fixture, not the workflows.** Declaring numpy in `ci.yml` and `release.yml` would turn both green while destroying what they prove: those jobs exist to run the suite in the closure a real `pip install gridbook` produces, and adding a package to that environment because a test wants it is how the gate stops being a gate. The K0.2 writer now emits its two F32 scalars directly, like its sibling. Nothing in the wheel changes — the read path Gridbook actually uses was never numpy-bound, and `gridbook/` contains no `save_file` call at all.

Because this is invisible on any host that has numpy (i.e. all of them), `test_release_metadata.py::test_suite_needs_nothing_the_wheel_does_not_declare` now bans the call across `tests/` and `scripts/`. AST, not text: the prose documenting the rule in `test_codebook_digest.py` has to stay legal.

**`install wheel` legs are not threatened** and passed throughout: they `pip install --no-deps`, so safetensors is not even installed, and `check_installed.py` only imports `gridbook` and resolves `csrc` paths from site-packages — no serialization on any path it touches.

### Verification (numpy made unimportable via a `PYTHONPATH` shim reproducing CI's warning)

- `test_validate_fused_nvfp4_ab.py`: **4 failed** before, **53 passed** after — the same four tests CI names.
- Guard reverted-check: flags both `test_validate_fused_nvfp4_ab.py:1836: imports it` and `:1894: calls it`.
- Full suite, numpy blocked: **862 passed, 118 skipped**. Same on a normal host.
- Release-verify simulation (0.6.0 wheel installed, suite staged as `gbtests/`, numpy blocked, `run_cpu_tests.sh`): `ran 47 test file(s) / CPU test suite OK`.
- CI: all 9 checks green, `mergeStateStatus: CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW
