### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.8.1 — 2026-08-05
+
+- **Per-expert split-format MoE stacks (#40).** Gridbook now accepts the
+  producer-owned `per_expert_format_groups` v1 declaration and serves one MoE
+  layer whose `w13` and `w2` families are independently partitioned across CB
+  formats and native MXFP4 passthrough groups. The loader validates complete,
+  non-overlapping expert partitions and exact wire-id/scheme agreement, builds
+  family-specific expert index maps, and refuses unknown or inconsistent
+  declarations. Artifacts without the declaration retain the legacy uniform
+  path and identical bytes.
+
+- **Split-stack correctness follow-ups (#40, #41).** The primary mixed-vs-
+  uniform oracle is now exact by construction: both sides use the same
+  `dispatch_family_stages` and `torch.bmm` primitives in the same order, so its
+  bit-equality claim no longer depends on BLAS reduction differences across
+  torch versions; the byte-identity check also no longer needs undeclared
+  NumPy. PR #41 adds a genuinely independent, explicit expert-loop witness
+  which does not call the dispatcher, accepts at most 2 float64 ULP, and proves
+  that both the exact assertion and tolerance bound reject deliberate
+  perturbations.
+
 ## 0.8.0 — 2026-08-03
 
 - **Release status note — read this before enabling anything below.** The MXFP8

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
 repository-code: "https://github.com/RobTand/gridbook"
 url: "https://github.com/RobTand/gridbook"
 license: Apache-2.0
-version: "0.8.0"
-date-released: 2026-08-03
+version: "0.8.1"
+date-released: 2026-08-05
 keywords:
   - quantization
   - vector-quantization

--- a/docker/Dockerfile.gridbook-pinned
+++ b/docker/Dockerfile.gridbook-pinned
@@ -1,0 +1,17 @@
+# Build a serving image whose installed Gridbook tree is tied to an immutable
+# release ref. pip's direct-VCS install writes the resolved commit and requested
+# ref to gridbook's PEP 610 direct_url.json provenance record.
+ARG BASE_IMAGE=gridbook:local
+FROM ${BASE_IMAGE}
+
+ARG GRIDBOOK_REF=v0.8.1
+
+USER root
+RUN test -n "${GRIDBOOK_REF}" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && python3 -m pip install --no-cache-dir --no-deps --force-reinstall \
+       "gridbook @ git+https://github.com/RobTand/gridbook.git@${GRIDBOOK_REF}" \
+    && GRIDBOOK_REF="${GRIDBOOK_REF}" python3 -c \
+       'import json, os; from importlib.metadata import distribution; p = json.loads(distribution("gridbook").read_text("direct_url.json")); assert p["vcs_info"]["requested_revision"] == os.environ["GRIDBOOK_REF"]; assert len(p["vcs_info"]["commit_id"]) == 40; print("gridbook provenance:", p)' \
+    && rm -rf /var/lib/apt/lists/* /root/.cache/pip

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -90,6 +90,36 @@ curl http://localhost:8000/v1/completions \
 Everything after the image name is passed straight to `vllm serve`, so every
 upstream vLLM flag works unchanged.
 
+### Provision a release-pinned image before the first serve
+
+Do not make the first production `docker run` clone or install Gridbook on its
+startup path. Build a small derived image once, from the already-provisioned
+serving image, using [`docker/Dockerfile.gridbook-pinned`](../docker/Dockerfile.gridbook-pinned):
+
+```bash
+docker build \
+  -f docker/Dockerfile.gridbook-pinned \
+  --build-arg BASE_IMAGE=gridbook:local \
+  --build-arg GRIDBOOK_REF=v0.8.1 \
+  -t gridbook:v0.8.1-pinned .
+```
+
+`GRIDBOOK_REF` is parameterized so the same recipe works for a release tag or,
+during a pre-tag rehearsal, the exact release commit SHA. For a release image,
+use the immutable `v0.8.1` tag. The direct-VCS requirement causes pip to write
+the requested ref and resolved 40-character commit to the installed
+distribution's PEP 610 `direct_url.json`; the Docker build reads that record
+back and fails if the requested revision or resolved commit is absent. This is
+the attestation-clean path: provisioning happens in an auditable image layer,
+not as an unrecorded mutation when the server starts.
+
+Then serve from the derived image with the same arguments shown above. On the
+0.6B smoke, the one-time image build took **383 s**, while an actual serve start
+from that completed image took **18 s**. The distinction is operationally
+important: budget the 383-second provision once before traffic, so the first
+serve sees the 18-second startup rather than paying installation and build work
+on its critical path.
+
 ---
 
 ## What the image contains

--- a/gridbook/__init__.py
+++ b/gridbook/__init__.py
@@ -14,7 +14,7 @@ package without vLLM installed.
 # Single source of truth for package and release metadata. Gridbook is the sole
 # owner of its runtime; producer repositories consume a released version or an
 # immutable commit and never mirror this package tree.
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 
 def register() -> None:


### PR DESCRIPTION
Version bump + CHANGELOG for the post-0.8.0 oracle/witness hardening (split-stack oracle exact-by-construction, independent 2-ULP witness), plus the attestation-clean pinned-image Dockerfile and provisioning docs (kills the 383s first-serve image-build cost measured in the 0.6B smoke).

Release gate: TAG-READY on 9f8c8c1 — complete installed-wheel five-extension/native-attestation gate + staged 76-test FP4 operator/SASS gate, `OMMA.SF.16864` in both fused symbols, no `QMMA` (GATE_REPORT.md, appended section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW