### PR TITLE
Release gridbook 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.7.0 — 2026-08-02
+
+- Release status note: the `deepseek_v4` contract below is validated by
+  fixture and instantiated-class tests; no released DSV4 artifact had
+  loaded through it at tag time (the first CB artifact was still being
+  produced). If the first real load surfaces contract gaps, a follow-up
+  release will carry them.
 - **D0.1 — register `deepseek_v4` and pin the DeepSeek-V4 serving contract.**
   Established against vLLM **0.24.0** and the released
   `deepseek-ai/DeepSeek-V4-Flash-0731` config (43 layers, all MoE, 256 routed +

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
 repository-code: "https://github.com/RobTand/gridbook"
 url: "https://github.com/RobTand/gridbook"
 license: Apache-2.0
-version: "0.6.0"
+version: "0.7.0"
 date-released: 2026-08-02
 keywords:
   - quantization

--- a/gridbook/__init__.py
+++ b/gridbook/__init__.py
@@ -14,7 +14,7 @@ package without vLLM installed.
 # Single source of truth for package and release metadata. Gridbook is the sole
 # owner of its runtime; producer repositories consume a released version or an
 # immutable commit and never mirror this package tree.
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 def register() -> None:


### PR DESCRIPTION
Version bump + CHANGELOG roll for 0.7.0: the DeepSeek-V4 serving contract (D0.1) and the post-0.6.0 review remediation (29 findings + 7 surfaced during fixing), with an honest status note that no released DSV4 artifact had loaded through the contract at tag time — a follow-up release carries any gaps the first real load surfaces.

Local pre-tag gates (per RELEASING.md §2.2, on the GB10): build + check_dist PASS (0 warnings); Gate A — all seven native modules compiled cold from the installed wheel with load-time attestations; Gate B — staged fused-FP4 SASS suite with nvdisasm (result in the merge gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW