### PR TITLE
release: serve source block-FP8 with W8A16

### DIFF
--- a/.github/scripts/check_dist.py
+++ b/.github/scripts/check_dist.py
@@ -103,6 +103,8 @@ PKG = "gridbook"
 REQUIRED = [
     f"{PKG}/csrc/cb_gemv.cu",
     f"{PKG}/csrc/cb_gemv_v2.cu",
+    f"{PKG}/csrc/fp8_source_w8a16.cu",
+    f"{PKG}/csrc/mxfp8_dense_gemm.cu",
     f"{PKG}/csrc/cb_bf16_grouped_gemm.cu",
     f"{PKG}/csrc/cb_fused_gemm.cu",
     f"{PKG}/csrc/cb_fused_fp4_gemm.cu",

--- a/.github/scripts/check_installed.py
+++ b/.github/scripts/check_installed.py
@@ -41,6 +41,8 @@ ENTRY_POINT_GROUP = "vllm.general_plugins"
 REQUIRED_SOURCES = [
     "csrc/cb_gemv.cu",
     "csrc/cb_gemv_v2.cu",
+    "csrc/fp8_source_w8a16.cu",
+    "csrc/mxfp8_dense_gemm.cu",
     "csrc/cb_bf16_grouped_gemm.cu",
     "csrc/cb_fused_gemm.cu",
     "csrc/cb_fused_fp4_gemm.cu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@
   installed-wheel, metadata, and GPU pre-tag compile gates therefore fail
   explicitly if either source or either strict native ABI is missing.
 
+- Load and dispatch now fail closed at the remaining raw-wire boundaries:
+  vLLM checkpoint loaders validate the E4M3 and UE8M0 source dtypes before a
+  destination `copy_` can cast them; grouped DSV4 `wo_a` admits only
+  `G=8,N=1024,K=4096,tp=1` (dense serving is separately TP=1); and the native
+  extension must carry the exact JIT digest, ABI schema, and live-device build
+  capability. Decode and prefill publish two-phase route telemetry identifying
+  `fp8_source_gemv` versus
+  `fp8_source_expand_bf16+cb_bf16_grouped_mm`, with the activation contract
+  recorded as preserved BF16 rather than dynamic FP8 QDQ.
+
 ## 0.8.4 — 2026-08-12
 
 - **Attest the routed per-role LUT ABI in the packaged runtime contract.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.8.5 — 2026-08-12
+
+- **Correct source block-FP8 serving to W8A16.** The
+  `fp8_e4m3_ue8m0_block128` source-passthrough wire keeps its E4M3 weight bytes
+  and UE8M0 128-by-128 scale blocks resident, but no longer dynamically
+  quantizes BF16 activations to MXFP8. Decode-sized `M <= 8` calls use the owned
+  `fp8_source_gemv` CUDA kernel directly on BF16 activations. Larger calls use
+  `fp8_source_expand_bf16` to materialize one bounded BF16 weight transient,
+  consume it with Gridbook's existing owned CUTLASS grouped-BF16 bridge, and
+  release it immediately. DeepSeek-V4's grouped `attn.wo_a` uses the same
+  contract, with the existing bridge expressed as one problem per group. There
+  is no PyTorch, cuBLAS, Triton, or persistent BF16 fallback.
+
+- The correction is deliberately scoped to the source block-128 wire. Direct
+  `mxfp8_e4m3_e8m0_g32` remains the opt-in `Mxfp8DenseLinearMethod` W8A8 lane
+  behind `GRIDBOOK_MXFP8_DENSE=1`; its resident format and dynamic MXFP8
+  activation quantization are unchanged. The existing v0.8.0 W8A8 measurements
+  remain historical evidence for that direct lane only, not evidence for the
+  new W8A16 route. Served quality and performance evidence for the W8A16 route
+  is pending the pre-tag gates in `docs/RELEASING.md`; this entry makes no
+  throughput or served-parity claim.
+
+- The packaged producer/runtime contract advances from closed schema v2 to v3
+  and explicitly attests
+  `abi_features.source_fp8_block128_w8a16 = 1`. Producers must require this
+  capability rather than infer correct activation semantics from a package
+  version. Missing, malformed, or future-valued declarations fail closed.
+
+- The distribution floor now names both serving-reachable source files that
+  were absent from its literal mirrors: the existing direct-MXFP8
+  `mxfp8_dense_gemm.cu` and the new `fp8_source_w8a16.cu`. The built-artifact,
+  installed-wheel, metadata, and GPU pre-tag compile gates therefore fail
+  explicitly if either source or either strict native ABI is missing.
+
 ## 0.8.4 — 2026-08-12
 
 - **Attest the routed per-role LUT ABI in the packaged runtime contract.**

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
 repository-code: "https://github.com/RobTand/gridbook"
 url: "https://github.com/RobTand/gridbook"
 license: Apache-2.0
-version: "0.8.4"
+version: "0.8.5"
 date-released: 2026-08-12
 keywords:
   - quantization

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -346,15 +346,17 @@ Two things banked from an attempt that was reverted before it shipped:
     `embed_tokens` are built with no quant config. `attn.wo_a` is created and
     post-processed through the quant contract but **applied outside it**
     (`nvidia/ops/o_proj.py` reads `.weight`/`.weight_scale_inv` directly), so
-    it is not CB-eligible. Its source block-FP8 form is nevertheless served on
-    sm_121 by Gridbook's ABI-guarded DSV4 adapter, which preserves vLLM's
-    inverse-RoPE and head-group ordering while routing the BMM through the
-    owning MXFP8 method. The distinction and hardware evidence are documented
-    in [`docs/PLUGIN.md`](docs/PLUGIN.md).
+    it is not CB-eligible. Its source block-FP8 form is now owned on sm_121 by
+    Gridbook's release-candidate W8A16 method and ABI-guarded DSV4 adapter,
+    which preserve vLLM's inverse-RoPE and head-group ordering. The direct-g32
+    MXFP8 W8A8 method is a separate, opt-in route. This is not yet a shipped
+    served-parity claim; the distinction and pending hardware gates are
+    documented in [`docs/PLUGIN.md`](docs/PLUGIN.md) and
+    [`docs/RELEASING.md`](docs/RELEASING.md).
 
-  Remaining before a real artifact loads is not contract work — see the
-  DSV4-Flash study's release gate (items 4-5: production calibration of the
-  eight K14 expert groups, then export/load/generate/benchmark).
+  Remaining work is release evidence, not another operator contract:
+  exact-artifact load/generate, served parity, graph replay, and performance
+  must be recorded through the DSV4-Flash release gate before promotion.
 - [ ] **D0.2 — Complete packed-expert native delegation if the assignment needs
   it.** Reuse Gridbook's existing top-level expert-loader path, canonical
   producer packers/metadata, and a version-attested upstream vLLM backend for

--- a/docker/Dockerfile.gridbook-pinned
+++ b/docker/Dockerfile.gridbook-pinned
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE=gridbook:local
 FROM ${BASE_IMAGE}
 
-ARG GRIDBOOK_REF=v0.8.4
+ARG GRIDBOOK_REF=v0.8.5
 
 USER root
 RUN test -n "${GRIDBOOK_REF}" \

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -100,13 +100,13 @@ serving image, using [`docker/Dockerfile.gridbook-pinned`](../docker/Dockerfile.
 docker build \
   -f docker/Dockerfile.gridbook-pinned \
   --build-arg BASE_IMAGE=gridbook:local \
-  --build-arg GRIDBOOK_REF=v0.8.4 \
-  -t gridbook:v0.8.4-pinned .
+  --build-arg GRIDBOOK_REF=v0.8.5 \
+  -t gridbook:v0.8.5-pinned .
 ```
 
 `GRIDBOOK_REF` is parameterized so the same recipe works for a release tag or,
 during a pre-tag rehearsal, the exact release commit SHA. For a release image,
-use the immutable `v0.8.4` tag. The direct-VCS requirement causes pip to write
+use the immutable `v0.8.5` tag. The direct-VCS requirement causes pip to write
 the requested ref and resolved 40-character commit to the installed
 distribution's PEP 610 `direct_url.json`; the Docker build reads that record
 back and fails if the requested revision or resolved commit is absent. This is

--- a/docs/KERNELS.md
+++ b/docs/KERNELS.md
@@ -8,7 +8,8 @@ here is evidence and design context, not a second backlog.
 
 Terminology used below: **GEMM** = matrix-matrix multiply (prefill / large batch);
 **GEMV** = matrix-vector multiply (decode / batch-1 or small batch); **M** = the
-number of activation rows (tokens) in a matmul; **MMA** = a tensor-core
+number of flattened token rows in a dispatch (for grouped source-FP8 BMM this
+does not include the separate `G` dimension); **MMA** = a tensor-core
 matrix-multiply-accumulate instruction; **QDQ** = quantize-then-dequantize the
 activations; **smem** = GPU shared memory; **TTFT** = time to first token
 (prefill latency).
@@ -109,9 +110,11 @@ change the activation format. Gridbook retains the source E4M3 bytes and one
 UE8M0 exponent per 128-by-128 weight block. BF16 activations cross the complete
 route unchanged; neither arm calls an activation quantizer or QDQ operation.
 
-- `fp8_source_gemv` owns `M <= 8`. It reads the raw E4M3 weight byte and the
-  matching 128-by-128 UE8M0 scale in the GEMV, accumulates in FP32, and rounds
-  the output to BF16. It does not materialize a weight tile.
+- `fp8_source_gemv` owns `M <= 8`, where `M` is the product of the leading
+  token dimensions after `[...,G,K]` is viewed as `[M,G,K]`; it is not `G*M`.
+  It reads the raw E4M3 weight byte and the matching 128-by-128 UE8M0 scale in
+  the GEMV, accumulates in FP32, and rounds the output to BF16. It does not
+  materialize a weight tile.
 - `fp8_source_expand_bf16` owns the large-M weight conversion. It expands one
   layer to a contiguous BF16 scratch tensor, which is consumed by
   `cb_bf16_grouped_mm` and then released. Dense Linear uses the bridge with
@@ -122,12 +125,17 @@ route unchanged; neither arm calls an activation quantizer or QDQ operation.
   involved.
 - Load requires both the source extension and the owned grouped-BF16 bridge.
   Missing source, strict symbol, supported device, shape, or bridge capability
-  is a load-time refusal. DSV4's qualified geometry is exactly
-  `G=8, N=1024, K=4096` at `tp=1`; a mismatch fails closed.
+  is a load-time refusal. Grouped BMM is qualified only for DSV4's exact
+  per-group geometry `G=8, N=1024, K=4096` at `tp=1`; any near miss is refused
+  before extension resolution or adapter-marker installation. Dense source-FP8
+  Linears are a separate contract: they retain the alignment and scale-shape
+  gates above and are not restricted to the grouped `wo_a` geometry; this
+  release still admits them only at `tp=1`.
 - Whole-layer dispatch stays behind an opaque custom op. `M` is selected when
-  the operation executes, so `FULL_DECODE_ONLY` captures only the native GEMV
-  arm for fixed sizes `[1,2,4,8]`; large-M expansion remains outside those
-  graphs.
+  the operation executes. The unit gate covers dense CUDA-graph replay at actual
+  flattened decode-token sizes `M in {1,2,4,8}`; `G` does not turn a grouped
+  `M=1` decode into `M=8`. Large-M expansion remains outside those graphs, and
+  exact-artifact grouped graph evidence remains a pre-tag gate.
 
 The direct `mxfp8_e4m3_e8m0_g32` wire is intentionally separate. It retains the
 existing opt-in W8A8 `mxfp8_dense_gemm.cu` route and dynamically quantized MXFP8
@@ -908,11 +916,13 @@ data-dependent control flow. The kernels follow these rules:
    behind a per-device atomic, which in steady state is one load.
 4. **Hoist the whole M-gated dispatch behind one opaque op.** The retired
    pre-hardening host branch was capture-hostile: a prefill-sized trace could
-   bake the expand arm into decode. Every current Linear/MoE call permanently
-   crosses one opaque `cb_*_forward` op whose eager implementation resolves M at
-   capture time. A `FULL_DECODE_ONLY` capture records the GEMV arm at each fixed
-   decode size; prefill stays outside that graph and resolves the large-M arm
-   independently. There is no environment switch back to the retired branch.
+   bake the expand arm into decode. Every current Linear/MoE/source-BMM call
+   permanently crosses one opaque `cb_*_forward` op whose eager implementation
+   resolves M at capture time. A `FULL_DECODE_ONLY` capture records the GEMV arm
+   at each fixed actual flattened token count `M <= 8`; a source-BMM group count
+   is not folded into M. Prefill stays outside that graph and resolves the
+   large-M arm independently. There is no environment switch back to the
+   retired branch.
 5. **Use full-decode graphs without compilation over the plugin.** The validated
    shape is `mode=0`, `cudagraph_mode=FULL_DECODE_ONLY`, capture sizes
    `[1,2,4,8]`. No Gridbook op carries `torch.Tag.cudagraph_unsafe`, so nothing
@@ -924,6 +934,8 @@ data-dependent control flow. The kernels follow these rules:
    evidence, not an exact-byte 27B claim. The FP4-v2 295B path separately
    measured +24% decode. Capture only the batch sizes the deployment needs:
    the 0.6B validation reported ~30 s startup and 2.64 GiB for four sizes.
+   Those served measurements predate source-FP8 W8A16 and must not be cited as
+   its exact-artifact graph evidence.
 
 ## A measurement side-effect worth knowing
 
@@ -944,7 +956,7 @@ too.
 
 | Path | Status |
 |---|---|
-| Source block-FP8 W8A16, dense + DSV4 grouped `wo_a` | **0.8.5 candidate; release evidence pending.** Raw E4M3/UE8M0 stays resident; BF16 activations are unchanged; `M<=8` uses native CUDA GEMV and larger M uses bounded native BF16 expansion plus the owned CUTLASS grouped bridge. Direct MXFP8 g32 remains the separate opt-in W8A8 lane. Do not claim shipped served parity or performance until the exact-artifact gates in RELEASING are recorded |
+| Source block-FP8 W8A16, dense + DSV4 grouped `wo_a` | **0.8.5 candidate; release evidence pending.** Raw E4M3/UE8M0 stays resident; BF16 activations are unchanged; actual flattened decode-token `M<=8` uses native CUDA GEMV and larger M uses bounded native BF16 expansion plus the owned CUTLASS grouped bridge. Grouped BMM is admitted only at `(G=8,N=1024,K=4096,tp=1)`; dense geometry is gated separately and also remains `tp=1` only. Direct MXFP8 g32 remains the separate opt-in W8A8 lane. Do not claim shipped served parity or performance until the exact-artifact gates in RELEASING are recorded |
 | FP8-CB decode (dense) | **Shipped**, at/above native parity |
 | FP4-CB v2 decode (dense) | **Shipped**: bit-matched CUDA GEMV (13/13 parity against the historical Triton result plus the independent expansion reference). The decode chain is compute-bound at GEMV shapes (ncu SM 71%/mem 44%) under the bit-exact contract — the measured ceiling, not a staging problem |
 | MoE grouped decode GEMV | **Shipped**: fp8 66–95% of peak; fp4-v2 w2 schedule redesigned (+50%, 37–47% of peak; reassociation served-gated with an env-switched legacy path). A rowpack variant measured NEGATIVE and stays opt-in-off as a documented result |

--- a/docs/KERNELS.md
+++ b/docs/KERNELS.md
@@ -15,10 +15,11 @@ activations; **smem** = GPU shared memory; **TTFT** = time to first token
 
 ## The three invariants everything is built around
 
-- **INV-1 — no resident expansion.** The resident weight is always the packed
-  `cb_qweight` (indices + scale plane) plus the small shared codebook. The dense
-  weight is **never** materialized in memory. Decoding happens in registers/smem
-  per tile, or into a per-layer scratch buffer that is freed after the matmul.
+- **INV-1 — no resident expansion.** A CB layer keeps its packed `cb_qweight`
+  (indices + scale plane) plus the small shared codebook; a source block-FP8
+  layer keeps its raw E4M3 weight plus UE8M0 scale blocks. The dense BF16 weight
+  is **never resident**. Decoding happens in registers/smem per tile, or into a
+  per-layer scratch buffer that is freed after the matmul.
   This is what makes a smaller-on-disk artifact also smaller in memory — the
   reason the format fits large models on one box. A resident-footprint assertion
   is a load-time gate, not a nicety.
@@ -86,6 +87,8 @@ serving contract:
 | FP8-CB, `9 ≤ M ≤ 128` | Fused CUTLASS decode-in-prologue when the rung/layout/device predicates hold; otherwise native CUDA FP8 expansion + CUTLASS W8A8 GEMM |
 | FP8-CB, `M > 128` | Native CUDA FP8 expansion + CUTLASS W8A8 GEMM |
 | FP4-CB, `M > 8` | Native CUDA BF16 expansion + Gridbook-owned CUTLASS grouped BF16 GEMM with `E=1` |
+| Source block-FP8, `M <= 8` | Native CUDA raw-E4M3/UE8M0 W8A16 GEMV; BF16 activations are not quantized |
+| Source block-FP8, `M > 8` | Native CUDA BF16 expansion + Gridbook-owned CUTLASS grouped BF16 GEMM; `E=1` for dense and one problem per DSV4 `wo_a` group |
 
 A missing native extension is an error, not another dispatch arm. See the
 CUDA-graph section for why this host-side branch matters. FP4-v2 model load
@@ -98,6 +101,40 @@ must be biasless, and FP4 must be unsigned product-v2. A non-`None` bias,
 signed S-rung, or FP4-v1 dense layer is format-valid where applicable but has
 no complete owned every-M native operation. The public method rejects bias;
 model load rejects the unsupported FP4 families.
+
+### Source block-FP8 W8A16 (`fp8_e4m3_ue8m0_block128`)
+
+This source-passthrough wire is a **weight-storage contract**, not permission to
+change the activation format. Gridbook retains the source E4M3 bytes and one
+UE8M0 exponent per 128-by-128 weight block. BF16 activations cross the complete
+route unchanged; neither arm calls an activation quantizer or QDQ operation.
+
+- `fp8_source_gemv` owns `M <= 8`. It reads the raw E4M3 weight byte and the
+  matching 128-by-128 UE8M0 scale in the GEMV, accumulates in FP32, and rounds
+  the output to BF16. It does not materialize a weight tile.
+- `fp8_source_expand_bf16` owns the large-M weight conversion. It expands one
+  layer to a contiguous BF16 scratch tensor, which is consumed by
+  `cb_bf16_grouped_mm` and then released. Dense Linear uses the bridge with
+  `E=1`. For grouped DSV4 `attn.wo_a`, `[M,G,K]` activations are made
+  group-major, the expanded weight is viewed as `[G,N,K]`, and cumulative
+  endpoints `[M,2M,...,G*M]` describe exactly one existing CUTLASS problem per
+  group; the result is restored to `[M,G,N]`. No new framework BMM fallback is
+  involved.
+- Load requires both the source extension and the owned grouped-BF16 bridge.
+  Missing source, strict symbol, supported device, shape, or bridge capability
+  is a load-time refusal. DSV4's qualified geometry is exactly
+  `G=8, N=1024, K=4096` at `tp=1`; a mismatch fails closed.
+- Whole-layer dispatch stays behind an opaque custom op. `M` is selected when
+  the operation executes, so `FULL_DECODE_ONLY` captures only the native GEMV
+  arm for fixed sizes `[1,2,4,8]`; large-M expansion remains outside those
+  graphs.
+
+The direct `mxfp8_e4m3_e8m0_g32` wire is intentionally separate. It retains the
+existing opt-in W8A8 `mxfp8_dense_gemm.cu` route and dynamically quantized MXFP8
+activations. The W8A16 source route does not reuse its scale-plane conversion or
+its activation quantizer. Kernel unit gates, exact-artifact served parity, and
+served performance for W8A16 remain pre-tag requirements; no result is claimed
+here before those gates are recorded.
 
 ---
 
@@ -879,7 +916,7 @@ data-dependent control flow. The kernels follow these rules:
 5. **Use full-decode graphs without compilation over the plugin.** The validated
    shape is `mode=0`, `cudagraph_mode=FULL_DECODE_ONLY`, capture sizes
    `[1,2,4,8]`. No Gridbook op carries `torch.Tag.cudagraph_unsafe`, so nothing
-   partitions the captured region — the two whole-dispatch ops are the only
+   partitions the captured region — Gridbook's whole-dispatch ops are opaque
    graph nodes and are capture-safe by construction. On a close-rate
    0.6B canary, changed inputs at capture sizes 1 and 4 matched eager text,
    tokens, and per-token logprobs exactly; 32+256 latency improved 20.1% and was
@@ -907,6 +944,7 @@ too.
 
 | Path | Status |
 |---|---|
+| Source block-FP8 W8A16, dense + DSV4 grouped `wo_a` | **0.8.5 candidate; release evidence pending.** Raw E4M3/UE8M0 stays resident; BF16 activations are unchanged; `M<=8` uses native CUDA GEMV and larger M uses bounded native BF16 expansion plus the owned CUTLASS grouped bridge. Direct MXFP8 g32 remains the separate opt-in W8A8 lane. Do not claim shipped served parity or performance until the exact-artifact gates in RELEASING are recorded |
 | FP8-CB decode (dense) | **Shipped**, at/above native parity |
 | FP4-CB v2 decode (dense) | **Shipped**: bit-matched CUDA GEMV (13/13 parity against the historical Triton result plus the independent expansion reference). The decode chain is compute-bound at GEMV shapes (ncu SM 71%/mem 44%) under the bit-exact contract — the measured ceiling, not a staging problem |
 | MoE grouped decode GEMV | **Shipped**: fp8 66–95% of peak; fp4-v2 w2 schedule redesigned (+50%, 37–47% of peak; reassociation served-gated with an env-switched legacy path). A rowpack variant measured NEGATIVE and stays opt-in-off as a documented result |

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -123,7 +123,7 @@ and recorded commands.
 
 Format labels are not execution evidence. Every report requires the
 format/rung, serialized weight layout, scale coding, full weight/activation
-contract (`W4A4`, `W8A8`, and so on), concrete kernel/backend, tensor-parallel
+contract (`W4A4`, `W8A8`, `W8A16`, and so on), concrete kernel/backend, tensor-parallel
 size, fallback state, exact server vLLM/runtime build, GPU identifier, driver,
 and accelerator runtime (for example CUDA or ROCm). Client and server runtime
 identifiers are separate required fields because the benchmark may run outside
@@ -148,6 +148,19 @@ identity fields. If an assignment uses more than one value, that CLI field must
 say `mixed`. Only these aggregate CLI fields may say `mixed`; per-unit assignment
 fields may not. The manifest is the authoritative identity for mixed menus; a
 single average bpp or headline format is not.
+
+For source block-FP8, `fp8_e4m3_ue8m0_block128` identifies the serialized
+**weight** representation only. Its Gridbook 0.8.5 assignment must say
+`quant_contract: "W8A16"`: the runtime consumes BF16 activations unchanged. The
+assignment's backend must name the complete owned dispatch chain, for example
+`gridbook-fp8-source-w8a16(fp8_source_gemv|fp8_source_expand_bf16+cb_bf16_grouped_mm)`,
+rather than the generic words `Gridbook`, `FP8`, or `source-passthrough`. Attach
+logs proving `fp8_source_gemv` for decode-sized calls and
+`fp8_source_expand_bf16` plus `cb_bf16_grouped_mm` for larger calls. For DSV4
+`wo_a`, the same evidence must show the grouped W8A16 adapter and `tp=1`.
+Conversely, direct `mxfp8_e4m3_e8m0_g32` remains W8A8 and must name
+`mxfp8_dense_mm`. Neither wire may borrow the other's arithmetic label or
+evidence merely because both store E4M3 weights with UE8M0 scales.
 
 Minimal syntax examples look like this (real inventories enumerate every
 shipped file, and production execution manifests must be generated from and
@@ -179,6 +192,13 @@ not a slower sample of the requested arm.
 An intentional Gridbook W4A16 arm is valid when its exact packing/metadata,
 profile, loader, and delegated backend are recorded as W4A16; it must never be
 used as evidence for W4A4 merely because both reuse a native weight family.
+
+The same rule is release-critical for the source block-FP8 correction. Historical
+block-128 results obtained by replicating scales into MXFP8 and dynamically
+quantizing activations are W8A8 results. They do not validate W8A16 quality,
+logits, CUDA-graph behavior, or speed. A 0.8.5 release claim needs a fresh
+same-artifact run whose manifest, logs, and server evidence prove unchanged BF16
+activations and the W8A16 kernel chain above.
 
 The opt-in fused native-FP4 prefill path is another contract-changing cell, not
 a transparent acceleration switch: it moves activation scaling from the

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -6,7 +6,7 @@ see [`INSTALL.md`](INSTALL.md) and [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md);
 for the format itself see [`SPEC.md`](SPEC.md).
 
 The served path is Gridbook's packaged **native CUDA/CUTLASS kernel set** under
-`gridbook/csrc/`. Native CUDA handles decode GEMV, codebook expansion,
+`gridbook/csrc/`. Native CUDA handles decode GEMV, codebook/source expansion,
 activation QDQ, and routing/combine support; CUTLASS handles GEMM and grouped
 GEMM. Gridbook defines, compiles, and dispatches no Triton operator and has no
 Triton dependency or serving fallback. Required native operations fail closed
@@ -29,10 +29,11 @@ gated activations are attested during model load and invoke their registered
 
 ## Invariants
 
-- **INV-1 (honored):** the resident weight is the packed k-bit index stream +
-  the tiny flat codebook + the (pre-decoded) scales. The dense `[N,K]` weight is
-  never materialized in HBM as a *model-wide* tensor — each superblock's weight
-  tile is expanded inside the kernel, in registers, then consumed by the matmul.
+- **INV-1 (honored):** a CB resident weight is the packed k-bit index stream +
+  the tiny flat codebook + the (pre-decoded) scales; a source block-FP8 resident
+  weight is its raw E4M3 tensor + UE8M0 scale blocks. A dense BF16 `[N,K]`
+  weight is never materialized in HBM as a *model-wide* tensor — each tile is
+  expanded inside the kernel, in registers, then consumed by the matmul.
   The large-M transient-expand prefill path materializes one layer's `[N,K]` tile
   at a time (expand → GEMM → free), a bounded, deliberate relaxation.
 - **INV-2 (native tensor-core matrix kernels):** honored by the CUTLASS
@@ -49,8 +50,11 @@ gated activations are attested during model load and invoke their registered
 
 The producer/runtime boundary is machine-readable at
 `gridbook/runtime_contract.json` and loadable without torch or vLLM through
-`gridbook.runtime_contract.load_runtime_contract()`. It declares accepted
-quantization names, serialized packing/type-size rules, supported CB rung
+`gridbook.runtime_contract.load_runtime_contract()`. Closed schema v3 also
+attests `abi_features.source_fp8_block128_w8a16 = 1`, so a producer can require
+the BF16-activation source route without inferring semantics from the package
+version. It declares accepted quantization names, serialized packing/type-size
+rules, supported CB rung
 families, and producer-profile loader coverage. The plugin derives its own
 registration aliases and top-level loader-module list from this file rather
 than repeating them in Python. PrismaQuant pins an immutable Gridbook
@@ -208,16 +212,16 @@ Gridbook.
   config, but it remains source block-FP8 rather than CB: the qualified eugr
   vLLM baseline's grouped output projection bypasses `apply()` and reads
   `.weight` plus its scale parameter for DeepGEMM directly. On sm_121 that
-  DeepGEMM scale transform is unsupported, and Gridbook has already converted
-  the source scales into its own MXFP8 CuTe planes. Gridbook therefore installs
-  a narrow, ABI-guarded DSV4 adapter only on marked `wo_a` modules: native
-  inverse RoPE, the Gridbook-owned grouped MXFP8 method, then `wo_b`. Every
+  DeepGEMM scale transform is unsupported. Gridbook therefore keeps the raw
+  E4M3 weight and block-128 UE8M0 scale resident and installs a narrow,
+  ABI-guarded DSV4 adapter only on marked `wo_a` modules: native inverse RoPE,
+  the Gridbook-owned grouped W8A16 method on unchanged BF16 activations, then
+  `wo_b`. Every
   unmarked stock DSV4 layer continues through vLLM's original `_o_proj` method
   unchanged. Exact artifact geometry `(G=8, N=1024, K=4096)` is
-  correctness-audited on GB10: M=1 max-abs 0.03125, relative Frobenius
-  1.2460984e-5; M=64 max-abs 0.25, relative Frobenius 4.4897934e-5. Both meet
-  the numeric contract of relative Frobenius at most 1e-4; neither is a
-  bit-exactness claim. End-to-end served parity remains a release gate.
+  covered by the exact-artifact W8A16 gates in `RELEASING.md`. Historical
+  grouped-MXFP8 W8A8 numbers are not evidence for this route. End-to-end served
+  parity and performance remain release gates.
 - **Fail-closed.** Outside `mtp.*`, vLLM's DSV4 loader looks parameters up
   unguarded, so any tensor the artifact emits with no matching parameter is a
   hard load failure rather than a silent skip. On the Gridbook side the usual
@@ -227,12 +231,14 @@ Gridbook.
 
 ## CUDA kernel set (decode-GEMV + prefill)
 
-JIT-built native CUDA/CUTLASS extensions. Numerics contract everywhere: identical weight
-rounding to the reference decode (`w = bf16_rn(codebook · scale)`), fp8/fp4
-activation QDQ bit-exact to the codec, and **fp32 accumulation** — so a CUDA
-result differs from the independent PyTorch/FP64 reference only by summation
-**reassociation**, held to `≤1 bf16 output ULP + a norm backstop` in the native
-kernel tests.
+JIT-built native CUDA/CUTLASS extensions. For CB lanes, the numerics contract is
+identical weight rounding to the reference decode
+(`w = bf16_rn(codebook · scale)`), fp8/fp4 activation QDQ bit-exact to the codec,
+and **fp32 accumulation**. The source block-FP8 W8A16 lane instead preserves its
+BF16 activation tensor and decodes the raw E4M3/UE8M0 weight directly. CUDA
+results are held against independent references with the operation-specific
+exactness/tolerance gate; summation reassociation remains the only admitted
+GEMM/GEMV difference.
 
 **`gridbook/csrc/cb_gemv.cu`** (`cuda_ext.get_ext()`) — dense M≤8, grouped-MoE
 M≤16, plus native expansion/support operators:
@@ -273,6 +279,20 @@ M≤16, plus native expansion/support operators:
 - `fp8_act_qdq`, `cb_moe_combine` — fused per-token fp8 QDQ and the deterministic
   expert-ascending bf16 combine.
 
+**`gridbook/csrc/fp8_source_w8a16.cu`**
+(`cuda_ext.get_fp8_source_w8a16_ext()`) — source block-FP8 W8A16:
+
+- `fp8_source_gemv` consumes BF16 activations and resident E4M3 weights with
+  their original 128-by-128 UE8M0 scale blocks for `M<=8`. It accumulates in
+  FP32 and emits BF16; no activation-QDQ operator is called.
+- `fp8_source_expand_bf16` creates the one-layer BF16 weight transient used for
+  `M>8`. The transient feeds the existing owned grouped-BF16 CUTLASS bridge and
+  is released immediately. DSV4 BMM uses one bridge problem per group rather
+  than a Python or framework matmul loop.
+- The extension has a strict two-symbol ABI and is required during weight load.
+  It is a separate digest-keyed JIT family so its source/toolchain identity
+  cannot alias the CB main module or direct-MXFP8 module.
+
 **`gridbook/csrc/cb_gemv_v2.cu`** (`cuda_ext.get_ext_v2()`) — required FP4-v2
 quality expansion plus an optional alternate decode GEMV:
 
@@ -307,7 +327,9 @@ quality-preserving BF16 bridge:
 
 - **`cb_bf16_grouped_mm`** — consumes ragged expert segments and transiently
   expanded BF16 weights in one owned CUTLASS grouped GEMM. MoE prefill uses
-  `E>1`; dense FP4-CB uses the same binding with `E=1` for every `M>8`. This
+  `E>1`; dense FP4-CB and dense source block-FP8 use the same binding with `E=1`
+  for every `M>8`. Grouped DSV4 source block-FP8 uses `E=G` with equal `M`-row
+  segments. This
   retains Gridbook's established activation-QDQ contract and must not be
   described as the quality-red native-W4A4 experiment. Its current
   SM80-compatible `DefaultGemmGrouped` schedule is not Blackwell-optimized: on
@@ -363,7 +385,7 @@ tooling and model cards — see the README's naming section.)
 
 | Variable | Default | Effect |
 |---|---|---|
-| `PRISMAQUANT_CB_EXT_DIR` | `~/.cache/prismaquant-cb-ext` | Root of the JIT build cache. Point it at a persistent, writable directory in containers so a cold start does not rebuild every module it reaches. Each of the eight modules owns a SUBDIRECTORY of it — `main`, `v2`, and the identity-keyed `bf16_grouped/<digest>`, `fused/<digest>`, `fused_fp4/<digest>`, `fused_fp4v2/<digest>`, `moe_persistent_b/<digest>`, `mxfp8_dense/<digest>` — so no two ninja workspaces share artefacts and a changed source, header, lane macro, target or toolchain ABI lands in a new directory instead of serving a stale kernel. Upgrading Gridbook therefore costs ONE rebuild per affected module; the old directories are inert and can be deleted. |
+| `PRISMAQUANT_CB_EXT_DIR` | `~/.cache/prismaquant-cb-ext` | Root of the JIT build cache. Point it at a persistent, writable directory in containers so a cold start does not rebuild every module it reaches. Each of the nine modules owns a SUBDIRECTORY of it — `main`, `v2`, and the identity-keyed `bf16_grouped/<digest>`, `fused/<digest>`, `fused_fp4/<digest>`, `fused_fp4v2/<digest>`, `moe_persistent_b/<digest>`, `mxfp8_dense/<digest>`, `fp8_source_w8a16/<digest>` — so no two ninja workspaces share artefacts and a changed source, header, lane macro, target or toolchain ABI lands in a new directory instead of serving a stale kernel. Upgrading Gridbook therefore costs ONE rebuild per affected module; the old directories are inert and can be deleted. |
 | `PRISMAQUANT_CUTLASS_INCLUDE` | unset (vLLM's bundled copy) | The `include` directory — the one holding `cutlass/cutlass.h` — that all **four** CUTLASS-compiling modules build against: grouped-BF16, fused FP8-CB, fused NVFP4-CB and the fused FP4-CB v2 mid-M lane. Set it to build in a venv with no vLLM wheel, or against a CUTLASS newer than the bundled tree. Unset, the path is discovered under `vllm/third_party/` *without importing vLLM* (importing it merely to locate files would eagerly initialize optional compiler backends, Triton among them). A set-but-wrong value **fails** with the missing header named; it never falls back silently, because compiling against a different CUTLASS than the one asked for is the surprise this override exists to prevent. |
 | `PRISMAQUANT_CB_GEMV` | `inherited` | Which grouped FP4-CB **decode GEMV** serves a layer: `inherited` \| `auto` \| `v2`. All FP4-v2 quality paths build/load `cb_gemv_v2.cu` and run its cc 12.0/12.1 device prepare because that module also owns the required exact expander. Unset/`inherited` keeps the shipped decode schedule; `auto` or `v2` may additionally use the module's smem-resident decode GEMV where its occupancy predicate says it wins. That alternate decode is **not** bit-exact against `inherited` (reassociation class). FP8-only serves do not need the v2 module. An unknown spelling raises; changing it mid-process raises. |
 | `PRISMAQUANT_CB_FUSED_FP4` | off | Dense fp4-CB native-FP4 prefill opt-in. `1`/`midm` use a fully attested artifact scalar for all prefill shapes / `16 < M <= 128`. `static_lsq`/`static_lsq_midm` keep that exact `G` and the native E2M1/SFA payload, but fit the existing per-row EVT residual by least squares; they add no model metadata, weight copy, decoder, or GEMM. `rowwise`/`rowwise_midm` instead derive an independent full-range scalar per runtime row and are the only fused choices accepted for legacy artifacts. All dense modes use one occupancy selector: TileM256 is chosen only for `M >= 256` and `ceil(M/256) * ceil(N/128) >= ceil(2*SM_count/3)`; otherwise TileM128 runs. The `*_midm` modes therefore always remain TileM128. All values are experimental and default-off; unknown spellings and mid-process changes fail. **Tops the dense precedence chain** — it changes the served activation contract, so it outranks `PRISMAQUANT_CB_FP4_FUSED_MIDM` and `PRISMAQUANT_CB_BF16_SM120` (see [Lane precedence](#lane-precedence--which-flag-wins-when-several-are-set)). A selected mode that the **load-time** gate finds ineligible **fails the load**; a mode that passes that gate and then declines a concrete **call** (in practice the rowwise / static-LSQ quantizers' half-precision guard) **raises** naming the activation dtype and shape. Neither falls through to the exact BF16 route: that route's activation bucket is the fp32-emulated group QDQ rather than the format's native ue4m3 scale factors, so serving it would silently substitute the contract the flag exists to make explicit. The K24 short exact gate passed, but long-context evidence is mixed and no >=4B/MoE served validation exists; see the [dated audit](audits/fused_nvfp4_enablement_2026-07-31.md). |
@@ -372,11 +394,11 @@ tooling and model cards — see the README's naming section.)
 | `PRISMAQUANT_CB_FP4_FUSED_MIDM` | off | `1` routes **dense FP4-CB v2 quality prefill at 9 ≤ M ≤ 128** to the fused decode-in-prologue lane (`csrc/cb_fused_fp4v2_gemm.cu`) instead of `expand_fp4_v2_to_weight` + the owned CUTLASS bridge. CONTRACT-PRESERVING: the decoded weights are bit-identical to `cb_expand_v2` and the activation is the same group-16 QDQ output, so only the FP32 GEMM reduction order changes. Compiled only for cc 12.0/12.1; resolved at model load and **fails the load** if unavailable rather than silently serving the bridge. Since 2026-08-02 the load-time gate is per LAYER, not merely "is the extension present": an uncompiled rung, `K % 256 ≠ 0`, `N % 8 ≠ 0`, a non-v2/non-product format, or a fused module whose roles use different interned codebooks all **fail the load** with the reason named — those are properties of the layer, so with the flag on they would otherwise have served the bridge for every request while the load reported success. The **M band is the one call-time fall-through** and is deliberate: `9 ≤ M ≤ 128` is a property of the REQUEST (and `M ≤ 128` is a HARD gate the kernel itself enforces, since decode-in-prologue re-decodes B per M-tile), so out-of-band shapes take today's exact path unchanged — that is what makes this a mid-M lane. Measured 1.06–4.37× the bridge at M ∈ {9,16,32,64,128}, bit-checked against a same-config oracle; served protocol NOT run. **Outranked by `PRISMAQUANT_CB_FUSED_FP4`** and above `PRISMAQUANT_CB_BF16_SM120` in the dense chain; still attested at load when overridden (see [Lane precedence](#lane-precedence--which-flag-wins-when-several-are-set)). Unknown spellings and mid-process changes raise. See [KERNELS](KERNELS.md#fp4-cb-v2-fused-mid-m-opt-in-prismaquant_cb_fp4_fused_midm) and the [benchmark table](BENCHMARKS.md#2026-08-02-fp4-cb-v2-fused-mid-m-lane-microbenchmark-proposal-data). |
 | `PRISMAQUANT_CB_MOE_PERSISTENT_B` | off | `1` routes the **FP4-CB MoE quality prefill** above the `M<=16` GEMV band to the persistent-B decode-in-mainloop kernel (`csrc/cb_moe_persistent_b.cu`, ROADMAP K1.1) instead of expand + grouped bridge. A CTA owns one (expert, N-tile), decodes that weight tile from packed CB bytes into shared memory ONCE, and streams the expert's routed rows through it, so the `[E,N,K]` BF16 transient never exists and unrouted experts cost nothing. Consumes the exact `expert_ends` segments the default path already builds — no padded rows, and no host read anywhere on the path. Compiled only for cc 12.0/12.1 and only for FP4-CB two-tier v2 (`n_sub=2`, `type_size=4k+9`, superblock-aligned dimensions); resolved at model load and **fails the load** if the flag is on where the lane cannot serve. Same activation payload and one bf16 round; the weight decode is bit-identical to `cb_expand_v2` (tested with `torch.equal`), so only the FP32 reduction order changes. It takes precedence over `PRISMAQUANT_CB_BF16_SM120` for these layers, because it replaces the pair of operations that lane is one half of — and is itself outranked by `PRISMAQUANT_CB_FUSED_FP4_MOE`, which changes the activation contract (see [Lane precedence](#lane-precedence--which-flag-wins-when-several-are-set)). When overridden it is still attested at load, and the load-time dispatch line says so rather than announcing a route that will not serve. Unknown spellings and mid-process changes raise. See [KERNELS](KERNELS.md#persistent-b-decode-in-mainloop-opt-in-prismaquant_cb_moe_persistent_b) and the [benchmark table](BENCHMARKS.md#2026-08-02-persistent-b-grouped-moe-decode-in-mainloop-microbenchmark-proposal-data). |
 | `PRISMAQUANT_CB_MOE_PERSISTENT_B_CFG` | `0` | Tile override for the lane above; `0` lets the kernel choose from the SHAPES (mean routed rows per expert), which is the production setting. A non-zero value is a 1-based index into `cb_moe_persistent_b_configs()` and is **validated at model load against what this build compiled**, so a stale or mistyped index fails the load instead of aborting the first request that carries routed rows. Measurement knob only. |
-| `GRIDBOOK_MXFP8_DENSE` | off | `1` opts in Gridbook's **MXFP8 dense W8A8 lane** (`csrc/mxfp8_dense_gemm.cu`): E4M3 weights with one UE8M0 scale per 32 K-elements, served on the stock sm120/sm121 block-scaled CollectiveBuilder collective (`kind::mxf8f6f4`), activations quantized dynamically per 32. Serves two source-passthrough wire spellings of the same on-device format — producer MXFP8 (`mxfp8_e4m3_e8m0_g32`) and DeepSeek block-128 FP8 (`fp8_e4m3_ue8m0_block128`), the latter embedded EXACTLY at load by scale replication (128 = 4 × 32; proof and torch reference in `gridbook/mxfp8.py`). Correctness-audited on sm_121 against the fp32 oracle over the seven distinct DSV4-Flash body shapes (worst relative Frobenius 5.9e-5 under the at-most-1e-4 numeric contract; no M=1 bit-exactness claim). The grouped `wo_a` gate on the qualified eugr baseline measures relative Frobenius 1.2460984e-5 at M=1 and 4.4897934e-5 at M=64; **OPT-IN because the NATIVE-PARITY served bench is pending** — run `python -m gridbook.bench_mxfp8_dense` on an idle GPU for the timing half. With the flag unset, an artifact declaring these passthrough units refuses at model load with this flag named; compiled only for cc 12.0/12.1 and attested at load like every lane (`lane_select.require_lane`). Unknown spellings and mid-process changes raise. |
+| `GRIDBOOK_MXFP8_DENSE` | off | `1` opts in Gridbook's **direct MXFP8 dense W8A8 lane** (`csrc/mxfp8_dense_gemm.cu`) for `mxfp8_e4m3_e8m0_g32`: E4M3 weights with one UE8M0 scale per 32 K-elements, served on the stock sm120/sm121 block-scaled CollectiveBuilder collective (`kind::mxf8f6f4`), with activations quantized dynamically per 32. Correctness was audited on sm_121, but the NATIVE-PARITY served timing bench remains pending. With the flag unset, a direct-MXFP8 passthrough unit refuses at model load with this flag named; compiled only for cc 12.0/12.1 and attested at load like every lane (`lane_select.require_lane`). The source `fp8_e4m3_ue8m0_block128` wire is **not controlled by this flag** and never enters this W8A8 lane: it uses the separately attested W8A16 source route with unchanged BF16 activations. Unknown spellings and mid-process changes raise. |
 | `PRISMAQUANT_CB_FUSED_MIDM` | `1` | Resolved during model load. `0` skips the CUTLASS mid-M FP8 fused specialization and its JIT build; the exact native expansion/CUTLASS route remains. Only `''` (unset), `0` and `1` are accepted — before 2026-08-02 this was compared `!= "0"`, so `false` and `off` silently ENABLED the lane they read as disabling. Process-stable: changing the value after dispatch is fixed raises rather than taking effect. |
 | `PRISMAQUANT_CB_DECODE_CONTRACT` | `v1` | `v2` selects the scale-epilogue-hoist decode contract. Measured **null** on the served 27B; kept for reproducibility. |
 | `PRISMAQUANT_DEBUG_PREFIXES` | off | `1` prints, per Linear, whether it resolved to a CB scheme or to a config-declared non-CB group — the first tool to reach for when memory use is higher than expected. |
-| `PRISMAQUANT_PRELOAD_FUSED` | off | `1` independently attempts to build/preload **every** native extension family at registration — decode GEMV, GEMV-v2, grouped BF16, both fused FP8-CB/NVFP4-CB modules, fused FP4-v2, persistent-B MoE and MXFP8 dense — so both arms of a served A/B can carry identical extension residency. (Before 2026-08-02 it warmed only the two fused modules, which left the other five free to differ between arms; the name is kept because it is the published one.) Each family is attempted independently and fail-soft: one that will not build on this box leaves the others warmed. Only `''` (unset), `0` and `1` are accepted: this was compared `== "1"` until 2026-08-02, so `true` and a stray-space `" 1 "` warmed nothing while the operator believed both arms were residency-matched — a failure invisible in the results. A family that does not warm is now named on stderr rather than silently skipped. Registration treats this as a capability probe; a serving caller still requires its selected native operation and fails closed (see the measurement side-effect in [`KERNELS.md`](KERNELS.md#a-measurement-side-effect-worth-knowing)). |
+| `PRISMAQUANT_PRELOAD_FUSED` | off | `1` independently attempts to build/preload **every** native extension family at registration — decode GEMV, GEMV-v2, grouped BF16, both fused FP8-CB/NVFP4-CB modules, fused FP4-v2, persistent-B MoE, direct MXFP8 dense, and source block-FP8 W8A16 — so both arms of a served A/B can carry identical extension residency. (Before 2026-08-02 it warmed only the two fused modules, which left the other five free to differ between arms; the name is kept because it is the published one.) Each family is attempted independently and fail-soft: one that will not build on this box leaves the others warmed. Only `''` (unset), `0` and `1` are accepted: this was compared `== "1"` until 2026-08-02, so `true` and a stray-space `" 1 "` warmed nothing while the operator believed both arms were residency-matched — a failure invisible in the results. A family that does not warm is now named on stderr rather than silently skipped. Registration treats this as a capability probe; a serving caller still requires its selected native operation and fails closed (see the measurement side-effect in [`KERNELS.md`](KERNELS.md#a-measurement-side-effect-worth-knowing)). |
 
 ### Lane precedence — which flag wins when several are set
 
@@ -524,4 +546,7 @@ and fp4-v2, QDQ bit-exactness, the expander) against independent PyTorch/FP64
 references. The grouped-BF16 bridge is gated against segmented BF16 matmul
 references, while `tests/test_fused_prefill.py` gates the specialized prefill
 kernels and `tests/test_persistent_tc.py` gates the research-only persistent-N
-source behind its opt-in.
+source behind its opt-in. `tests/test_fp8_source_w8a16_cuda.py` independently
+gates the source GEMV and BF16 expander; the integration suite separately pins
+resident raw storage, dense/grouped dispatch, no activation QDQ, and fail-closed
+load behavior.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -140,7 +140,9 @@ docker run --rm --gpus all -v "$PWD/dist:/dist" \
   TORCH_CUDA_ARCH_LIST=12.1a python -c "
 from gridbook.cuda_ext import (
     csrc_dir, get_bf16_grouped_ext, get_ext, get_ext_v2,
-    get_fused_ext, get_fused_fp4_ext,
+    get_fp8_source_w8a16_ext, get_fused_ext, get_fused_fp4_ext,
+    get_fused_fp4v2_ext, get_moe_persistent_b_ext,
+    get_mxfp8_dense_ext,
 )
 from gridbook.native_cutlass import (
     require_native_fp8_cutlass, require_native_moe_activation,
@@ -169,18 +171,98 @@ for symbol in (\"cb_fused_fp4_prefill_mm_scaled\",
                \"cb_fused_fp4_moe_tile_sizes\"):
     assert hasattr(fp4_fused, symbol), f\"built FP4 fused module is missing {symbol}\"
 assert list(fp4_fused.cb_fused_fp4_moe_tile_sizes()) == [128, 256]
+fp4v2_fused = get_fused_fp4v2_ext()
+assert fp4v2_fused is not None, \"fused FP4-v2 extension failed to build\"
+assert hasattr(fp4v2_fused, \"cb_fused_fp4v2_prefill_mm\")
+persistent_b = get_moe_persistent_b_ext()
+assert persistent_b is not None, \"persistent-B MoE extension failed to build\"
+assert hasattr(persistent_b, \"cb_moe_persistent_b_prefill\")
+mxfp8 = get_mxfp8_dense_ext()
+assert mxfp8 is not None, \"direct MXFP8 extension failed to build\"
+for symbol in (\"mxfp8_dense_mm\", \"mxfp8_dense_mm_out\"):
+    assert hasattr(mxfp8, symbol), f\"built MXFP8 module is missing {symbol}\"
+source_w8a16 = get_fp8_source_w8a16_ext()
+assert source_w8a16 is not None, \"source-FP8 W8A16 extension failed to build\"
+for symbol in (\"fp8_source_gemv\", \"fp8_source_expand_bf16\"):
+    assert hasattr(source_w8a16, symbol), \
+        f\"built source-W8A16 module is missing {symbol}\"
 require_native_fp8_cutlass(\"release native-op gate\")
 require_native_moe_activation(\"silu\", \"release native-op gate\")
-print(\"ok:\", m, v2, grouped, fp8_fused, fp4_fused)"'
+print(\"ok:\", m, v2, grouped, fp8_fused, fp4_fused, fp4v2_fused,
+      persistent_b, mxfp8, source_w8a16)"'
 ```
 
 This command compiles every serving-reachable packaged extension: the main and
 v2 decode/expansion modules, the required exact grouped BF16 CUTLASS quality
-bridge, and both optional fused specializations. It also attests the direct
+bridge, all fused/persistent specializations, the direct-MXFP8 W8A8 module, and
+the source block-FP8 W8A16 module. It also attests the direct
 compiled vLLM FP8/CUTLASS and activation ABI that Gridbook invokes without a
 Python fallback helper. The retained `cb_persistent_tc.cu` source is not part
 of this gate: its serving selector, custom op, and package loader were deleted,
 and it remains available only to the explicitly opted-in research test.
+
+#### 0.8.5 source block-FP8 W8A16 gate
+
+The compile check proves that the wheel carries and builds the ABI. It does not
+prove activation semantics, bounded residency, DSV4 grouping, graph behavior,
+quality, or speed. Before tagging 0.8.5, run the focused GPU suite against that
+same installed wheel on the Spark release device. Stage these test files and
+their test-only helpers outside the checkout and run from that staging
+directory, so the repository cannot shadow the wheel:
+
+```bash
+python -m pytest -q \
+  tests/test_fp8_source_w8a16.py \
+  tests/test_fp8_source_w8a16_cuda.py \
+  tests/test_source_passthrough.py \
+  tests/test_dsv4_woa.py \
+  tests/test_mixed_fused_linear.py
+```
+
+Zero failures and zero relevant skips are required. The gate must cover all of
+the following; a CPU-only skip does not count:
+
+- fp8_source_gemv against an independent dequantize-plus-FP64/FP32 oracle at
+  M in {1,2,4,8}, including scale-block boundaries and every distinct
+  DSV4-Flash source shape;
+- fp8_source_expand_bf16 against an independent raw-E4M3/UE8M0 decoder,
+  including exact BF16 transient values, then its output through
+  cb_bf16_grouped_mm;
+- dense and grouped (G=8,N=1024,K=4096) DSV4 wo_a, at decode and
+  representative prefill M, with tp=1, group isolation, and invalid geometry
+  refusal;
+- unchanged BF16 activation tensors and a source dispatch that cannot call
+  activation QDQ, mxfp8_dense_mm, PyTorch matmul, cuBLAS, or Triton;
+- resident raw E4M3 weight plus UE8M0 scale only, with no persistent BF16
+  duplicate and the one-layer large-M transient released after the call;
+- eager/fullgraph opacity and FULL_DECODE_ONLY replay at [1,2,4,8], with
+  changed inputs and eager-versus-capture output equality; and
+- load-time refusal for missing/stale source symbols, an unavailable grouped
+  BF16 bridge, unsupported device/dtype/shape, and bias.
+
+Then load and serve the **exact final DSV4-Flash artifact**, not a synthetic
+submodule, in both the intended eager configuration and mode-0
+FULL_DECODE_ONLY. Bind the final whole-directory inventory and a complete
+gridbook.execution-manifest.v1 to the reports. Every block-128 source
+assignment must say W8A16; direct MXFP8 g32 assignments, if any, must remain
+W8A8. Retain the bound producer/export compatibility evidence plus closed
+startup/dispatch logs proving:
+
+1. the v3 feature source_fp8_block128_w8a16=1 was required by the producer;
+2. source decode dispatched fp8_source_gemv;
+3. source prefill dispatched fp8_source_expand_bf16 followed by
+   cb_bf16_grouped_mm;
+4. DSV4 wo_a used the grouped W8A16 adapter; and
+5. no source unit fell back or entered mxfp8_dense_mm/activation QDQ.
+
+Use fixed prompts to compare eager and graph tokens plus per-token logprobs, and
+run the workload matrix in NATIVE-PARITY.md with byte, resident-memory,
+peak-scratch, TTFT, ITL, and throughput limits declared **before** inspecting
+the results. Record every block and the exact GPU/runtime/image identities.
+Historical W8A8 block-128 results are a different activation contract and
+cannot satisfy any W8A16 quality or performance cell. Until these artifacts are
+attached and their predeclared limits pass, the route is implemented but the
+0.8.5 release gate is open; do not tag or claim served parity/performance.
 
 The fused FP4 extension also requires the GPU operator/SASS suite from an
 installed wheel. Stage `tests/test_fused_fp4_prefill.py` outside the checkout,
@@ -196,7 +278,7 @@ split-toolkit images may contain only `cuda-cuobjdump`; install the matching
 the validation container. A missing or older disassembler is a failed release
 environment, not a skipped kernel gate.
 
-If the command prints all five extension modules and passes the native-op
+If the command prints all nine extension modules and passes the native-op
 attestation, the installed wheel's native serving floor is genuinely sound.
 Two ways it can fail, and they mean different things:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -255,6 +255,13 @@ startup/dispatch logs proving:
 4. DSV4 wo_a used the grouped W8A16 adapter; and
 5. no source unit fell back or entered mxfp8_dense_mm/activation QDQ.
 
+The source method writes this proof through Gridbook's existing latest-route
+telemetry: `contract=bf16_preserved`; decode names `fp8_source_gemv`; prefill
+names `fp8_source_expand_bf16+cb_bf16_grouped_mm`; and the two-phase state
+remains `error` if either launch chain raises. Exact-artifact evidence must read
+these records from the loaded layers rather than infer dispatch from format
+metadata.
+
 Use fixed prompts to compare eager and graph tokens plus per-token logprobs, and
 run the workload matrix in NATIVE-PARITY.md with byte, resident-memory,
 peak-scratch, TTFT, ITL, and throughput limits declared **before** inspecting

--- a/gridbook/__init__.py
+++ b/gridbook/__init__.py
@@ -14,7 +14,7 @@ package without vLLM installed.
 # Single source of truth for package and release metadata. Gridbook is the sole
 # owner of its runtime; producer repositories consume a released version or an
 # immutable commit and never mirror this package tree.
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 
 def register() -> None:

--- a/gridbook/csrc/fp8_source_w8a16.cu
+++ b/gridbook/csrc/fp8_source_w8a16.cu
@@ -1,0 +1,268 @@
+// Native W8A16 execution for verbatim DeepSeek block-128 source FP8 weights.
+//
+// Resident state remains exactly the checkpoint's E4M3 [N,K] value plane and
+// UE8M0 [ceil(N/128), ceil(K/128)] scale plane.  Decode (M<=8) streams those
+// bytes directly through a bandwidth-bound GEMV.  Prefill expands one bounded
+// layer tile to BF16 for Gridbook's owned CUTLASS BF16 bridge; the tile is
+// caller-scoped and never becomes resident model state.
+//
+// Both paths reconstruct each weight identically:
+//
+//   w_bf16 = bf16_rn(e4m3(value_byte) * 2^(scale_byte - 127))
+//
+// GEMV converts that BF16 value back to FP32 before FMA, matching a BF16 GEMM
+// consuming the expanded tile.  Activations enter as BF16 and are never QDQ'd.
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+constexpr int kThreads = 256;
+constexpr int kWarps = kThreads / 32;
+constexpr int kBlock = 128;
+constexpr int kMaxM = 8;
+
+__device__ __forceinline__ float bf16_to_f32(uint16_t bits) {
+  __nv_bfloat16_raw raw;
+  raw.x = bits;
+  return __bfloat162float(__nv_bfloat16(raw));
+}
+
+__device__ __forceinline__ uint16_t f32_to_bf16_rn(float value) {
+  return __bfloat16_as_ushort(__float2bfloat16_rn(value));
+}
+
+__device__ __forceinline__ float e4m3_to_f32(uint8_t bits) {
+  return __half2float(
+      __nv_cvt_fp8_to_halfraw((__nv_fp8_storage_t)bits, __NV_E4M3));
+}
+
+__device__ __forceinline__ float ue8m0_to_f32(uint8_t bits) {
+  // float8_e8m0fnu reserves 0xff as NaN.  Every other byte is exactly
+  // 2^(byte-127), including byte zero (2^-127).
+  return bits == 0xffu ? __int_as_float(0x7f800001)
+                       : ldexpf(1.0f, int(bits) - 127);
+}
+
+template <int MT>
+__global__ __launch_bounds__(kThreads) void fp8_source_gemv_kernel(
+    const uint16_t* __restrict__ x,       // [M,G,K] BF16
+    const uint8_t* __restrict__ q,        // [N,K] E4M3 bytes
+    const uint8_t* __restrict__ scales,   // [ceil(N/128),ceil(K/128)]
+    uint16_t* __restrict__ out,           // [M,N] BF16
+    int m, int groups, int n_total, int k, int scale_cols) {
+  const int n = int(blockIdx.x);
+  const int group_rows = n_total / groups;
+  const int group = n / group_rows;
+  const int scale_row = n / kBlock;
+
+  extern __shared__ uint8_t scale_cache[];
+  for (int col = int(threadIdx.x); col < scale_cols; col += kThreads) {
+    scale_cache[col] = scales[scale_row * scale_cols + col];
+  }
+  __shared__ float warp_partial[kMaxM][kWarps];
+  __syncthreads();
+
+  float accum[MT];
+#pragma unroll
+  for (int row = 0; row < MT; ++row) {
+    accum[row] = 0.0f;
+  }
+
+  const uint8_t* q_row = q + int64_t(n) * k;
+  for (int col = int(threadIdx.x); col < k; col += kThreads) {
+    const float scale = ue8m0_to_f32(scale_cache[col / kBlock]);
+    const float decoded = e4m3_to_f32(q_row[col]) * scale;
+    // Establish the W8A16 weight value exactly once, just as the transient
+    // expander does before the CUTLASS bridge consumes it.
+    const float weight = bf16_to_f32(f32_to_bf16_rn(decoded));
+#pragma unroll
+    for (int row = 0; row < MT; ++row) {
+      if (row < m) {
+        const int64_t x_index =
+            (int64_t(row) * groups + group) * k + col;
+        accum[row] = fmaf(weight, bf16_to_f32(x[x_index]), accum[row]);
+      }
+    }
+  }
+
+  const int lane = int(threadIdx.x) & 31;
+  const int warp = int(threadIdx.x) >> 5;
+#pragma unroll
+  for (int row = 0; row < MT; ++row) {
+    float value = accum[row];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_down_sync(0xffffffffu, value, offset);
+    }
+    if (lane == 0) {
+      warp_partial[row][warp] = value;
+    }
+  }
+  __syncthreads();
+
+  if (warp == 0) {
+#pragma unroll
+    for (int row = 0; row < MT; ++row) {
+      float value = lane < kWarps ? warp_partial[row][lane] : 0.0f;
+#pragma unroll
+      for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffu, value, offset);
+      }
+      if (lane == 0 && row < m) {
+        out[int64_t(row) * n_total + n] = f32_to_bf16_rn(value);
+      }
+    }
+  }
+}
+
+__global__ __launch_bounds__(kThreads) void fp8_source_expand_kernel(
+    const uint8_t* __restrict__ q,
+    const uint8_t* __restrict__ scales,
+    uint16_t* __restrict__ out,
+    int n_total, int k, int scale_cols) {
+  const int n = int(blockIdx.x);
+  const int scale_row = n / kBlock;
+  extern __shared__ uint8_t scale_cache[];
+  for (int col = int(threadIdx.x); col < scale_cols; col += kThreads) {
+    scale_cache[col] = scales[scale_row * scale_cols + col];
+  }
+  __syncthreads();
+
+  const int64_t row = int64_t(n) * k;
+  for (int col = int(threadIdx.x); col < k; col += kThreads) {
+    const float decoded =
+        e4m3_to_f32(q[row + col]) *
+        ue8m0_to_f32(scale_cache[col / kBlock]);
+    out[row + col] = f32_to_bf16_rn(decoded);
+  }
+}
+
+void check_source_planes(const torch::Tensor& q,
+                         const torch::Tensor& scales) {
+  TORCH_CHECK(q.is_cuda() && scales.is_cuda(),
+              "FP8 source value and scale planes must be CUDA tensors");
+  TORCH_CHECK(q.device() == scales.device(),
+              "FP8 source value and scale planes must share one CUDA device");
+  TORCH_CHECK(q.scalar_type() == torch::kFloat8_e4m3fn,
+              "FP8 source value plane must be float8_e4m3fn");
+  TORCH_CHECK(scales.scalar_type() == torch::kUInt8 ||
+                  scales.scalar_type() == torch::kFloat8_e8m0fnu,
+              "FP8 source scale plane must be uint8/float8_e8m0fnu");
+  TORCH_CHECK(q.dim() == 2 && scales.dim() == 2,
+              "expected FP8 source q [N,K] and scales [ceil(N/128),"
+              "ceil(K/128)]");
+  TORCH_CHECK(q.is_contiguous() && scales.is_contiguous(),
+              "FP8 source value and scale planes must be contiguous");
+
+  const int64_t n = q.size(0);
+  const int64_t k = q.size(1);
+  TORCH_CHECK(n > 0 && k > 0,
+              "FP8 source value plane must have positive N and K");
+  TORCH_CHECK(scales.size(0) == (n + kBlock - 1) / kBlock &&
+                  scales.size(1) == (k + kBlock - 1) / kBlock,
+              "FP8 source block128 scale shape does not match q [N,K]");
+  TORCH_CHECK(n <= std::numeric_limits<int>::max() &&
+                  k <= std::numeric_limits<int>::max(),
+              "FP8 source dimensions exceed int32");
+}
+
+torch::Tensor fp8_source_gemv(torch::Tensor x,
+                              torch::Tensor q,
+                              torch::Tensor scales,
+                              int64_t groups64) {
+  check_source_planes(q, scales);
+  TORCH_CHECK(x.is_cuda() && x.device() == q.device(),
+              "FP8 source activation must be on the planes' CUDA device");
+  TORCH_CHECK(x.scalar_type() == torch::kBFloat16,
+              "FP8 source W8A16 GEMV requires BF16 activations");
+  TORCH_CHECK(x.dim() == 3 && x.is_contiguous(),
+              "FP8 source W8A16 GEMV expects contiguous x [M,G,K]");
+  TORCH_CHECK(groups64 > 0 && groups64 <= std::numeric_limits<int>::max(),
+              "FP8 source W8A16 groups must be a positive int32 value");
+
+  const int64_t m64 = x.size(0);
+  const int64_t groups = groups64;
+  const int64_t n64 = q.size(0);
+  const int64_t k64 = q.size(1);
+  TORCH_CHECK(m64 >= 1 && m64 <= kMaxM,
+              "FP8 source W8A16 GEMV owns 1 <= M <= ", kMaxM,
+              ", got M=", m64);
+  TORCH_CHECK(x.size(1) == groups && x.size(2) == k64,
+              "FP8 source activation shape must be [M,groups,K]");
+  TORCH_CHECK(n64 % groups == 0,
+              "FP8 source output rows N must be divisible by groups");
+
+  const c10::cuda::OptionalCUDAGuard guard(x.device());
+  auto output = torch::empty({m64, n64}, x.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const int m = int(m64);
+  const int g = int(groups);
+  const int n = int(n64);
+  const int k = int(k64);
+  const int scale_cols = int(scales.size(1));
+  const size_t shared_bytes = size_t(scale_cols) * sizeof(uint8_t);
+
+#define LAUNCH_SOURCE_GEMV(MT)                                             \
+  fp8_source_gemv_kernel<MT><<<(unsigned)n, kThreads, shared_bytes, stream>>>(\
+      reinterpret_cast<const uint16_t*>(x.data_ptr()),                     \
+      reinterpret_cast<const uint8_t*>(q.data_ptr()),                      \
+      reinterpret_cast<const uint8_t*>(scales.data_ptr()),                 \
+      reinterpret_cast<uint16_t*>(output.data_ptr()),                      \
+      m, g, n, k, scale_cols)
+  switch (m) {
+    case 1: LAUNCH_SOURCE_GEMV(1); break;
+    case 2: LAUNCH_SOURCE_GEMV(2); break;
+    case 3: LAUNCH_SOURCE_GEMV(3); break;
+    case 4: LAUNCH_SOURCE_GEMV(4); break;
+    case 5: LAUNCH_SOURCE_GEMV(5); break;
+    case 6: LAUNCH_SOURCE_GEMV(6); break;
+    case 7: LAUNCH_SOURCE_GEMV(7); break;
+    case 8: LAUNCH_SOURCE_GEMV(8); break;
+    default: TORCH_CHECK(false, "unreachable FP8 source GEMV M");
+  }
+#undef LAUNCH_SOURCE_GEMV
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return output;
+}
+
+torch::Tensor fp8_source_expand_bf16(torch::Tensor q,
+                                     torch::Tensor scales) {
+  check_source_planes(q, scales);
+  const c10::cuda::OptionalCUDAGuard guard(q.device());
+  const int n = int(q.size(0));
+  const int k = int(q.size(1));
+  const int scale_cols = int(scales.size(1));
+  auto output = torch::empty(q.sizes(), q.options().dtype(torch::kBFloat16));
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const size_t shared_bytes = size_t(scale_cols) * sizeof(uint8_t);
+  fp8_source_expand_kernel<<<(unsigned)n, kThreads, shared_bytes, stream>>>(
+      reinterpret_cast<const uint8_t*>(q.data_ptr()),
+      reinterpret_cast<const uint8_t*>(scales.data_ptr()),
+      reinterpret_cast<uint16_t*>(output.data_ptr()),
+      n, k, scale_cols);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return output;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("fp8_source_gemv", &fp8_source_gemv,
+        "Raw-resident block128 FP8 x BF16 activation GEMV (W8A16)",
+        pybind11::arg("x"), pybind11::arg("q"), pybind11::arg("scales"),
+        pybind11::arg("groups"));
+  m.def("fp8_source_expand_bf16", &fp8_source_expand_bf16,
+        "Bounded block128 FP8 -> BF16 source-weight expansion",
+        pybind11::arg("q"), pybind11::arg("scales"));
+}

--- a/gridbook/csrc/fp8_source_w8a16.cu
+++ b/gridbook/csrc/fp8_source_w8a16.cu
@@ -202,6 +202,10 @@ torch::Tensor fp8_source_gemv(torch::Tensor x,
               "FP8 source activation shape must be [M,groups,K]");
   TORCH_CHECK(n64 % groups == 0,
               "FP8 source output rows N must be divisible by groups");
+  TORCH_CHECK(k64 % 8 == 0,
+              "FP8 source W8A16 GEMV needs K divisible by 8");
+  TORCH_CHECK((n64 / groups) % 8 == 0,
+              "FP8 source W8A16 GEMV needs per-group N divisible by 8");
 
   const c10::cuda::OptionalCUDAGuard guard(x.device());
   auto output = torch::empty({m64, n64}, x.options());

--- a/gridbook/csrc/mxfp8_dense_gemm.cu
+++ b/gridbook/csrc/mxfp8_dense_gemm.cu
@@ -1,16 +1,11 @@
 // MXFP8 dense W8A8 block-scaled GEMM (sm120/sm121).
 //
-// Serves two producer spellings of the SAME on-device format — E4M3 elements
-// with one UE8M0 (F8_E8M0) exponent scale per 32 contiguous K elements:
-//
-//  * ``mxfp8_e4m3_e8m0_g32``: producer-emitted MXFP8, scales stored row-major
-//    [rows, ceil(K/32)] on disk;
-//  * ``fp8_e4m3_ue8m0_block128``: DeepSeek-convention block quantization
-//    (one UE8M0 scale per 128x128 tile).  128 = 4 * 32, so a 32-wide MX chunk
-//    never straddles a block boundary and the block form embeds EXACTLY into
-//    MXFP8 by pure scale replication: SF_mx[n, c] = S_ds[n // 128, c // 4].
-//    No element byte changes, no scale arithmetic, no rounding.  The Python
-//    lane (gridbook/mxfp8.py) performs that broadcast at model load.
+// Serves only producer-emitted ``mxfp8_e4m3_e8m0_g32``: E4M3 elements with
+// one UE8M0 (F8_E8M0) exponent scale per 32 contiguous K elements, stored
+// row-major [rows, ceil(K/32)] on disk.  DeepSeek's
+// ``fp8_e4m3_ue8m0_block128`` wire is a distinct W8A16 contract and is
+// deliberately rejected by mxfp8_dense_lane.py; it is served by the raw-plane
+// fp8_source_w8a16.cu path with unchanged BF16 activations.
 //
 // The GEMM itself is the STOCK sm120 block-scaled CollectiveBuilder mainloop —
 // kind::mxf8f6f4 with hardware SF application every 32 elements — the one

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -1950,12 +1950,30 @@ def require_fp8_source_w8a16_ext(operation: str = "this operation",
             f"{operation} requires the source-FP8 W8A16 lane release-gated "
             f"for compute capability 12.1; this device reports {rendered}.")
     built_for = getattr(ext, "__gridbook_jit_capability__", None)
-    if built_for is not None and tuple(built_for) != tuple(capability):
+    if built_for is None:
+        raise NativeKernelUnavailableError(
+            f"{operation} found a source-FP8 W8A16 module without Gridbook's "
+            "JIT build-capability identity. Gridbook cannot prove that the "
+            f"module targets this device ({capability[0]}.{capability[1]}) "
+            "and refuses the load.")
+    if tuple(built_for) != tuple(capability):
         raise NativeKernelUnavailableError(
             f"{operation} found a source-FP8 W8A16 module built for compute "
             f"capability {built_for[0]}.{built_for[1]}, but this device "
             f"reports {capability[0]}.{capability[1]}. Serve each capability "
             "from its own process; Gridbook refuses a cross-device launch.")
+    identity = getattr(ext, "__gridbook_jit_identity__", None)
+    abi_schema = getattr(ext, "__gridbook_jit_abi_schema__", None)
+    if (
+        not isinstance(identity, str)
+        or len(identity) != 64
+        or any(char not in "0123456789abcdef" for char in identity)
+        or abi_schema != _FP8_SOURCE_W8A16_ABI_SCHEMA
+    ):
+        raise NativeKernelUnavailableError(
+            f"{operation} found a source-FP8 W8A16 module without the exact "
+            "Gridbook source/toolchain identity and ABI schema. Gridbook "
+            "refuses an unbound or stale JIT module.")
     return ext
 
 

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -18,16 +18,17 @@ extension build fails.
 Build cache: ``PRISMAQUANT_CB_EXT_DIR`` if set, else ``~/.cache/prismaquant-
 cb-ext``. EVERY module builds in its own subdirectory of that root — ``main``,
 ``v2``, ``bf16_grouped/<identity>``, ``fused/<identity>``,
-``fused_fp4/<identity>``, ``fused_fp4v2/<identity>`` and
-``moe_persistent_b/<identity>``, seven in all — so no two ninja workspaces
-share artefacts. Inside the container the root is ephemeral, so a cold start
+``fused_fp4/<identity>``, ``fused_fp4v2/<identity>``,
+``mxfp8_dense/<identity>``, ``fp8_source_w8a16/<identity>`` and
+``moe_persistent_b/<identity>``, nine in all — so no two ninja workspaces share
+artefacts. Inside the container the root is ephemeral, so a cold start
 pays ONE build per module it actually reaches; mount a host dir over it to
 persist those builds across restarts. Never ``/tmp``. There is deliberately no
 single build-time figure here: the modules differ by more than an order of
 magnitude in compile cost (the CUTLASS collectives dominate the hand-written
 CUDA), what a given serve reaches depends on format and opt-in flags, and the
 one measurement this docstring used to quote was taken against a single module
-before five of the seven existed. ``docs/CONTAINER.md`` carries the measured
+before seven of the nine existed. ``docs/CONTAINER.md`` carries the measured
 image-build numbers.
 
 Architecture: every module is compiled for exactly the live device's compute
@@ -46,11 +47,12 @@ module. Strict call contracts use :func:`_require_symbols`; fused FP4 uses
 independent symbol families because its dense and grouped call sites are
 separately guarded. An incompatible module would otherwise fail with
 ``AttributeError`` mid-forward, or silently disable a probed fast path. The
-five digest-keyed modules — ``fused`` (FP8), ``fused_fp4``, ``bf16_grouped``,
-``fused_fp4v2`` and ``moe_persistent_b`` — additionally hash their packaged
+seven digest-keyed modules — ``fused`` (FP8), ``fused_fp4``, ``bf16_grouped``,
+``fused_fp4v2``, ``mxfp8_dense``, ``fp8_source_w8a16`` and
+``moe_persistent_b`` — additionally hash their packaged
 sources, Gridbook headers (transitively: a header reached only through another
 Gridbook header counts), target, compiled-in lane macros and toolchain ABI
-into the module name and build directory, so a loaded module of those five is
+into the module name and build directory, so a loaded module of those seven is
 always built from the current sources. ``main`` and ``v2`` are not keyed that
 way: they include no Gridbook header, so torch's own versioner over the
 ``.cu`` is already complete for them.
@@ -913,8 +915,8 @@ def _load_bf16_grouped_ext_locked():
 # file remains authoritative for the complete external include graph.
 # --------------------------------------------------------------------------
 def _fused_build_identity(torch, cpp_extension, *, src_dir: str,
-                          cutlass_include: str,
-                          util_include: str,
+                          cutlass_include: str | None,
+                          util_include: str | None,
                           capability: tuple[int, int],
                           build_inputs: tuple[str, ...],
                           bindings,
@@ -954,18 +956,20 @@ def _fused_build_identity(torch, cpp_extension, *, src_dir: str,
         name: _sha256_file(os.path.join(src_dir, name))
         for name in build_inputs
     }
-    cutlass_inputs = {}
-    for label, path in (
-        ("cutlass/cutlass.h",
-         os.path.join(cutlass_include, "cutlass", "cutlass.h")),
-        ("cutlass/version.h",
-         os.path.join(cutlass_include, "cutlass", "version.h")),
-        ("cutlass/util/packed_stride.hpp",
-         os.path.join(util_include, "cutlass", "util",
-                      "packed_stride.hpp")),
-    ):
-        cutlass_inputs[label] = (
-            _sha256_file(path) if os.path.isfile(path) else None)
+    cutlass_inputs = None
+    if cutlass_include is not None and util_include is not None:
+        cutlass_inputs = {}
+        for label, path in (
+            ("cutlass/cutlass.h",
+             os.path.join(cutlass_include, "cutlass", "cutlass.h")),
+            ("cutlass/version.h",
+             os.path.join(cutlass_include, "cutlass", "version.h")),
+            ("cutlass/util/packed_stride.hpp",
+             os.path.join(util_include, "cutlass", "util",
+                          "packed_stride.hpp")),
+        ):
+            cutlass_inputs[label] = (
+                _sha256_file(path) if os.path.isfile(path) else None)
 
     major, minor = capability
     compute, code = _arch_target((major, minor), accelerated=accelerated)
@@ -975,7 +979,6 @@ def _fused_build_identity(torch, cpp_extension, *, src_dir: str,
             [label, list(names)] for label, names in bindings
         ],
         "inputs": packaged_inputs,
-        "cutlass_inputs": cutlass_inputs,
         "target": {
             "capability": [major, minor],
             "compute": compute,
@@ -1013,6 +1016,8 @@ def _fused_build_identity(torch, cpp_extension, *, src_dir: str,
         "host_compiler": _compiler_identity(
             None if cxx is None else os.fspath(cxx)),
     }
+    if cutlass_inputs is not None:
+        payload["cutlass_inputs"] = cutlass_inputs
     if defines:
         payload["defines"] = {str(k): str(v) for k, v in defines.items()}
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"),
@@ -1181,7 +1186,7 @@ def preload_native_extensions(*, strict: bool = False) -> dict[str, bool]:
     docs/KERNELS.md "a measurement side-effect worth knowing"), so an arm that
     warms only the two fused modules is still residency-MISmatched against an
     arm that later touches ``cb_gemv_v2`` or the grouped BF16 bridge. This
-    warms every loader in ``_PRELOAD_FAMILIES`` — all seven modules — so both
+    warms every loader in ``_PRELOAD_FAMILIES`` — all nine modules — so both
     arms of an A/B carry the same set (2026-08-01 performance audit §3 P4,
     "preload completeness").
 
@@ -1712,12 +1717,11 @@ def get_mxfp8_dense_ext():
     """The MXFP8 dense W8A8 block-scaled extension (mxfp8_dense_gemm.cu), or
     None.
 
-    Serves two wire spellings of one on-device format: producer-emitted MXFP8
-    (``mxfp8_e4m3_e8m0_g32``) and DeepSeek block-128 FP8
-    (``fp8_e4m3_ue8m0_block128``), the latter embedded exactly by scale
-    replication at load (gridbook/mxfp8.py).  Fail-soft here, fail-closed at
-    the lane: ``mxfp8_dense_lane`` attests symbols, device and built-for
-    capability via ``lane_select.require_lane`` before any unit is served.
+    Serves only producer-emitted ``mxfp8_e4m3_e8m0_g32``.  The DeepSeek
+    block-128 source wire is W8A16 and belongs exclusively to the separate
+    ``fp8_source_w8a16`` module.  Fail-soft here, fail-closed at the lane:
+    ``mxfp8_dense_lane`` attests symbols, device and built-for capability via
+    ``lane_select.require_lane`` before any unit is served.
     """
     if _mxfp8_dense_tried:
         return _mxfp8_dense
@@ -1802,6 +1806,163 @@ def _load_mxfp8_dense_ext_locked():
 _PRELOAD_FAMILIES.append(("mxfp8_dense", "get_mxfp8_dense_ext"))
 # ===========================================================================
 # END ADDITIVE BLOCK — MXFP8 dense block-scaled loader
+# ===========================================================================
+# BEGIN ADDITIVE BLOCK — raw-resident block128 source-FP8 W8A16 loader.
+#
+# This module intentionally has no CUTLASS dependency.  Its decode kernel
+# streams the checkpoint's E4M3 + UE8M0 planes directly; its second symbol
+# expands one caller-scoped BF16 tile for the existing owned grouped-BF16
+# bridge.  Keeping it separate from the MXFP8 W8A8 module makes activation
+# numerics part of the attested module contract instead of a runtime branch.
+# ===========================================================================
+_fp8_source_w8a16 = None
+_fp8_source_w8a16_tried = False
+_fp8_source_w8a16_lock = threading.Lock()
+
+_FP8_SOURCE_W8A16_BUILD_INPUTS = ("fp8_source_w8a16.cu",)
+_FP8_SOURCE_W8A16_ABI_SCHEMA = 1
+_FP8_SOURCE_W8A16_SYMBOLS = (
+    "fp8_source_gemv",
+    "fp8_source_expand_bf16",
+)
+# Spark / GB10 is this release's sole target.  The source is architecture-
+# generic CUDA, but admission stays limited while measured release evidence
+# is pending rather than silently creating another serving lane.
+_FP8_SOURCE_W8A16_CAPABILITIES = ((12, 1),)
+
+
+def fp8_source_w8a16_buildable(capability) -> bool:
+    """Whether raw-resident source-FP8 W8A16 is audited for ``capability``."""
+    return tuple(capability) in _FP8_SOURCE_W8A16_CAPABILITIES
+
+
+def _fp8_source_w8a16_build_identity(torch, cpp_extension, *, src_dir: str,
+                                      capability: tuple[int, int]):
+    """``(digest, payload)`` for the source-FP8 W8A16 module's ABI."""
+    return _fused_build_identity(
+        torch, cpp_extension, src_dir=src_dir,
+        cutlass_include=None, util_include=None,
+        capability=capability,
+        build_inputs=_FP8_SOURCE_W8A16_BUILD_INPUTS,
+        bindings=(("source FP8 W8A16", _FP8_SOURCE_W8A16_SYMBOLS),),
+        abi_schema=_FP8_SOURCE_W8A16_ABI_SCHEMA,
+        accelerated=False)
+
+
+def get_fp8_source_w8a16_ext():
+    """Return the raw-resident block128 source-FP8 W8A16 module, or None.
+
+    This loader remains fail-soft for capability probes and preload inventory.
+    Model construction uses :func:`require_fp8_source_w8a16_ext` and therefore
+    refuses the unit before serving if the exact native contract is absent.
+    """
+    if _fp8_source_w8a16_tried:
+        return _fp8_source_w8a16
+    with _fp8_source_w8a16_lock:
+        if _fp8_source_w8a16_tried:
+            return _fp8_source_w8a16
+        return _load_fp8_source_w8a16_ext_locked()
+
+
+def _load_fp8_source_w8a16_ext_locked():
+    """Build/publish source-FP8 W8A16 with its loader lock held."""
+    global _fp8_source_w8a16, _fp8_source_w8a16_tried
+    build_dir = "<unresolved>"
+    try:
+        import torch  # noqa: F401  (must import before cpp_extension)
+        from torch.utils import cpp_extension
+
+        cc = _target_capability(
+            "the raw-resident source-FP8 W8A16 extension "
+            "(fp8_source_w8a16.cu)")
+        if not fp8_source_w8a16_buildable(cc):
+            raise RuntimeError(
+                "raw-resident source-FP8 W8A16 is release-gated only for "
+                f"compute capability 12.1, got {cc[0]}.{cc[1]}")
+        src_dir = _require_csrc(*_FP8_SOURCE_W8A16_BUILD_INPUTS)
+        identity, _identity_payload = _fp8_source_w8a16_build_identity(
+            torch, cpp_extension, src_dir=src_dir, capability=cc)
+        module_name = f"pq_fp8_source_w8a16_{identity}"
+        build_root = (os.environ.get("PRISMAQUANT_CB_EXT_DIR") or os.path.join(
+            os.path.expanduser("~"), ".cache", "prismaquant-cb-ext"))
+        build_dir = os.path.join(build_root, "fp8_source_w8a16", identity)
+        os.makedirs(build_dir, exist_ok=True)
+        mod = cpp_extension.load(
+            name=module_name,
+            sources=[os.path.join(src_dir, "fp8_source_w8a16.cu")],
+            extra_include_paths=[src_dir],
+            extra_cuda_cflags=[
+                "-O3", _gencode_flag(cc, accelerated=False),
+            ],
+            build_directory=build_dir,
+            verbose=False)
+        mod = _require_symbols(
+            mod, _FP8_SOURCE_W8A16_SYMBOLS, build_dir=build_dir,
+            source="fp8_source_w8a16.cu")
+        _fp8_source_w8a16 = _require_fused_identity(
+            mod, expected_name=module_name, identity=identity,
+            abi_schema=_FP8_SOURCE_W8A16_ABI_SCHEMA,
+            build_dir=build_dir, source="fp8_source_w8a16.cu",
+            capability=cc)
+    except StaleExtensionError as exc:
+        print("[prismaquant-cb] ERROR: incompatible source-FP8 W8A16 "
+              f"extension — {exc} Source-FP8 units stay refused "
+              "(fail-closed).", file=sys.stderr, flush=True)
+        _fp8_source_w8a16 = None
+    except IncompleteInstallError as exc:
+        print(f"[prismaquant-cb] ERROR: broken gridbook install — {exc} "
+              "Source-FP8 W8A16 units stay refused (fail-closed).",
+              file=sys.stderr, flush=True)
+        _fp8_source_w8a16 = None
+    except Exception as exc:  # noqa: BLE001 — capability probe is fail-soft
+        print("[prismaquant-cb] WARNING: source-FP8 W8A16 extension "
+              f"unavailable ({type(exc).__name__}: {exc}); source-FP8 units "
+              "will refuse at load (expected off cc 12.1 and without nvcc). "
+              f"To enable the native path: {_NVCC_HINT}.",
+              file=sys.stderr, flush=True)
+        _fp8_source_w8a16 = None
+    finally:
+        _fp8_source_w8a16_tried = True
+    return _fp8_source_w8a16
+
+
+def require_fp8_source_w8a16_ext(operation: str = "this operation",
+                                  device=None):
+    """Return the exact source-FP8 W8A16 module or fail at model load."""
+    from .lane_select import device_capability
+
+    capability = device_capability(device)
+    ext = get_fp8_source_w8a16_ext()
+    missing = [name for name in _FP8_SOURCE_W8A16_SYMBOLS
+               if ext is None or not hasattr(ext, name)]
+    if missing:
+        raise NativeKernelUnavailableError(
+            f"{operation} requires Gridbook's native raw-resident "
+            "source-FP8 W8A16 extension (fp8_source_w8a16.cu), but it is "
+            f"unavailable or incomplete (missing {missing}; device "
+            f"capability {capability}). Gridbook does not expand weights "
+            "persistently, quantize activations, or fall back to torch. "
+            f"To enable the native path: {_NVCC_HINT}.")
+    if capability is None or not fp8_source_w8a16_buildable(capability):
+        rendered = ("unavailable" if capability is None else
+                    f"{capability[0]}.{capability[1]}")
+        raise NativeKernelUnavailableError(
+            f"{operation} requires the source-FP8 W8A16 lane release-gated "
+            f"for compute capability 12.1; this device reports {rendered}.")
+    built_for = getattr(ext, "__gridbook_jit_capability__", None)
+    if built_for is not None and tuple(built_for) != tuple(capability):
+        raise NativeKernelUnavailableError(
+            f"{operation} found a source-FP8 W8A16 module built for compute "
+            f"capability {built_for[0]}.{built_for[1]}, but this device "
+            f"reports {capability[0]}.{capability[1]}. Serve each capability "
+            "from its own process; Gridbook refuses a cross-device launch.")
+    return ext
+
+
+_PRELOAD_FAMILIES.append(
+    ("fp8_source_w8a16", "get_fp8_source_w8a16_ext"))
+# ===========================================================================
+# END ADDITIVE BLOCK — raw-resident block128 source-FP8 W8A16 loader
 # ===========================================================================
 # BEGIN ADDITIVE BLOCK — persistent-B grouped MoE loader (ROADMAP K1.1, audit
 # §3 P2b).  Self-contained: it adds module-level globals, constants and three

--- a/gridbook/cuda_ext.py
+++ b/gridbook/cuda_ext.py
@@ -1666,8 +1666,8 @@ def _load_fused_fp4v2_ext_locked():
     return _fused_fp4v2
 # =========================== END P2a BLOCK ========================================
 # ===========================================================================
-# BEGIN ADDITIVE BLOCK — MXFP8 dense block-scaled loader (task: MXFP8 lane;
-# serves producer MXFP8 and the DeepSeek fp8-ue8m0-block128 embedding).
+# BEGIN ADDITIVE BLOCK — direct-g32 MXFP8 dense block-scaled loader.
+# DeepSeek's block128 source-FP8 wire is owned by the separate W8A16 loader.
 # Self-contained: adds module-level globals, constants and three functions,
 # and modifies nothing above.
 # ===========================================================================
@@ -1780,18 +1780,18 @@ def _load_mxfp8_dense_ext_locked():
             capability=cc)
     except StaleExtensionError as exc:
         print(f"[prismaquant-cb] ERROR: incompatible MXFP8 dense extension — "
-              f"{exc} MXFP8/DeepSeek-FP8 passthrough units stay refused "
+              f"{exc} Direct-g32 MXFP8 units stay refused "
               f"(fail-closed).", file=sys.stderr, flush=True)
         _mxfp8_dense = None
     except IncompleteInstallError as exc:
         print(f"[prismaquant-cb] ERROR: broken gridbook install — {exc} "
-              f"MXFP8/DeepSeek-FP8 passthrough units stay refused "
+              f"Direct-g32 MXFP8 units stay refused "
               f"(fail-closed).", file=sys.stderr, flush=True)
         _mxfp8_dense = None
     except Exception as exc:  # noqa: BLE001 — capability probe is fail-soft
         print(f"[prismaquant-cb] WARNING: MXFP8 dense extension unavailable "
-              f"({type(exc).__name__}: {exc}); MXFP8/DeepSeek-FP8 passthrough "
-              f"units will refuse at load (expected off cc 12.0/12.1 and "
+              f"({type(exc).__name__}: {exc}); direct-g32 MXFP8 units will "
+              f"refuse at load (expected off cc 12.0/12.1 and "
               f"without nvcc). To enable the native path: {_NVCC_HINT}.",
               file=sys.stderr, flush=True)
         _mxfp8_dense = None

--- a/gridbook/dsv4_woa.py
+++ b/gridbook/dsv4_woa.py
@@ -1,15 +1,15 @@
 """DeepSeek-V4 ``wo_a`` adapter for Gridbook-owned BMM linears.
 
-The qualified eugr Spark vLLM baseline
-(``0.26.1rc1.dev515+g653ebb52d.d20260808``) does not call ``self.wo_a`` from
-NVIDIA DSV4 attention.  Its specialized output projection reads
-``wo_a.weight`` and its scale parameter directly and feeds both to DeepGEMM
-``fp8_einsum``.  That is valid for vLLM's stock block-FP8 method, but not for
-Gridbook's ``Mxfp8DenseLinearMethod``: after load, the latter owns a CuTe MXFP8
-scale plane and deliberately removes the checkpoint-scale parameter.
+The qualified Spark vLLM baseline does not call ``self.wo_a`` from NVIDIA
+DSV4 attention.  Its specialized output projection instead reads the weight
+and scale parameters directly and feeds them to DeepGEMM ``fp8_einsum``.
+That bypass is invalid for either Gridbook-owned route: direct-g32 MXFP8 W8A8
+repackages its scale plane for CuTe, while block128 source-FP8 W8A16 retains
+the raw checkpoint value and scale planes for Gridbook's own dispatch.
 
 This module installs one narrowly guarded class wrapper.  It activates only
-when the ``wo_a`` module carries :data:`DSV4_MXFP8_BMM_ATTR`; every other DSV4
+when the ``wo_a`` module carries one of Gridbook's versioned BMM ownership
+markers: direct MXFP8 W8A8 or block128 source-FP8 W8A16.  Every other DSV4
 attention instance calls the original vLLM method byte-for-byte.  The guarded
 path uses vLLM's own PyTorch-native inverse RoPE, calls the BMM-aware Gridbook
 linear normally, then calls ``wo_b``.  No Gridbook Triton fallback or stock
@@ -26,13 +26,18 @@ import torch
 __all__ = [
     "DSV4_MXFP8_BMM_ATTR",
     "DSV4_MXFP8_BMM_ABI",
+    "DSV4_FP8_SOURCE_W8A16_BMM_ATTR",
+    "DSV4_FP8_SOURCE_W8A16_BMM_ABI",
+    "dsv4_gridbook_o_proj",
     "dsv4_mxfp8_o_proj",
     "install_dsv4_woa_adapter",
 ]
 
 DSV4_MXFP8_BMM_ATTR = "_gridbook_mxfp8_bmm"
 DSV4_MXFP8_BMM_ABI = 1
-_ADAPTER_ABI = 1
+DSV4_FP8_SOURCE_W8A16_BMM_ATTR = "_gridbook_fp8_source_w8a16_bmm"
+DSV4_FP8_SOURCE_W8A16_BMM_ABI = 1
+_ADAPTER_ABI = 2
 _WRAPPED_ABI_ATTR = "_gridbook_dsv4_woa_adapter_abi"
 _LOGGED = False
 
@@ -47,17 +52,28 @@ _NVIDIA_ATTN_CLASSES = {
 }
 
 
-def dsv4_mxfp8_o_proj(
+def _owns_gridbook_bmm(wo_a: Any) -> bool:
+    """Whether ``wo_a`` carries one exact Gridbook BMM contract marker."""
+
+    if wo_a is None:
+        return False
+    return (
+        getattr(wo_a, DSV4_MXFP8_BMM_ATTR, None) == DSV4_MXFP8_BMM_ABI or
+        getattr(wo_a, DSV4_FP8_SOURCE_W8A16_BMM_ATTR, None) ==
+        DSV4_FP8_SOURCE_W8A16_BMM_ABI
+    )
+
+
+def dsv4_gridbook_o_proj(
     attention: Any, o: torch.Tensor, positions: torch.Tensor
 ) -> torch.Tensor:
     """Run DSV4 output projection through the owning Gridbook BMM method."""
 
     wo_a = getattr(attention, "wo_a", None)
-    if (wo_a is None or
-            getattr(wo_a, DSV4_MXFP8_BMM_ATTR, None) != DSV4_MXFP8_BMM_ABI):
+    if not _owns_gridbook_bmm(wo_a):
         raise RuntimeError(
             "Gridbook DSV4 wo_a adapter was called for a layer that does not "
-            "own the MXFP8 BMM contract"
+            "own a supported Gridbook BMM contract"
         )
     if o.ndim != 3:
         raise RuntimeError(
@@ -99,6 +115,10 @@ def dsv4_mxfp8_o_proj(
     return result
 
 
+# Compatibility spelling used by the existing direct-MXFP8 lane and callers.
+dsv4_mxfp8_o_proj = dsv4_gridbook_o_proj
+
+
 def _wrap_attention_class(cls: type) -> bool:
     current = cls._o_proj
     abi = getattr(current, _WRAPPED_ABI_ATTR, None)
@@ -112,9 +132,8 @@ def _wrap_attention_class(cls: type) -> bool:
 
     @functools.wraps(current)
     def _o_proj(self, o, positions, _original=current):
-        if (getattr(getattr(self, "wo_a", None),
-                    DSV4_MXFP8_BMM_ATTR, None) == DSV4_MXFP8_BMM_ABI):
-            return dsv4_mxfp8_o_proj(self, o, positions)
+        if _owns_gridbook_bmm(getattr(self, "wo_a", None)):
+            return dsv4_gridbook_o_proj(self, o, positions)
         return _original(self, o, positions)
 
     setattr(_o_proj, _WRAPPED_ABI_ATTR, _ADAPTER_ABI)
@@ -147,12 +166,12 @@ def install_dsv4_woa_adapter() -> None:
             changed += int(_wrap_attention_class(cls))
     if seen == 0:
         raise RuntimeError(
-            "Gridbook MXFP8 BMM encountered DSV4 wo_a, but no audited vLLM "
-            "NVIDIA DSV4 attention class is loaded"
+            "Gridbook BMM encountered DSV4 wo_a, but no admitted vLLM NVIDIA "
+            "DSV4 attention class is loaded"
         )
     if not _LOGGED:
         print(
-            "[prismaquant-cb] dsv4_wo_a=gridbook-mxfp8-bmm "
+            "[prismaquant-cb] dsv4_wo_a=gridbook-bmm "
             f"adapter_abi={_ADAPTER_ABI} classes={seen} changed={changed}",
             flush=True,
         )

--- a/gridbook/fp8_source_w8a16.py
+++ b/gridbook/fp8_source_w8a16.py
@@ -27,7 +27,6 @@ from .mxfp8 import DS_BLOCK
 
 __all__ = [
     "WIRE_FP8_BLOCK128",
-    "Fp8SourceW8A16LinearMethod",
     "build_fp8_source_w8a16_method",
 ]
 
@@ -163,9 +162,9 @@ def _build_method_class():
                 raise TypeError(
                     "source-FP8 W8A16 needs a 2-D float8_e4m3fn value "
                     f"plane, got dtype={q.dtype}, shape={tuple(q.shape)}")
-            if scales.dtype not in (torch.float8_e8m0fnu, torch.uint8):
+            if scales.dtype != torch.float8_e8m0fnu:
                 raise TypeError(
-                    "source-FP8 W8A16 needs float8_e8m0fnu/uint8 scales, "
+                    "source-FP8 W8A16 needs a float8_e8m0fnu scale plane, "
                     f"got {scales.dtype}")
             if scales.ndim != 2 or scales.device != q.device:
                 raise ValueError(
@@ -334,15 +333,52 @@ def _build_method_class():
                 fp8_source_expand_bf16,
                 fp8_source_gemv,
             )
+            from .nvfp4_activation_contract import emit_route
+
+            route = {
+                "kind": "dense",
+                "shape": (
+                    f"M{m}:G{groups}:N{rows}:K{k}"
+                    if is_bmm else f"M{m}:N{n}:K{k}"
+                ),
+                "contract": "bf16_preserved",
+                "tile_m": 0,
+            }
 
             if m <= _DECODE_MAX_M:
+                emit_route(
+                    layer,
+                    policy="source_fp8_w8a16_decode",
+                    symbol="fp8_source_gemv",
+                    state="error",
+                    reason="launch did not return",
+                    **route,
+                )
                 flat = fp8_source_gemv(x3, q, scales, groups)
                 if is_bmm:
-                    return flat.reshape(*outer, groups, rows)
-                return flat.reshape(*outer, n)
+                    result = flat.reshape(*outer, groups, rows)
+                else:
+                    result = flat.reshape(*outer, n)
+                emit_route(
+                    layer,
+                    policy="source_fp8_w8a16_decode",
+                    symbol="fp8_source_gemv",
+                    state="served",
+                    reason=None,
+                    **route,
+                )
+                return result
 
             # One bounded caller-scoped transient, consumed immediately by
             # Gridbook's owned CUTLASS bridge and never attached to the layer.
+            emit_route(
+                layer,
+                policy="source_fp8_w8a16_prefill",
+                symbol="fp8_source_expand_bf16+cb_bf16_grouped_mm",
+                state="error",
+                reason="launch chain did not return",
+                **route,
+            )
             expanded = fp8_source_expand_bf16(q, scales)
             if not is_bmm:
                 expert_ends = torch.full(
@@ -350,7 +386,16 @@ def _build_method_class():
                 result = cb_bf16_grouped_mm(
                     x3[:, 0, :], expanded.view(1, n, k), expert_ends, 0)
                 del expanded
-                return result.reshape(*outer, n)
+                result = result.reshape(*outer, n)
+                emit_route(
+                    layer,
+                    policy="source_fp8_w8a16_prefill",
+                    symbol="fp8_source_expand_bf16+cb_bf16_grouped_mm",
+                    state="served",
+                    reason=None,
+                    **route,
+                )
+                return result
 
             # The bridge's row contract is expert/group-major.  Flatten A in
             # that order, run G equal contiguous segments, then restore the
@@ -365,7 +410,16 @@ def _build_method_class():
             del expanded
             restored = grouped.view(groups, m, rows).permute(
                 1, 0, 2).contiguous()
-            return restored.reshape(*outer, groups, rows)
+            result = restored.reshape(*outer, groups, rows)
+            emit_route(
+                layer,
+                policy="source_fp8_w8a16_prefill",
+                symbol="fp8_source_expand_bf16+cb_bf16_grouped_mm",
+                state="served",
+                reason=None,
+                **route,
+            )
+            return result
 
     return Fp8SourceW8A16LinearMethod
 
@@ -379,7 +433,3 @@ def build_fp8_source_w8a16_method(wire_id: str):
             f"{WIRE_FP8_BLOCK128!r}, got {wire_id!r}; direct g32 MXFP8 stays "
             "on Mxfp8DenseLinearMethod (W8A8)")
     return _build_method_class()()
-
-
-class Fp8SourceW8A16LinearMethod:  # pragma: no cover - public identity marker
-    """Public identity of Gridbook's block128 source-FP8 W8A16 route."""

--- a/gridbook/fp8_source_w8a16.py
+++ b/gridbook/fp8_source_w8a16.py
@@ -38,6 +38,10 @@ _READY_ATTR = "_gridbook_fp8_source_w8a16_ready"
 _READY_ABI = 1
 _DECODE_MAX_M = 8
 _GEMM_ALIGNMENT = 8
+_DSV4_BMM_GROUPS = 8
+_DSV4_BMM_ROWS = 1024
+_DSV4_BMM_K = 4096
+_DSV4_RELEASE_TP = 1
 
 
 def _checked_source_loader(weight_loader, *, expected_dtype: torch.dtype,
@@ -187,6 +191,7 @@ def _build_method_class():
             is_bmm = bool(getattr(layer, "is_bmm", False))
             groups = 1
             rows = n
+            tp_size = int(getattr(layer, "tp_size", 1))
             if is_bmm:
                 groups = int(getattr(layer, "bmm_batch_size", 0))
                 if groups <= 0 or n % groups != 0:
@@ -194,13 +199,22 @@ def _build_method_class():
                         "source-FP8 W8A16 BMM needs a positive group count "
                         f"dividing N; got groups={groups}, N={n}")
                 rows = n // groups
-                if int(getattr(layer, "tp_size", 1)) != 1:
+                geometry = (groups, rows, k, tp_size)
+                qualified = (
+                    _DSV4_BMM_GROUPS,
+                    _DSV4_BMM_ROWS,
+                    _DSV4_BMM_K,
+                    _DSV4_RELEASE_TP,
+                )
+                if geometry != qualified:
                     raise ValueError(
-                        "source-FP8 W8A16 BMM is release-gated only for TP=1")
-                if rows % DS_BLOCK != 0 or k % DS_BLOCK != 0:
-                    raise ValueError(
-                        "block128 source-FP8 W8A16 BMM needs per-group N and "
-                        f"K divisible by {DS_BLOCK}; got N={rows}, K={k}")
+                        "source-FP8 W8A16 BMM is qualified only for grouped "
+                        "geometry G=8, N=1024, K=4096, TP=1; got "
+                        f"G={groups}, N={rows}, K={k}, TP={tp_size}")
+            elif tp_size != _DSV4_RELEASE_TP:
+                raise ValueError(
+                    "source-FP8 W8A16 dense serving is release-gated only "
+                    f"for TP=1; got TP={tp_size}")
             if rows % _GEMM_ALIGNMENT != 0:
                 raise ValueError(
                     "source-FP8 W8A16 needs per-group N divisible by the "

--- a/gridbook/fp8_source_w8a16.py
+++ b/gridbook/fp8_source_w8a16.py
@@ -1,0 +1,324 @@
+"""Raw-resident W8A16 serving for DeepSeek block-128 source FP8.
+
+The source-passthrough declaration is a weight-storage contract, not an
+activation-quantization request.  This method therefore keeps exactly the
+checkpoint's E4M3 ``[N,K]`` value plane and UE8M0 block-128 scale plane
+resident while accepting BF16 activations unchanged.
+
+Execution is native and fail-closed:
+
+* decode (``M <= 8``) streams both raw planes through Gridbook's CUDA GEMV;
+* larger inputs expand one caller-scoped BF16 tile and immediately consume it
+  through Gridbook's owned CUTLASS grouped-BF16 bridge;
+* the entire size dispatch is an opaque custom op, so Dynamo never substitutes
+  Triton or bakes the prefill arm into captured decode.
+
+There is no persistent BF16 expansion, activation QDQ, ``F.linear``,
+``torch.bmm``, or CPU serving fallback.  Direct per-32 MXFP8 is intentionally
+not accepted here; it remains the separate W8A8 ``Mxfp8DenseLinearMethod``.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from .mxfp8 import DS_BLOCK
+
+__all__ = [
+    "WIRE_FP8_BLOCK128",
+    "Fp8SourceW8A16LinearMethod",
+    "build_fp8_source_w8a16_method",
+]
+
+
+WIRE_FP8_BLOCK128 = "fp8_e4m3_ue8m0_block128"
+
+_READY_ATTR = "_gridbook_fp8_source_w8a16_ready"
+_READY_ABI = 1
+_DECODE_MAX_M = 8
+_GEMM_ALIGNMENT = 8
+
+
+def _require_source_cuda(tensor: torch.Tensor) -> None:
+    """Fail closed off CUDA; kept as the narrow CPU policy-test seam."""
+
+    if tensor.device.type != "cuda":
+        raise RuntimeError(
+            "source-FP8 W8A16 model loading requires CUDA; Gridbook has no "
+            "CPU or interpreted-kernel fallback")
+
+
+def _build_method_class():
+    """Build the vLLM-bound class lazily so policy imports stay lightweight."""
+
+    from vllm.model_executor.layers.linear import LinearMethodBase
+    from vllm.model_executor.parameter import (
+        BlockQuantScaleParameter,
+        ModelWeightParameter,
+    )
+
+    class Fp8SourceW8A16LinearMethod(LinearMethodBase):
+        """Raw block128 FP8 weights with unquantized BF16 activations."""
+
+        def __init__(self) -> None:
+            self._wire = WIRE_FP8_BLOCK128
+
+        def create_weights(self, layer, input_size_per_partition,
+                           output_partition_sizes, input_size, output_size,
+                           params_dtype, **extra_weight_attrs):
+            del input_size, output_size, params_dtype
+            out_size = int(sum(output_partition_sizes))
+            in_size = int(input_size_per_partition)
+            if out_size <= 0 or in_size <= 0:
+                raise ValueError(
+                    "source-FP8 W8A16 needs positive N and K, got "
+                    f"N={out_size}, K={in_size}")
+            weight_loader = extra_weight_attrs.get("weight_loader")
+            weight = ModelWeightParameter(
+                data=torch.empty(out_size, in_size,
+                                 dtype=torch.float8_e4m3fn),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            )
+            layer.register_parameter("weight", weight)
+
+            # vLLM's fused-shard loader needs the source block geometry to
+            # place each physical role's scale rows at the correct offset.
+            layer.weight_block_size = [DS_BLOCK, DS_BLOCK]
+            scale = BlockQuantScaleParameter(
+                data=torch.empty(
+                    (out_size + DS_BLOCK - 1) // DS_BLOCK,
+                    (in_size + DS_BLOCK - 1) // DS_BLOCK,
+                    dtype=torch.float8_e8m0fnu,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+            )
+            # DeepSeek's checkpoint spelling.  The loader copies the UE8M0
+            # bytes verbatim; "inv" is a name, not a numeric transformation.
+            layer.register_parameter("weight_scale_inv", scale)
+
+        def process_weights_after_loading(self, layer) -> None:
+            if getattr(layer, _READY_ATTR, None) is not None:
+                raise RuntimeError(
+                    "source-FP8 W8A16 weights were finalized more than once")
+
+            q = layer.weight.data
+            scales = layer.weight_scale_inv.data
+            if q.dtype != torch.float8_e4m3fn or q.ndim != 2:
+                raise TypeError(
+                    "source-FP8 W8A16 needs a 2-D float8_e4m3fn value "
+                    f"plane, got dtype={q.dtype}, shape={tuple(q.shape)}")
+            if scales.dtype not in (torch.float8_e8m0fnu, torch.uint8):
+                raise TypeError(
+                    "source-FP8 W8A16 needs float8_e8m0fnu/uint8 scales, "
+                    f"got {scales.dtype}")
+            if scales.ndim != 2 or scales.device != q.device:
+                raise ValueError(
+                    "source-FP8 W8A16 value and scale planes must be 2-D "
+                    f"on one device; got {q.device} and {scales.device}")
+            _require_source_cuda(q)
+
+            n, k = int(q.shape[0]), int(q.shape[1])
+            expected_scales = (
+                (n + DS_BLOCK - 1) // DS_BLOCK,
+                (k + DS_BLOCK - 1) // DS_BLOCK,
+            )
+            if tuple(scales.shape) != expected_scales:
+                raise ValueError(
+                    "source-FP8 W8A16 block128 scale shape mismatch: got "
+                    f"{tuple(scales.shape)}, expected {expected_scales} for "
+                    f"weight {(n, k)}")
+            if k % _GEMM_ALIGNMENT != 0:
+                raise ValueError(
+                    "source-FP8 W8A16 needs K divisible by the native BF16 "
+                    f"bridge alignment {_GEMM_ALIGNMENT}, got {k}")
+
+            is_bmm = bool(getattr(layer, "is_bmm", False))
+            groups = 1
+            rows = n
+            if is_bmm:
+                groups = int(getattr(layer, "bmm_batch_size", 0))
+                if groups <= 0 or n % groups != 0:
+                    raise ValueError(
+                        "source-FP8 W8A16 BMM needs a positive group count "
+                        f"dividing N; got groups={groups}, N={n}")
+                rows = n // groups
+                if int(getattr(layer, "tp_size", 1)) != 1:
+                    raise ValueError(
+                        "source-FP8 W8A16 BMM is release-gated only for TP=1")
+                if rows % DS_BLOCK != 0 or k % DS_BLOCK != 0:
+                    raise ValueError(
+                        "block128 source-FP8 W8A16 BMM needs per-group N and "
+                        f"K divisible by {DS_BLOCK}; got N={rows}, K={k}")
+            if rows % _GEMM_ALIGNMENT != 0:
+                raise ValueError(
+                    "source-FP8 W8A16 needs per-group N divisible by the "
+                    f"native BF16 bridge alignment {_GEMM_ALIGNMENT}, got "
+                    f"{rows}")
+
+            # Resolve BOTH possible size arms now, outside first forward and
+            # graph capture.  Neither helper is allowed a torch/Triton fallback.
+            from .cuda_ext import (
+                require_bf16_grouped_ext,
+                require_fp8_source_w8a16_ext,
+            )
+
+            require_fp8_source_w8a16_ext(
+                "source-FP8 W8A16 model loading", device=q.device)
+            require_bf16_grouped_ext(
+                "source-FP8 W8A16 transient prefill")
+
+            # Contiguity may replace a non-contiguous loader view, but never
+            # changes the wire representation or creates a second resident
+            # plane.  Both raw parameters deliberately remain registered.
+            layer.weight.data = q.contiguous()
+            layer.weight_scale_inv.data = scales.contiguous()
+            q = layer.weight.data
+            scales = layer.weight_scale_inv.data
+            if q.element_size() != 1 or scales.element_size() != 1:
+                raise RuntimeError(
+                    "source-FP8 W8A16 resident planes must remain byte-wide")
+
+            layer._fp8_source_N = n
+            layer._fp8_source_K = k
+            layer._fp8_source_groups = groups
+            layer._fp8_source_rows = rows
+            layer._fp8_source_resident_bytes = q.numel() + scales.numel()
+
+            from .ops import register_cb_layer
+
+            layer._fp8_source_layer_id = register_cb_layer(self, layer)
+
+            if is_bmm:
+                from .dsv4_woa import (
+                    DSV4_FP8_SOURCE_W8A16_BMM_ABI,
+                    DSV4_FP8_SOURCE_W8A16_BMM_ATTR,
+                    install_dsv4_woa_adapter,
+                )
+
+                setattr(layer, DSV4_FP8_SOURCE_W8A16_BMM_ATTR,
+                        DSV4_FP8_SOURCE_W8A16_BMM_ABI)
+                install_dsv4_woa_adapter()
+
+            setattr(layer, _READY_ATTR, _READY_ABI)
+
+        def apply(self, layer, x: torch.Tensor,
+                  bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+            if bias is not None:
+                raise ValueError(
+                    "source-FP8 W8A16 does not serve biased linears")
+            if getattr(layer, _READY_ATTR, None) != _READY_ABI:
+                raise RuntimeError(
+                    "source-FP8 W8A16 weight was not finalized at model load")
+            layer_id = getattr(layer, "_fp8_source_layer_id", None)
+            if layer_id is None:
+                raise RuntimeError(
+                    "source-FP8 W8A16 dispatch layer was not registered")
+            from .ops import fp8_source_linear_forward
+
+            return fp8_source_linear_forward(x, int(layer_id))
+
+        def _apply_inline(self, layer, x: torch.Tensor) -> torch.Tensor:
+            """Run inside the opaque whole-dispatch custom op."""
+
+            if x.dtype != torch.bfloat16:
+                raise TypeError(
+                    "source-FP8 W8A16 preserves BF16 activations and refuses "
+                    f"dtype {x.dtype}")
+            q = layer.weight
+            scales = layer.weight_scale_inv
+            if x.device != q.device or scales.device != q.device:
+                raise RuntimeError(
+                    "source-FP8 W8A16 activations and raw planes must share "
+                    "one CUDA device")
+            if not q.is_contiguous() or not scales.is_contiguous():
+                raise RuntimeError(
+                    "source-FP8 W8A16 resident planes lost contiguity")
+
+            n = int(layer._fp8_source_N)
+            k = int(layer._fp8_source_K)
+            groups = int(layer._fp8_source_groups)
+            rows = int(layer._fp8_source_rows)
+            is_bmm = bool(getattr(layer, "is_bmm", False))
+
+            if is_bmm:
+                if x.ndim < 2 or int(x.shape[-2]) != groups:
+                    raise ValueError(
+                        "source-FP8 W8A16 BMM expected [..., groups, K] with "
+                        f"groups={groups}, got {tuple(x.shape)}")
+                if int(x.shape[-1]) != k:
+                    raise ValueError(
+                        f"source-FP8 W8A16 BMM input K={x.shape[-1]} does "
+                        f"not match weight K={k}")
+                outer = tuple(x.shape[:-2])
+                x3 = x.reshape(-1, groups, k).contiguous()
+            else:
+                if x.ndim < 1 or int(x.shape[-1]) != k:
+                    raise ValueError(
+                        "source-FP8 W8A16 dense input must end in "
+                        f"K={k}, got {tuple(x.shape)}")
+                outer = tuple(x.shape[:-1])
+                x3 = x.reshape(-1, 1, k).contiguous()
+
+            m = int(x3.shape[0])
+            if m <= 0:
+                raise ValueError("source-FP8 W8A16 does not serve empty inputs")
+
+            from .ops import (
+                cb_bf16_grouped_mm,
+                fp8_source_expand_bf16,
+                fp8_source_gemv,
+            )
+
+            if m <= _DECODE_MAX_M:
+                flat = fp8_source_gemv(x3, q, scales, groups)
+                if is_bmm:
+                    return flat.reshape(*outer, groups, rows)
+                return flat.reshape(*outer, n)
+
+            # One bounded caller-scoped transient, consumed immediately by
+            # Gridbook's owned CUTLASS bridge and never attached to the layer.
+            expanded = fp8_source_expand_bf16(q, scales)
+            if not is_bmm:
+                expert_ends = torch.full(
+                    (1,), m, dtype=torch.int32, device=x.device)
+                result = cb_bf16_grouped_mm(
+                    x3[:, 0, :], expanded.view(1, n, k), expert_ends, 0)
+                del expanded
+                return result.reshape(*outer, n)
+
+            # The bridge's row contract is expert/group-major.  Flatten A in
+            # that order, run G equal contiguous segments, then restore the
+            # caller's [..., G, N_per_group] layout.
+            a_group_major = x3.permute(1, 0, 2).contiguous().view(
+                groups * m, k)
+            weights = expanded.view(groups, rows, k)
+            expert_ends = torch.arange(
+                1, groups + 1, dtype=torch.int32, device=x.device) * m
+            grouped = cb_bf16_grouped_mm(
+                a_group_major, weights, expert_ends, 0)
+            del expanded
+            restored = grouped.view(groups, m, rows).permute(
+                1, 0, 2).contiguous()
+            return restored.reshape(*outer, groups, rows)
+
+    return Fp8SourceW8A16LinearMethod
+
+
+def build_fp8_source_w8a16_method(wire_id: str):
+    """Construct the block128-only source-FP8 W8A16 serving method."""
+
+    if wire_id != WIRE_FP8_BLOCK128:
+        raise ValueError(
+            "Fp8SourceW8A16LinearMethod accepts only "
+            f"{WIRE_FP8_BLOCK128!r}, got {wire_id!r}; direct g32 MXFP8 stays "
+            "on Mxfp8DenseLinearMethod (W8A8)")
+    return _build_method_class()()
+
+
+class Fp8SourceW8A16LinearMethod:  # pragma: no cover - public identity marker
+    """Public identity of Gridbook's block128 source-FP8 W8A16 route."""

--- a/gridbook/fp8_source_w8a16.py
+++ b/gridbook/fp8_source_w8a16.py
@@ -40,6 +40,43 @@ _DECODE_MAX_M = 8
 _GEMM_ALIGNMENT = 8
 
 
+def _checked_source_loader(weight_loader, *, expected_dtype: torch.dtype,
+                           plane: str):
+    """Reject a mis-typed checkpoint tensor before vLLM can cast-copy it.
+
+    vLLM's default, fused, and merged loaders all receive the destination
+    parameter followed by ``loaded_weight``; fused loaders may add a positional
+    shard id, while merged loaders may pass it by keyword.  Keep that call
+    shape opaque and delegate it unchanged after checking the source tensor.
+    """
+
+    if weight_loader is None:
+        return None
+
+    def checked_loader(*args, **kwargs):
+        if len(args) >= 2:
+            loaded_weight = args[1]
+        elif "loaded_weight" in kwargs:
+            loaded_weight = kwargs["loaded_weight"]
+        else:
+            raise TypeError(
+                f"source-FP8 W8A16 {plane} loader requires the checkpoint "
+                "tensor as loaded_weight")
+        if not isinstance(loaded_weight, torch.Tensor):
+            raise TypeError(
+                f"source-FP8 W8A16 {plane} checkpoint value must be a "
+                f"torch.Tensor before vLLM loader delegation, got "
+                f"{type(loaded_weight).__name__}")
+        if loaded_weight.dtype != expected_dtype:
+            raise TypeError(
+                f"source-FP8 W8A16 {plane} checkpoint tensor must be "
+                f"exactly {expected_dtype} before vLLM loader delegation, "
+                f"got {loaded_weight.dtype}")
+        return weight_loader(*args, **kwargs)
+
+    return checked_loader
+
+
 def _require_source_cuda(tensor: torch.Tensor) -> None:
     """Fail closed off CUDA; kept as the narrow CPU policy-test seam."""
 
@@ -75,12 +112,22 @@ def _build_method_class():
                     "source-FP8 W8A16 needs positive N and K, got "
                     f"N={out_size}, K={in_size}")
             weight_loader = extra_weight_attrs.get("weight_loader")
+            value_loader = _checked_source_loader(
+                weight_loader,
+                expected_dtype=torch.float8_e4m3fn,
+                plane="value-plane",
+            )
+            scale_loader = _checked_source_loader(
+                weight_loader,
+                expected_dtype=torch.float8_e8m0fnu,
+                plane="scale-plane",
+            )
             weight = ModelWeightParameter(
                 data=torch.empty(out_size, in_size,
                                  dtype=torch.float8_e4m3fn),
                 input_dim=1,
                 output_dim=0,
-                weight_loader=weight_loader,
+                weight_loader=value_loader,
             )
             layer.register_parameter("weight", weight)
 
@@ -95,7 +142,7 @@ def _build_method_class():
                 ),
                 input_dim=1,
                 output_dim=0,
-                weight_loader=weight_loader,
+                weight_loader=scale_loader,
             )
             # DeepSeek's checkpoint spelling.  The loader copies the UE8M0
             # bytes verbatim; "inv" is a name, not a numeric transformation.

--- a/gridbook/mxfp8_dense_lane.py
+++ b/gridbook/mxfp8_dense_lane.py
@@ -1,16 +1,15 @@
-"""The MXFP8 dense serving lane: one linear method, two wire spellings.
+"""The direct-g32 MXFP8 dense serving lane.
 
-Serves passthrough ``linear`` units whose weights are E4M3 with UE8M0
-scales — either producer-emitted MXFP8 (``mxfp8_e4m3_e8m0_g32``, scales
-row-major per 32) or DeepSeek block-128 FP8 (``fp8_e4m3_ue8m0_block128``,
-scales per 128x128 tile, embedded exactly into MXFP8 by scale replication at
-load; see ``gridbook/mxfp8.py`` for the one-line proof).
+Serves producer-emitted MXFP8 ``linear`` units whose weights are E4M3 with
+row-major UE8M0 scales per 32 K elements (``mxfp8_e4m3_e8m0_g32``).
+DeepSeek block-128 source FP8 is deliberately rejected: that wire is W8A16
+and belongs exclusively to ``Fp8SourceW8A16LinearMethod``.  Keeping the
+rejection here as well as in the source-format registry makes it impossible
+for a stale factory to silently restore dynamic activation quantization.
 
-W8A8: activations are quantized dynamically to MXFP8 per 32-element group —
-strictly FINER than the per-[1,128] grouping the checkpoint's own serving
-path uses, so reference accuracy bounds this lane's.  The GEMM is the stock
-sm120/sm121 block-scaled CollectiveBuilder collective (``kind::mxf8f6f4``)
-via ``cuda_ext.get_mxfp8_dense_ext``.
+W8A8: activations are quantized dynamically to MXFP8 per 32-element group.
+The GEMM is the stock sm120/sm121 block-scaled CollectiveBuilder collective
+(``kind::mxf8f6f4``) via ``cuda_ext.get_mxfp8_dense_ext``.
 
 OPT-IN (``GRIDBOOK_MXFP8_DENSE=1``): the lane is correctness-audited
 (kernel-vs-oracle parity over the DSV4 body shapes, recorded in
@@ -32,9 +31,7 @@ import torch
 from . import cuda_ext
 from .lane_select import latched_bool, require_lane
 from .mxfp8 import (
-    DS_BLOCK,
     SFVEC,
-    broadcast_block128_scales,
     fill_sf_plane,
     quantize_mxfp8,
 )
@@ -44,13 +41,13 @@ __all__ = [
     "mxfp8_dense_enabled",
     "build_mxfp8_dense_method",
     "WIRE_MXFP8_G32",
-    "WIRE_FP8_BLOCK128",
 ]
 
 MXFP8_DENSE_FLAG = "GRIDBOOK_MXFP8_DENSE"
 
-#: The two wire spellings this lane serves (ids owned by source_passthrough).
+#: The sole wire spelling this W8A8 lane serves.
 WIRE_MXFP8_G32 = "mxfp8_e4m3_e8m0_g32"
+# Kept private as an explicit hard-refusal sentinel for stale callers.
 WIRE_FP8_BLOCK128 = "fp8_e4m3_ue8m0_block128"
 
 
@@ -116,12 +113,16 @@ def build_mxfp8_dense_method(wire_id: str):
     vLLM present.  The returned instance's CLASS NAME is the audited backend
     label in ``source_passthrough.FORMATS`` — renaming it is a registry edit.
     """
-    if wire_id not in (WIRE_MXFP8_G32, WIRE_FP8_BLOCK128):
+    if wire_id == WIRE_FP8_BLOCK128:
+        raise ValueError(
+            "block128 source FP8 is a W8A16 contract and cannot enter "
+            "Mxfp8DenseLinearMethod (W8A8); use "
+            "Fp8SourceW8A16LinearMethod")
+    if wire_id != WIRE_MXFP8_G32:
         raise ValueError(f"unknown MXFP8 dense wire id {wire_id!r}")
 
     from vllm.model_executor.layers.linear import LinearMethodBase
     from vllm.model_executor.parameter import (
-        BlockQuantScaleParameter,
         GroupQuantScaleParameter,
         ModelWeightParameter,
     )
@@ -146,40 +147,20 @@ def build_mxfp8_dense_method(wire_id: str):
                                  dtype=torch.float8_e4m3fn),
                 input_dim=1, output_dim=0, weight_loader=weight_loader)
             layer.register_parameter("weight", weight)
-            if self._wire == WIRE_FP8_BLOCK128:
-                # MergedColumnParallelLinear needs this block shape to place
-                # each physical role's scale shard at the correct output-row
-                # offset on the homogeneous native fast path.
-                layer.weight_block_size = [DS_BLOCK, DS_BLOCK]
-                scale = BlockQuantScaleParameter(
-                    data=torch.empty(
-                        (out_size + DS_BLOCK - 1) // DS_BLOCK,
-                        (in_size + DS_BLOCK - 1) // DS_BLOCK,
-                        dtype=torch.float8_e8m0fnu),
-                    input_dim=1, output_dim=0, weight_loader=weight_loader)
-                # The checkpoint spelling: DeepSeek stores the reciprocal-form
-                # name; bytes are copied verbatim by the producer.
-                layer.register_parameter("weight_scale_inv", scale)
-            else:
-                layer.weight_block_size = None
-                scale = GroupQuantScaleParameter(
-                    data=torch.empty(out_size, in_size // SFVEC,
-                                     dtype=torch.float8_e8m0fnu),
-                    input_dim=1, output_dim=0, weight_loader=weight_loader)
-                layer.register_parameter("weight_scale", scale)
+            layer.weight_block_size = None
+            scale = GroupQuantScaleParameter(
+                data=torch.empty(out_size, in_size // SFVEC,
+                                 dtype=torch.float8_e8m0fnu),
+                input_dim=1, output_dim=0, weight_loader=weight_loader)
+            layer.register_parameter("weight_scale", scale)
 
         def process_weights_after_loading(self, layer) -> None:
             device = layer.weight.device
             ext = _require_lane_ext(device)
             w = layer.weight.data
             n, k = int(w.shape[0]), int(w.shape[1])
-            if self._wire == WIRE_FP8_BLOCK128:
-                s_block = layer.weight_scale_inv.data
-                sf_rm = broadcast_block128_scales(s_block, n, k)
-                del layer.weight_scale_inv
-            else:
-                sf_rm = layer.weight_scale.data
-                del layer.weight_scale
+            sf_rm = layer.weight_scale.data
+            del layer.weight_scale
             is_bmm = bool(getattr(layer, "is_bmm", False))
             if is_bmm:
                 groups = int(getattr(layer, "bmm_batch_size", 0))
@@ -190,11 +171,6 @@ def build_mxfp8_dense_method(wire_id: str):
                 rows = n // groups
                 if int(getattr(layer, "tp_size", 1)) != 1:
                     raise ValueError("MXFP8 BMM is audited only for TP=1")
-                if (self._wire == WIRE_FP8_BLOCK128 and
-                        (rows % DS_BLOCK != 0 or k % DS_BLOCK != 0)):
-                    raise ValueError(
-                        "block128 MXFP8 BMM needs per-group N and K divisible "
-                        f"by {DS_BLOCK}; got N={rows}, K={k}")
                 sf_groups = sf_rm.reshape(groups, rows, k // SFVEC).to(device)
                 offs = _OFFSETS.get(
                     ext, rows, k, is_b=True, device=device)

--- a/gridbook/nvfp4_activation_contract.py
+++ b/gridbook/nvfp4_activation_contract.py
@@ -100,6 +100,7 @@ ROUTE_CONTRACTS = frozenset((
     "fp8_per_token_dynamic",
     "fp4_group16_rtn",
     "fp32_emulated_group_qdq",
+    "bf16_preserved",
 ))
 
 ROUTE_STATES = frozenset(("served", "fallback", "error"))

--- a/gridbook/ops.py
+++ b/gridbook/ops.py
@@ -178,6 +178,42 @@ def _cb_bf16_grouped_mm_out_fake(out, a, weights, expert_ends,
     return None
 
 
+@torch.library.custom_op("prismaquant::fp8_source_gemv", mutates_args=())
+def fp8_source_gemv(x: torch.Tensor, q: torch.Tensor, scales: torch.Tensor,
+                     groups: int) -> torch.Tensor:
+    """Raw-resident block128 source-FP8 GEMV for BF16 activations."""
+    from .cuda_ext import require_fp8_source_w8a16_ext
+
+    return require_fp8_source_w8a16_ext(
+        "source-FP8 W8A16 decode GEMV", device=x.device
+    ).fp8_source_gemv(x, q, scales, groups)
+
+
+@fp8_source_gemv.register_fake
+def _fp8_source_gemv_fake(x, q, scales, groups):
+    del scales, groups
+    return torch.empty((x.shape[0], q.shape[0]), dtype=torch.bfloat16,
+                       device=x.device)
+
+
+@torch.library.custom_op("prismaquant::fp8_source_expand_bf16",
+                         mutates_args=())
+def fp8_source_expand_bf16(q: torch.Tensor,
+                           scales: torch.Tensor) -> torch.Tensor:
+    """Expand one caller-scoped BF16 source-weight tile for native prefill."""
+    from .cuda_ext import require_fp8_source_w8a16_ext
+
+    return require_fp8_source_w8a16_ext(
+        "source-FP8 W8A16 transient expansion", device=q.device
+    ).fp8_source_expand_bf16(q, scales)
+
+
+@fp8_source_expand_bf16.register_fake
+def _fp8_source_expand_bf16_fake(q, scales):
+    del scales
+    return torch.empty(q.shape, dtype=torch.bfloat16, device=q.device)
+
+
 @torch.library.custom_op("prismaquant::cb_bf16_grouped_mm_sm120",
                          mutates_args=())
 def cb_bf16_grouped_mm_sm120(a: torch.Tensor, weights: torch.Tensor,
@@ -606,6 +642,26 @@ def _cb_linear_forward_fake(x, layer_id):
     _method, layer = _lookup_cb_layer(layer_id)
     return torch.empty((*x.shape[:-1], layer._cb_N), dtype=x.dtype,
                        device=x.device)
+
+
+@torch.library.custom_op("prismaquant::fp8_source_linear_forward",
+                         mutates_args=())
+def fp8_source_linear_forward(x: torch.Tensor, layer_id: int) -> torch.Tensor:
+    """Opaque whole-dispatch op for raw-resident source-FP8 W8A16."""
+    method, layer = _lookup_cb_layer(layer_id)
+    return method._apply_inline(layer, x)
+
+
+@fp8_source_linear_forward.register_fake
+def _fp8_source_linear_forward_fake(x, layer_id):
+    _method, layer = _lookup_cb_layer(layer_id)
+    groups = int(layer._fp8_source_groups)
+    rows = int(layer._fp8_source_rows)
+    if bool(getattr(layer, "is_bmm", False)):
+        return torch.empty((*x.shape[:-2], groups, rows), dtype=x.dtype,
+                           device=x.device)
+    return torch.empty((*x.shape[:-1], int(layer._fp8_source_N)),
+                       dtype=x.dtype, device=x.device)
 
 
 @torch.library.custom_op("prismaquant::cb_moe_forward", mutates_args=())

--- a/gridbook/runtime_contract.json
+++ b/gridbook/runtime_contract.json
@@ -1,8 +1,9 @@
 {
-  "schema": "gridbook.runtime-contract.v2",
-  "contract_version": 2,
+  "schema": "gridbook.runtime-contract.v3",
+  "contract_version": 3,
   "abi_features": {
-    "routed_moe_per_role_codebook_lut": 1
+    "routed_moe_per_role_codebook_lut": 1,
+    "source_fp8_block128_w8a16": 1
   },
   "quant_method": {
     "canonical": "gridbook",

--- a/gridbook/runtime_contract.py
+++ b/gridbook/runtime_contract.py
@@ -11,7 +11,7 @@ from importlib.resources import files
 from typing import Any, Mapping
 
 
-RUNTIME_CONTRACT_SCHEMA = "gridbook.runtime-contract.v2"
+RUNTIME_CONTRACT_SCHEMA = "gridbook.runtime-contract.v3"
 _RESOURCE_NAME = "runtime_contract.json"
 
 #: The vLLM package roots a ``top_level_loader_modules`` entry may name. The
@@ -107,12 +107,13 @@ def validate_runtime_contract(contract: Any) -> None:
         _fail("contract.schema", f"must be {RUNTIME_CONTRACT_SCHEMA!r}")
     contract_version = _positive_int(
         root["contract_version"], "contract.contract_version")
-    if contract_version != 2:
-        _fail("contract.contract_version", "must be 2 for this schema")
+    if contract_version != 3:
+        _fail("contract.contract_version", "must be 3 for this schema")
 
     features = _object(root["abi_features"], "contract.abi_features")
     _keys(features, "contract.abi_features", {
         "routed_moe_per_role_codebook_lut",
+        "source_fp8_block128_w8a16",
     })
     per_role_lut = _positive_int(
         features["routed_moe_per_role_codebook_lut"],
@@ -121,6 +122,15 @@ def validate_runtime_contract(contract: Any) -> None:
     if per_role_lut != 1:
         _fail(
             "contract.abi_features.routed_moe_per_role_codebook_lut",
+            "must be 1",
+        )
+    source_fp8_w8a16 = _positive_int(
+        features["source_fp8_block128_w8a16"],
+        "contract.abi_features.source_fp8_block128_w8a16",
+    )
+    if source_fp8_w8a16 != 1:
+        _fail(
+            "contract.abi_features.source_fp8_block128_w8a16",
             "must be 1",
         )
 

--- a/gridbook/source_passthrough.py
+++ b/gridbook/source_passthrough.py
@@ -164,17 +164,12 @@ _FP8_BLOCK_LINEAR = SourceFormat(
     ),
     audited_capabilities=((12, 1),),
     # The route is GRIDBOOK-OWNED: every rung in vLLM 0.24's block-scaled FP8
-    # linear ladder was measured to fail on sm_121 for UE8M0 scales (the
-    # known_broken_backends below record each symptom), so Gridbook serves the
-    # format itself by embedding it into MXFP8 — 128 = 4 * 32, one scale byte
-    # replicated per chunk, bit-exact by construction — and running the stock
-    # sm120 block-scaled collective (gridbook/mxfp8_dense_lane.py; the
-    # embedding proof is in gridbook/mxfp8.py).  Correctness-audited
-    # kernel-vs-oracle over the ordinary DSV4 body shapes and its grouped
-    # wo_a projection on sm_121; NATIVE-PARITY *served* evidence pending, so
-    # the lane is OPT-IN
-    # (GRIDBOOK_MXFP8_DENSE=1) and the factory refuses without it.
-    audited_backends=frozenset({"Mxfp8DenseLinearMethod"}),
+    # linear ladder fails for this UE8M0 wire on sm_121 (recorded below).
+    # Gridbook keeps the source E4M3 + block128 UE8M0 planes verbatim and
+    # serves BF16 activations through a raw-plane native decode GEMV or a
+    # caller-scoped BF16 transient consumed by its CUTLASS bridge.  Release
+    # evidence is pending; admission is intentionally limited to Spark.
+    audited_backends=frozenset({"Fp8SourceW8A16LinearMethod"}),
     known_broken_backends={
         "DeepGemmFp8BlockScaledMMKernel": (
             "DeepGEMM's UE8M0 scale-layout transform rejects sm_121 "
@@ -198,15 +193,18 @@ _FP8_BLOCK_LINEAR = SourceFormat(
             "and its can_implement does not verify UE8M0 128x128 handling"
         ),
     },
-    quantizes_activations=True,
+    quantizes_activations=False,
     remedy=(
         "No native block-scaled FP8 kernel serves UE8M0 scales on sm_121 in "
-        "vLLM 0.24; Gridbook's own MXFP8 lane does. Set "
-        "GRIDBOOK_MXFP8_DENSE=1 to opt in (correctness-audited; serve-parity "
-        "bench pending), export the unit as Gridbook FP8-CB, or serve it on "
-        "an audited device."
+        "vLLM 0.24; Gridbook's raw-resident W8A16 route preserves the source "
+        "planes and BF16 activations. Use the pinned Gridbook runtime carrying "
+        "source_fp8_block128_w8a16 ABI feature 1, export the unit as Gridbook "
+        "FP8-CB, or serve it on an admitted device."
     ),
-    method_factory="gridbook.source_passthrough:_build_gridbook_mxfp8_block128_method",
+    method_factory=(
+        "gridbook.source_passthrough:"
+        "_build_gridbook_fp8_source_w8a16_method"
+    ),
 )
 
 _MXFP8_LINEAR = SourceFormat(
@@ -217,8 +215,8 @@ _MXFP8_LINEAR = SourceFormat(
         "exponent scale per 32 contiguous K elements, scales stored row-major"
     ),
     audited_capabilities=((12, 1),),
-    # Same Gridbook-owned route as fp8_e4m3_ue8m0_block128, minus the
-    # load-time scale broadcast: the wire already stores per-32 scales.
+    # Distinct from the block-128 W8A16 route above: this direct per-32 wire
+    # deliberately enters the dynamically quantized W8A8 MXFP8 collective.
     audited_backends=frozenset({"Mxfp8DenseLinearMethod"}),
     known_broken_backends={},
     quantizes_activations=True,
@@ -440,13 +438,16 @@ def _require_mxfp8_opt_in(fmt_id: str, prefix: str) -> None:
         )
 
 
-def _build_gridbook_mxfp8_block128_method(layer: Any, prefix: str) -> Any:
-    """Gridbook's MXFP8 dense lane reading the DeepSeek block-128 wire."""
+def _build_gridbook_fp8_source_w8a16_method(layer: Any, prefix: str) -> Any:
+    """Gridbook's raw-resident W8A16 route for DeepSeek block-128 FP8."""
 
-    _require_mxfp8_opt_in(_FP8_BLOCK_LINEAR.id, prefix)
-    from .mxfp8_dense_lane import WIRE_FP8_BLOCK128, build_mxfp8_dense_method
+    del layer, prefix
+    from .fp8_source_w8a16 import (
+        WIRE_FP8_BLOCK128,
+        build_fp8_source_w8a16_method,
+    )
 
-    return build_mxfp8_dense_method(WIRE_FP8_BLOCK128)
+    return build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
 
 
 def _build_gridbook_mxfp8_direct_method(layer: Any, prefix: str) -> Any:
@@ -461,8 +462,9 @@ def _build_gridbook_mxfp8_direct_method(layer: Any, prefix: str) -> Any:
 _FACTORIES: dict[str, Callable[[Any, str], Any]] = {
     "gridbook.source_passthrough:_build_vllm_mxfp4_moe_method":
         _build_vllm_mxfp4_moe_method,
-    "gridbook.source_passthrough:_build_gridbook_mxfp8_block128_method":
-        _build_gridbook_mxfp8_block128_method,
+    ("gridbook.source_passthrough:"
+     "_build_gridbook_fp8_source_w8a16_method"):
+        _build_gridbook_fp8_source_w8a16_method,
     "gridbook.source_passthrough:_build_gridbook_mxfp8_direct_method":
         _build_gridbook_mxfp8_direct_method,
 }

--- a/tests/test_cb_gemv_select.py
+++ b/tests/test_cb_gemv_select.py
@@ -320,6 +320,8 @@ def test_check_dist_native_floor_tracks_serving_not_retired_research():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     assert "gridbook/csrc/cb_gemv_v2.cu" in mod.REQUIRED
+    assert "gridbook/csrc/fp8_source_w8a16.cu" in mod.REQUIRED
+    assert "gridbook/csrc/mxfp8_dense_gemm.cu" in mod.REQUIRED
     assert "gridbook/csrc/cb_bf16_grouped_gemm.cu" in mod.REQUIRED
     assert "gridbook/csrc/cb_persistent_tc.cu" not in mod.REQUIRED
     assert "gridbook/kernels.py" in mod.FORBIDDEN

--- a/tests/test_dsv4_woa.py
+++ b/tests/test_dsv4_woa.py
@@ -1,4 +1,4 @@
-"""Narrow DeepSeek-V4 output-projection adapter for Gridbook MXFP8 BMM."""
+"""Narrow DeepSeek-V4 output-projection adapter for Gridbook-owned BMM."""
 from __future__ import annotations
 
 import types

--- a/tests/test_dsv4_woa.py
+++ b/tests/test_dsv4_woa.py
@@ -69,9 +69,23 @@ def test_adapter_runs_inverse_rope_group_bmm_then_wo_b():
 def test_adapter_refuses_missing_or_stale_method_protocol():
     attention = _attention()
     setattr(attention.wo_a, dsv4_woa.DSV4_MXFP8_BMM_ATTR, 99)
-    with pytest.raises(RuntimeError, match="does not own the MXFP8 BMM"):
+    with pytest.raises(RuntimeError, match="does not own a supported"):
         dsv4_woa.dsv4_mxfp8_o_proj(
             attention, torch.zeros(1, 4, 2), torch.zeros(1, dtype=torch.long))
+
+
+def test_adapter_accepts_source_fp8_w8a16_bmm_marker():
+    attention = _attention()
+    delattr(attention.wo_a, dsv4_woa.DSV4_MXFP8_BMM_ATTR)
+    setattr(attention.wo_a, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR,
+            dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ABI)
+    o = torch.arange(2 * 4 * 2, dtype=torch.bfloat16).reshape(2, 4, 2)
+    result = dsv4_woa.dsv4_gridbook_o_proj(
+        attention, o, torch.tensor([3, 9]))
+    grouped = (o * 2).reshape(2, 2, 4)
+    expected = torch.einsum(
+        "tgk,grk->tgr", grouped.float(), attention.wo_a.weights)
+    assert torch.equal(result, expected.flatten(1) + 7)
 
 
 def test_class_wrapper_leaves_stock_wo_a_byte_for_byte():

--- a/tests/test_ext_build_identity.py
+++ b/tests/test_ext_build_identity.py
@@ -37,6 +37,7 @@ _LOADER_STATE = (
     ("_fused", "_fused_tried"),
     ("_fused_fp4", "_fused_fp4_tried"),
     ("_fused_fp4v2", "_fused_fp4v2_tried"),
+    ("_fp8_source_w8a16", "_fp8_source_w8a16_tried"),
 )
 
 
@@ -234,6 +235,59 @@ def _fp8_identity_fixture(tmp_path):
     packed.parent.mkdir(parents=True)
     packed.write_text("// packed v1\n")
     return src, cutlass, util
+
+
+def test_source_fp8_w8a16_identity_is_source_complete_without_cutlass(
+        tmp_path):
+    src = tmp_path / "csrc"
+    src.mkdir()
+    source = src / "fp8_source_w8a16.cu"
+    source.write_text("// source W8A16 v1\n")
+    fake_cpp = types.SimpleNamespace(
+        CUDA_HOME="/toolkit", get_cxx_compiler=lambda: "c++")
+
+    before, payload = cuda_ext._fp8_source_w8a16_build_identity(
+        _fake_torch(), fake_cpp, src_dir=str(src), capability=(12, 1))
+    assert payload["schema"] == cuda_ext._FP8_SOURCE_W8A16_ABI_SCHEMA
+    assert set(payload["inputs"]) == {"fp8_source_w8a16.cu"}
+    assert payload["target"]["code"] == "sm_121"
+    assert "cutlass_inputs" not in payload
+
+    source.write_text("// source W8A16 v2\n")
+    after, _ = cuda_ext._fp8_source_w8a16_build_identity(
+        _fake_torch(), fake_cpp, src_dir=str(src), capability=(12, 1))
+    assert after != before
+
+
+def test_source_fp8_w8a16_loader_uses_own_identity_directory(
+        monkeypatch, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _patch_capability(monkeypatch, (12, 1))
+    good = _stub(cuda_ext._FP8_SOURCE_W8A16_SYMBOLS)
+    calls = _patch_load(monkeypatch, good)
+
+    assert cuda_ext.get_fp8_source_w8a16_ext() is good
+    kwargs = calls[0][1]
+    assert re.fullmatch(r"pq_fp8_source_w8a16_[0-9a-f]{64}", kwargs["name"])
+    identity = kwargs["name"].removeprefix("pq_fp8_source_w8a16_")
+    assert kwargs["build_directory"] == str(
+        tmp_path / "fp8_source_w8a16" / identity)
+    assert kwargs["sources"] == [
+        os.path.join(cuda_ext.csrc_dir(), "fp8_source_w8a16.cu")]
+    assert "-gencode=arch=compute_121,code=sm_121" in \
+        kwargs["extra_cuda_cflags"]
+    assert not any("121a" in flag for flag in kwargs["extra_cuda_cflags"])
+    assert good.__gridbook_jit_capability__ == (12, 1)
+
+
+def test_source_fp8_w8a16_rejects_non_spark_before_build(
+        monkeypatch, tmp_path):
+    monkeypatch.setenv("PRISMAQUANT_CB_EXT_DIR", str(tmp_path))
+    _patch_capability(monkeypatch, (12, 0))
+    calls = _patch_load(
+        monkeypatch, error=AssertionError("source W8A16 build ran on sm120"))
+    assert cuda_ext.get_fp8_source_w8a16_ext() is None
+    assert calls == []
 
 
 def test_fp8_identity_names_every_packaged_build_input():

--- a/tests/test_ext_symbols.py
+++ b/tests/test_ext_symbols.py
@@ -383,6 +383,7 @@ def _exports(cu_name):
 @pytest.mark.parametrize("required,cu_name", [
     (cuda_ext._EXT_SYMBOLS, "cb_gemv.cu"),
     (cuda_ext._FUSED_SYMBOLS, "cb_fused_gemm.cu"),
+    (cuda_ext._FP8_SOURCE_W8A16_SYMBOLS, "fp8_source_w8a16.cu"),
 ])
 def test_strict_symbols_exist_in_packaged_source(required, cu_name):
     assert not (set(required) - _exports(cu_name))

--- a/tests/test_fp8_source_loader_dtype_guard.py
+++ b/tests/test_fp8_source_loader_dtype_guard.py
@@ -1,0 +1,124 @@
+"""CPU checks for source-dtype guards on raw FP8 checkpoint loaders."""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def _module(monkeypatch, name):
+    module = types.ModuleType(name)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _install_vllm_method_stubs(monkeypatch):
+    _module(monkeypatch, "vllm")
+    _module(monkeypatch, "vllm.model_executor")
+    _module(monkeypatch, "vllm.model_executor.layers")
+    linear = _module(monkeypatch, "vllm.model_executor.layers.linear")
+    linear.LinearMethodBase = type("LinearMethodBase", (), {})
+    parameter = _module(monkeypatch, "vllm.model_executor.parameter")
+
+    class StubParameter(torch.nn.Parameter):
+        def __new__(cls, data, **kwargs):
+            return super().__new__(cls, data, requires_grad=False)
+
+        def __init__(self, data, **kwargs):
+            for name, value in kwargs.items():
+                setattr(self, name, value)
+
+    parameter.BlockQuantScaleParameter = StubParameter
+    parameter.ModelWeightParameter = StubParameter
+
+
+def _invoke(pattern, loader, param, loaded_weight):
+    if pattern == "default":
+        return loader(param, loaded_weight)
+    if pattern == "fused-positional":
+        return loader(param, loaded_weight, "q")
+    if pattern == "merged-keyword":
+        return loader(
+            param=param,
+            loaded_weight=loaded_weight,
+            loaded_shard_id=1,
+        )
+    raise AssertionError(f"unknown test loader pattern {pattern}")
+
+
+@pytest.mark.parametrize(
+    ("plane", "expected_dtype", "wrong_dtype", "parameter_name"),
+    [
+        ("value-plane", torch.float8_e4m3fn, torch.bfloat16, "weight"),
+        ("scale-plane", torch.float8_e8m0fnu, torch.uint8,
+         "weight_scale_inv"),
+    ],
+)
+@pytest.mark.parametrize(
+    "pattern", ["default", "fused-positional", "merged-keyword"])
+def test_source_loader_rejects_before_delegation_and_preserves_valid_bytes(
+        monkeypatch, plane, expected_dtype, wrong_dtype, parameter_name,
+        pattern):
+    _install_vllm_method_stubs(monkeypatch)
+    from gridbook import fp8_source_w8a16 as lane
+
+    calls = []
+    delegated = object()
+
+    def loader(*args, **kwargs):
+        calls.append((args, kwargs))
+        if args:
+            param, loaded_weight = args[:2]
+        else:
+            param = kwargs["param"]
+            loaded_weight = kwargs["loaded_weight"]
+        param.data.copy_(loaded_weight)
+        return delegated
+
+    method = lane.build_fp8_source_w8a16_method(lane.WIRE_FP8_BLOCK128)
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=4,
+        output_partition_sizes=[4],
+        input_size=4,
+        output_size=4,
+        params_dtype=torch.bfloat16,
+        weight_loader=loader,
+    )
+    param = getattr(layer, parameter_name)
+
+    wrong = torch.zeros(param.shape, dtype=wrong_dtype)
+    before = param.detach().view(torch.uint8).clone()
+    with pytest.raises(
+            TypeError,
+            match=rf"{plane} checkpoint tensor must be exactly "
+                  rf"{expected_dtype} before vLLM loader delegation"):
+        _invoke(pattern, param.weight_loader, param, wrong)
+    assert calls == []
+    assert torch.equal(param.detach().view(torch.uint8), before)
+
+    source = torch.empty(param.shape, dtype=expected_dtype)
+    source.view(torch.uint8).copy_(
+        torch.arange(source.numel(), dtype=torch.uint8).reshape(source.shape))
+    result = _invoke(pattern, param.weight_loader, param, source)
+
+    assert result is delegated
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    if pattern == "default":
+        assert len(args) == 2 and args[0] is param and args[1] is source
+        assert kwargs == {}
+    elif pattern == "fused-positional":
+        assert len(args) == 3 and args[0] is param and args[1] is source
+        assert args[2] == "q" and kwargs == {}
+    else:
+        assert args == ()
+        assert kwargs["param"] is param
+        assert kwargs["loaded_weight"] is source
+        assert kwargs["loaded_shard_id"] == 1
+    assert torch.equal(
+        param.detach().view(torch.uint8), source.detach().view(torch.uint8))

--- a/tests/test_fp8_source_w8a16.py
+++ b/tests/test_fp8_source_w8a16.py
@@ -110,6 +110,12 @@ def _built_layer(monkeypatch, *, groups=1):
     if groups > 1:
         layer.is_bmm = True
         layer.bmm_batch_size = groups
+        # Keep this small tensor focused on group-ordering math. The immutable
+        # release geometry and every near miss are pinned independently in
+        # test_fp8_source_w8a16_geometry.py.
+        monkeypatch.setattr(lane, "_DSV4_BMM_GROUPS", groups)
+        monkeypatch.setattr(lane, "_DSV4_BMM_ROWS", rows)
+        monkeypatch.setattr(lane, "_DSV4_BMM_K", k)
     torch.manual_seed(9)
     layer.weight.data.copy_(
         (torch.randn(groups * rows, k) * 0.25).to(torch.float8_e4m3fn))

--- a/tests/test_fp8_source_w8a16.py
+++ b/tests/test_fp8_source_w8a16.py
@@ -135,6 +135,43 @@ def test_method_accepts_block128_only_before_vllm_import(monkeypatch):
         lane.build_fp8_source_w8a16_method("mxfp8_e4m3_e8m0_g32")
 
 
+def test_source_extension_requires_exact_jit_capability_identity(monkeypatch):
+    from gridbook import cuda_ext, lane_select
+
+    extension = types.SimpleNamespace(
+        fp8_source_gemv=lambda *args: None,
+        fp8_source_expand_bf16=lambda *args: None,
+    )
+    monkeypatch.setattr(
+        lane_select, "device_capability", lambda device=None: (12, 1))
+    monkeypatch.setattr(
+        cuda_ext, "get_fp8_source_w8a16_ext", lambda: extension)
+
+    with pytest.raises(
+            cuda_ext.NativeKernelUnavailableError,
+            match="without Gridbook's JIT build-capability identity"):
+        cuda_ext.require_fp8_source_w8a16_ext("identity gate")
+
+
+def test_source_extension_requires_exact_jit_digest_and_abi(monkeypatch):
+    from gridbook import cuda_ext, lane_select
+
+    extension = types.SimpleNamespace(
+        fp8_source_gemv=lambda *args: None,
+        fp8_source_expand_bf16=lambda *args: None,
+        __gridbook_jit_capability__=(12, 1),
+    )
+    monkeypatch.setattr(
+        lane_select, "device_capability", lambda device=None: (12, 1))
+    monkeypatch.setattr(
+        cuda_ext, "get_fp8_source_w8a16_ext", lambda: extension)
+
+    with pytest.raises(
+            cuda_ext.NativeKernelUnavailableError,
+            match="without the exact Gridbook source/toolchain identity"):
+        cuda_ext.require_fp8_source_w8a16_ext("identity gate")
+
+
 def test_process_keeps_exact_raw_planes_resident(monkeypatch):
     lane, _, method, layer, calls, q_before, s_before = _built_layer(monkeypatch)
     assert type(method).__name__ == "Fp8SourceW8A16LinearMethod"
@@ -159,12 +196,54 @@ def test_dense_decode_and_prefill_choose_native_arms(monkeypatch):
     assert torch.equal(decode, expected_decode)
     assert calls == [("gemv", 2, 1)]
 
+    from gridbook.nvfp4_activation_contract import read_route
+    decode_route = read_route(layer)
+    assert decode_route["policy"] == "source_fp8_w8a16_decode"
+    assert decode_route["symbol"] == "fp8_source_gemv"
+    assert decode_route["shape"] == "M2:N128:K128"
+    assert decode_route["contract"] == "bf16_preserved"
+    assert decode_route["state"] == "served"
+
     calls.clear()
     prefill_x = torch.randn(9, 128, dtype=torch.bfloat16)
     prefill = method.apply(layer, prefill_x)
     expected_prefill = (prefill_x.float() @ w.float().t()).to(torch.bfloat16)
     assert torch.equal(prefill, expected_prefill)
     assert calls == [("expand",), ("grouped", (9,))]
+
+    assert read_route(layer) == {
+        "kind": "dense",
+        "policy": "source_fp8_w8a16_prefill",
+        "symbol": "fp8_source_expand_bf16+cb_bf16_grouped_mm",
+        "tile_m": 0,
+        "shape": "M9:N128:K128",
+        "contract": "bf16_preserved",
+        "state": "served",
+        "reason": None,
+        "tile_candidate_ctas": 0,
+        "tile_sm_count": 0,
+        "tile_rho": 0,
+        "tile_compiled": "",
+    }
+
+
+def test_source_route_telemetry_retains_error_when_launch_raises(monkeypatch):
+    from gridbook import ops
+    from gridbook.nvfp4_activation_contract import read_route
+
+    _, _, method, layer, _, _, _ = _built_layer(monkeypatch)
+    monkeypatch.setattr(
+        ops,
+        "fp8_source_gemv",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("launch failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        method.apply(layer, torch.randn(1, 128, dtype=torch.bfloat16))
+    route = read_route(layer)
+    assert route["symbol"] == "fp8_source_gemv"
+    assert route["state"] == "error"
+    assert route["reason"] == "launch did not return"
 
 
 def test_bmm_decode_and_prefill_preserve_group_mapping(monkeypatch):
@@ -189,6 +268,11 @@ def test_bmm_decode_and_prefill_preserve_group_mapping(monkeypatch):
     prefill_x = torch.randn(9, 2, 128, dtype=torch.bfloat16)
     assert torch.equal(method.apply(layer, prefill_x), oracle(prefill_x))
     assert calls == [("expand",), ("grouped", (9, 18))]
+    from gridbook.nvfp4_activation_contract import read_route
+    route = read_route(layer)
+    assert route["shape"] == "M9:G2:N128:K128"
+    assert route["contract"] == "bf16_preserved"
+    assert route["state"] == "served"
 
 
 def test_apply_refuses_activation_cast_and_bias(monkeypatch):

--- a/tests/test_fp8_source_w8a16.py
+++ b/tests/test_fp8_source_w8a16.py
@@ -1,0 +1,195 @@
+"""CPU contract tests for raw-resident block128 source-FP8 W8A16."""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def _module(monkeypatch, name):
+    module = types.ModuleType(name)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _install_vllm_method_stubs(monkeypatch):
+    _module(monkeypatch, "vllm")
+    _module(monkeypatch, "vllm.model_executor")
+    _module(monkeypatch, "vllm.model_executor.layers")
+    linear = _module(monkeypatch, "vllm.model_executor.layers.linear")
+    linear.LinearMethodBase = type("LinearMethodBase", (), {})
+    parameter = _module(monkeypatch, "vllm.model_executor.parameter")
+
+    class StubParameter(torch.nn.Parameter):
+        def __new__(cls, data, **kwargs):
+            return super().__new__(cls, data, requires_grad=False)
+
+        def __init__(self, data, **kwargs):
+            for name, value in kwargs.items():
+                setattr(self, name, value)
+
+    parameter.BlockQuantScaleParameter = StubParameter
+    parameter.ModelWeightParameter = StubParameter
+
+
+def _dequant_block128(q, scales):
+    scale_bytes = scales.view(torch.uint8)
+    exponents = scale_bytes.to(torch.int16) - 127
+    sf = torch.ldexp(
+        torch.ones_like(exponents, dtype=torch.float32), exponents)
+    sf = sf.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    return (q.float() * sf[:q.shape[0], :q.shape[1]]).to(torch.bfloat16)
+
+
+def _patch_native_contract(monkeypatch, lane, dsv4_woa):
+    from gridbook import cuda_ext, ops
+
+    monkeypatch.setattr(lane, "_require_source_cuda", lambda tensor: None)
+    monkeypatch.setattr(
+        cuda_ext, "require_fp8_source_w8a16_ext",
+        lambda operation="", device=None: object())
+    monkeypatch.setattr(
+        cuda_ext, "require_bf16_grouped_ext",
+        lambda operation="": object())
+    monkeypatch.setattr(dsv4_woa, "install_dsv4_woa_adapter", lambda: None)
+
+    calls = []
+
+    def gemv(x, q, scales, groups):
+        calls.append(("gemv", int(x.shape[0]), groups))
+        w = _dequant_block128(q, scales)
+        rows = q.shape[0] // groups
+        return torch.stack([
+            x[:, group].float() @
+            w[group * rows:(group + 1) * rows].float().t()
+            for group in range(groups)
+        ], dim=1).to(torch.bfloat16).reshape(x.shape[0], q.shape[0])
+
+    def expand(q, scales):
+        calls.append(("expand",))
+        return _dequant_block128(q, scales)
+
+    def grouped_mm(a, weights, expert_ends, expert_start=0):
+        calls.append(("grouped", tuple(int(v) for v in expert_ends.tolist())))
+        out = torch.empty(a.shape[0], weights.shape[1], dtype=torch.bfloat16)
+        start = 0 if expert_start == 0 else int(expert_ends[expert_start - 1])
+        for local, weight in enumerate(weights):
+            end = int(expert_ends[expert_start + local])
+            out[start:end] = (a[start:end].float() @ weight.float().t()).to(
+                torch.bfloat16)
+            start = end
+        return out
+
+    monkeypatch.setattr(ops, "fp8_source_gemv", gemv)
+    monkeypatch.setattr(ops, "fp8_source_expand_bf16", expand)
+    monkeypatch.setattr(ops, "cb_bf16_grouped_mm", grouped_mm)
+    # Exercise the implementation behind the opaque boundary without asking a
+    # CPU-only torch build to dispatch a CUDA custom op.
+    monkeypatch.setattr(
+        ops, "fp8_source_linear_forward",
+        lambda x, layer_id: ops._lookup_cb_layer(layer_id)[0]._apply_inline(
+            ops._lookup_cb_layer(layer_id)[1], x))
+    return calls
+
+
+def _built_layer(monkeypatch, *, groups=1):
+    _install_vllm_method_stubs(monkeypatch)
+    from gridbook import dsv4_woa
+    from gridbook import fp8_source_w8a16 as lane
+
+    calls = _patch_native_contract(monkeypatch, lane, dsv4_woa)
+    rows, k = 128, 128
+    layer = torch.nn.Module()
+    layer.tp_size = 1
+    method = lane.build_fp8_source_w8a16_method(lane.WIRE_FP8_BLOCK128)
+    method.create_weights(
+        layer, k, [groups * rows], k, groups * rows, torch.bfloat16)
+    if groups > 1:
+        layer.is_bmm = True
+        layer.bmm_batch_size = groups
+    torch.manual_seed(9)
+    layer.weight.data.copy_(
+        (torch.randn(groups * rows, k) * 0.25).to(torch.float8_e4m3fn))
+    scale_bytes = torch.tensor(
+        [[127], [128]][:groups], dtype=torch.uint8)
+    layer.weight_scale_inv.data.view(torch.uint8).copy_(scale_bytes)
+    q_before = layer.weight.detach().view(torch.uint8).clone()
+    s_before = layer.weight_scale_inv.detach().view(torch.uint8).clone()
+    method.process_weights_after_loading(layer)
+    return lane, dsv4_woa, method, layer, calls, q_before, s_before
+
+
+def test_method_accepts_block128_only_before_vllm_import(monkeypatch):
+    from gridbook import fp8_source_w8a16 as lane
+
+    with pytest.raises(ValueError, match="accepts only.*direct g32 MXFP8"):
+        lane.build_fp8_source_w8a16_method("mxfp8_e4m3_e8m0_g32")
+
+
+def test_process_keeps_exact_raw_planes_resident(monkeypatch):
+    lane, _, method, layer, calls, q_before, s_before = _built_layer(monkeypatch)
+    assert type(method).__name__ == "Fp8SourceW8A16LinearMethod"
+    assert layer.weight.dtype == torch.float8_e4m3fn
+    assert layer.weight_scale_inv.dtype == torch.float8_e8m0fnu
+    assert torch.equal(layer.weight.detach().view(torch.uint8), q_before)
+    assert torch.equal(layer.weight_scale_inv.detach().view(torch.uint8),
+                       s_before)
+    assert layer._fp8_source_resident_bytes == q_before.numel() + s_before.numel()
+    assert not any(name.startswith("weight_sf") for name, _ in
+                   layer.named_buffers())
+    assert calls == []
+
+
+def test_dense_decode_and_prefill_choose_native_arms(monkeypatch):
+    _, _, method, layer, calls, _, _ = _built_layer(monkeypatch)
+    w = _dequant_block128(layer.weight, layer.weight_scale_inv)
+
+    decode_x = torch.randn(2, 128, dtype=torch.bfloat16)
+    decode = method.apply(layer, decode_x)
+    expected_decode = (decode_x.float() @ w.float().t()).to(torch.bfloat16)
+    assert torch.equal(decode, expected_decode)
+    assert calls == [("gemv", 2, 1)]
+
+    calls.clear()
+    prefill_x = torch.randn(9, 128, dtype=torch.bfloat16)
+    prefill = method.apply(layer, prefill_x)
+    expected_prefill = (prefill_x.float() @ w.float().t()).to(torch.bfloat16)
+    assert torch.equal(prefill, expected_prefill)
+    assert calls == [("expand",), ("grouped", (9,))]
+
+
+def test_bmm_decode_and_prefill_preserve_group_mapping(monkeypatch):
+    _, dsv4_woa, method, layer, calls, _, _ = _built_layer(
+        monkeypatch, groups=2)
+    assert getattr(layer, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR) == \
+        dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ABI
+    w = _dequant_block128(
+        layer.weight, layer.weight_scale_inv).view(2, 128, 128)
+
+    def oracle(x):
+        return torch.stack([
+            (x[:, group].float() @ w[group].float().t()).to(torch.bfloat16)
+            for group in range(2)
+        ], dim=1)
+
+    decode_x = torch.randn(1, 2, 128, dtype=torch.bfloat16)
+    assert torch.equal(method.apply(layer, decode_x), oracle(decode_x))
+    assert calls == [("gemv", 1, 2)]
+
+    calls.clear()
+    prefill_x = torch.randn(9, 2, 128, dtype=torch.bfloat16)
+    assert torch.equal(method.apply(layer, prefill_x), oracle(prefill_x))
+    assert calls == [("expand",), ("grouped", (9, 18))]
+
+
+def test_apply_refuses_activation_cast_and_bias(monkeypatch):
+    _, _, method, layer, _, _, _ = _built_layer(monkeypatch)
+    with pytest.raises(TypeError, match="preserves BF16"):
+        method.apply(layer, torch.zeros(1, 128, dtype=torch.float32))
+    with pytest.raises(ValueError, match="does not serve biased"):
+        method.apply(
+            layer, torch.zeros(1, 128, dtype=torch.bfloat16),
+        torch.zeros(128, dtype=torch.bfloat16))

--- a/tests/test_fp8_source_w8a16_cuda.py
+++ b/tests/test_fp8_source_w8a16_cuda.py
@@ -24,6 +24,7 @@ if tuple(torch.cuda.get_device_capability()) != (12, 1):
                 allow_module_level=True)
 
 from gridbook import cuda_ext, dsv4_woa, ops  # noqa: E402
+from gridbook import fp8_source_w8a16 as source_lane  # noqa: E402
 from gridbook.fp8_source_w8a16 import (  # noqa: E402
     WIRE_FP8_BLOCK128,
     build_fp8_source_w8a16_method,
@@ -242,6 +243,11 @@ def test_large_m_transient_is_not_retained(monkeypatch):
 
 def test_grouped_whole_method_decode_and_prefill_are_isolated(monkeypatch):
     groups, rows, k = 8, 128, 256
+    # This compact case isolates group indexing and leakage. Exact release
+    # geometry is exercised below; CPU refusal coverage pins every near miss.
+    monkeypatch.setattr(source_lane, "_DSV4_BMM_GROUPS", groups)
+    monkeypatch.setattr(source_lane, "_DSV4_BMM_ROWS", rows)
+    monkeypatch.setattr(source_lane, "_DSV4_BMM_K", k)
     q, scales = _raw_planes(groups * rows, k, seed=51)
     method, layer = _layer_for(
         q, scales, groups=groups, monkeypatch=monkeypatch)

--- a/tests/test_fp8_source_w8a16_cuda.py
+++ b/tests/test_fp8_source_w8a16_cuda.py
@@ -1,0 +1,477 @@
+"""Spark release gate for raw-resident block128 source-FP8 W8A16.
+
+The oracle decodes the raw E4M3 and UE8M0 bytes here, independently of every
+Gridbook format helper and native symbol.  The tests exercise the installed
+wheel's two low-level CUDA bindings, the opaque whole-method dispatch, DSV4
+group mapping, fullgraph opacity, changed-input CUDA-graph replay, fail-closed
+contracts, bounded transient lifetime, and non-gating representative timings.
+"""
+from __future__ import annotations
+
+import gc
+import types
+import weakref
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+if not torch.cuda.is_available():
+    pytest.skip("source-FP8 W8A16 release gate needs CUDA",
+                allow_module_level=True)
+if tuple(torch.cuda.get_device_capability()) != (12, 1):
+    pytest.skip("source-FP8 W8A16 release target is Spark / sm_121",
+                allow_module_level=True)
+
+from gridbook import cuda_ext, dsv4_woa, ops  # noqa: E402
+from gridbook.fp8_source_w8a16 import (  # noqa: E402
+    WIRE_FP8_BLOCK128,
+    build_fp8_source_w8a16_method,
+)
+
+SOURCE_EXT = cuda_ext.get_fp8_source_w8a16_ext()
+if SOURCE_EXT is None:
+    pytest.skip("installed source-FP8 W8A16 extension is unavailable",
+                allow_module_level=True)
+GROUPED_EXT = cuda_ext.get_bf16_grouped_ext()
+if GROUPED_EXT is None:
+    pytest.skip("installed grouped-BF16 bridge is unavailable",
+                allow_module_level=True)
+
+DEV = torch.device("cuda")
+
+
+def _raw_planes(n: int, k: int, *, seed: int = 1):
+    """Finite E4M3 bytes plus nontrivial block128 UE8M0 bytes on CUDA."""
+
+    generator = torch.Generator(device=DEV).manual_seed(seed)
+    raw_q = torch.randint(
+        0, 256, (n, k), dtype=torch.uint8, device=DEV,
+        generator=generator)
+    # E4M3FN reserves sign-agnostic exponent=15,mantissa=7 as NaN.
+    raw_q.masked_fill_((raw_q & 0x7f) == 0x7f, 0x7e)
+    scale_shape = ((n + 127) // 128, (k + 127) // 128)
+    raw_scale = torch.randint(
+        118, 126, scale_shape, dtype=torch.uint8, device=DEV,
+        generator=generator)
+    # Make every block visibly distinct so a row/column indexing swap cannot
+    # cancel under random data, including partial edge blocks.
+    row = torch.arange(scale_shape[0], device=DEV, dtype=torch.int16)[:, None]
+    col = torch.arange(scale_shape[1], device=DEV, dtype=torch.int16)[None, :]
+    raw_scale.copy_(((119 + 3 * row + 5 * col) % 13 + 113).to(torch.uint8))
+    return (raw_q.view(torch.float8_e4m3fn),
+            raw_scale.view(torch.float8_e8m0fnu))
+
+
+def _decode_e4m3_bytes(raw: torch.Tensor) -> torch.Tensor:
+    """Independent E4M3FN bit decoder producing FP32."""
+
+    bits = raw.to(torch.int16)
+    sign = torch.where((bits & 0x80) != 0, -1.0, 1.0)
+    exponent = (bits >> 3) & 0x0f
+    mantissa = bits & 0x07
+    subnormal = mantissa.float() * (2.0 ** -9)
+    normal = torch.ldexp(
+        1.0 + mantissa.float() / 8.0,
+        exponent.to(torch.int32) - 7,
+    )
+    decoded = torch.where(exponent == 0, subnormal, normal) * sign
+    return torch.where(
+        (exponent == 15) & (mantissa == 7),
+        torch.full_like(decoded, float("nan")), decoded)
+
+
+def _decode_ue8m0_bytes(raw: torch.Tensor) -> torch.Tensor:
+    """Independent UE8M0 bit decoder producing FP32."""
+
+    bits = raw.to(torch.int16)
+    decoded = torch.ldexp(
+        torch.ones_like(bits, dtype=torch.float32),
+        bits.to(torch.int32) - 127,
+    )
+    return torch.where(bits == 0xff,
+                       torch.full_like(decoded, float("nan")), decoded)
+
+
+def _weight_oracle(q: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    """The exact W8A16 weight: one BF16 round after raw-byte decode."""
+
+    n, k = q.shape
+    sf = _decode_ue8m0_bytes(scales.view(torch.uint8))
+    sf = sf.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    decoded = _decode_e4m3_bytes(q.view(torch.uint8)) * sf[:n, :k]
+    return decoded.to(torch.bfloat16)
+
+
+def _reference(x: torch.Tensor, q: torch.Tensor,
+               scales: torch.Tensor, groups: int = 1) -> torch.Tensor:
+    weight = _weight_oracle(q, scales)
+    rows = q.shape[0] // groups
+    pieces = [
+        x[:, group].float() @
+        weight[group * rows:(group + 1) * rows].float().t()
+        for group in range(groups)
+    ]
+    return torch.stack(pieces, dim=1).to(torch.bfloat16)
+
+
+def _rel_l2(got: torch.Tensor, expected: torch.Tensor) -> float:
+    return float((got.float() - expected.float()).norm()
+                 / expected.float().norm().clamp_min(1e-30))
+
+
+def _assert_reassociated_close(got: torch.Tensor, expected: torch.Tensor,
+                               *, limit: float = 3e-3) -> None:
+    assert got.dtype is torch.bfloat16
+    assert torch.isfinite(got).all()
+    error = _rel_l2(got, expected)
+    assert error <= limit, f"relative L2 {error:.7g} exceeds {limit}"
+
+
+def _layer_for(q: torch.Tensor, scales: torch.Tensor, *, groups: int = 1,
+               monkeypatch=None):
+    method = build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
+    layer = torch.nn.Module()
+    layer.tp_size = 1
+    layer.register_parameter(
+        "weight", torch.nn.Parameter(q, requires_grad=False))
+    layer.register_parameter(
+        "weight_scale_inv", torch.nn.Parameter(scales, requires_grad=False))
+    if groups > 1:
+        layer.is_bmm = True
+        layer.bmm_batch_size = groups
+        if monkeypatch is not None:
+            monkeypatch.setattr(
+                dsv4_woa, "install_dsv4_woa_adapter", lambda: None)
+    # Mirror vLLM's authoritative ownership edge in addition to the local
+    # variable: the weak custom-op registry must never own model storage.
+    layer.quant_method = method
+    method.process_weights_after_loading(layer)
+    return method, layer
+
+
+def test_expander_is_bit_exact_at_both_partial_block_boundaries():
+    q, scales = _raw_planes(257, 385, seed=11)
+    got = SOURCE_EXT.fp8_source_expand_bf16(q, scales)
+    expected = _weight_oracle(q, scales)
+    assert tuple(got.shape) == (257, 385)
+    assert torch.equal(got.view(torch.int16), expected.view(torch.int16))
+
+
+@pytest.mark.parametrize("m", [1, 2, 4, 8])
+def test_raw_gemv_m1_m2_m4_m8_matches_independent_oracle(m):
+    q, scales = _raw_planes(257, 385, seed=100 + m)
+    x = torch.randn(m, 1, 385, device=DEV, dtype=torch.bfloat16) * 0.125
+    got = SOURCE_EXT.fp8_source_gemv(x.contiguous(), q, scales, 1)
+    expected = _reference(x, q, scales).reshape(m, 257)
+    _assert_reassociated_close(got, expected)
+
+
+@pytest.mark.parametrize("n,k", [
+    (8192, 4096),
+    (32768, 1024),
+    (4096, 8192),
+])
+def test_decode_covers_each_distinct_dsv4_source_shape(n, k):
+    q, scales = _raw_planes(n, k, seed=n + k)
+    x = torch.randn(1, 1, k, device=DEV, dtype=torch.bfloat16) * 0.03125
+    got = SOURCE_EXT.fp8_source_gemv(x, q, scales, 1)
+    expected = _reference(x, q, scales).reshape(1, n)
+    _assert_reassociated_close(got, expected, limit=4e-3)
+
+
+def test_low_level_ops_honor_a_nondefault_stream():
+    q, scales = _raw_planes(256, 384, seed=31)
+    x = torch.randn(4, 1, 384, device=DEV, dtype=torch.bfloat16)
+    producer = torch.cuda.current_stream()
+    worker = torch.cuda.Stream()
+    worker.wait_stream(producer)
+    with torch.cuda.stream(worker):
+        expanded = SOURCE_EXT.fp8_source_expand_bf16(q, scales)
+        got = SOURCE_EXT.fp8_source_gemv(x, q, scales, 1)
+    producer.wait_stream(worker)
+    expected_w = _weight_oracle(q, scales)
+    expected_y = _reference(x, q, scales).reshape(4, 256)
+    assert torch.equal(expanded.view(torch.int16),
+                       expected_w.view(torch.int16))
+    _assert_reassociated_close(got, expected_y)
+
+
+def test_dense_whole_method_decode_and_prefill_keep_activation_bf16():
+    q, scales = _raw_planes(256, 256, seed=41)
+    q_bits = q.view(torch.uint8).clone()
+    scale_bits = scales.view(torch.uint8).clone()
+    method, layer = _layer_for(q, scales)
+
+    # Model loading preserves only the exact source planes as resident state.
+    assert torch.equal(layer.weight.view(torch.uint8), q_bits)
+    assert torch.equal(layer.weight_scale_inv.view(torch.uint8), scale_bits)
+    assert layer._fp8_source_resident_bytes == q.numel() + scales.numel()
+    assert not [tensor for tensor in layer.parameters()
+                if tensor.dtype is torch.bfloat16]
+
+    for m in (1, 8, 9, 33):
+        x = torch.randn(m, 256, device=DEV, dtype=torch.bfloat16)
+        before = x.view(torch.int16).clone()
+        got = method.apply(layer, x)
+        expected = _reference(x.view(m, 1, 256), q, scales).reshape(m, 256)
+        _assert_reassociated_close(got, expected)
+        assert torch.equal(x.view(torch.int16), before)
+
+
+def test_large_m_transient_is_not_retained(monkeypatch):
+    q, scales = _raw_planes(256, 256, seed=43)
+    method, layer = _layer_for(q, scales)
+    seen = []
+    original = ops.fp8_source_expand_bf16
+
+    def tracked(*args):
+        transient = original(*args)
+        seen.append(weakref.ref(transient))
+        return transient
+
+    monkeypatch.setattr(ops, "fp8_source_expand_bf16", tracked)
+    output = method.apply(
+        layer, torch.randn(9, 256, device=DEV, dtype=torch.bfloat16))
+    torch.cuda.synchronize()
+    gc.collect()
+    assert output.shape == (9, 256)
+    assert len(seen) == 1 and seen[0]() is None
+    assert not any(t.dtype is torch.bfloat16 for t in layer.parameters())
+
+
+def test_grouped_whole_method_decode_and_prefill_are_isolated(monkeypatch):
+    groups, rows, k = 8, 128, 256
+    q, scales = _raw_planes(groups * rows, k, seed=51)
+    method, layer = _layer_for(
+        q, scales, groups=groups, monkeypatch=monkeypatch)
+    assert getattr(layer, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR) == \
+        dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ABI
+
+    for m in (1, 8, 9, 32):
+        x = torch.randn(m, groups, k, device=DEV, dtype=torch.bfloat16)
+        got = method.apply(layer, x)
+        expected = _reference(x, q, scales, groups=groups)
+        _assert_reassociated_close(got, expected)
+        assert tuple(got.shape) == (m, groups, rows)
+
+    # One nonzero group cannot leak into any other output group.
+    isolated = torch.zeros(1, groups, k, device=DEV, dtype=torch.bfloat16)
+    isolated[:, 3] = torch.randn(1, k, device=DEV, dtype=torch.bfloat16)
+    got = method.apply(layer, isolated)
+    assert torch.count_nonzero(got[:, :3]) == 0
+    assert torch.count_nonzero(got[:, 4:]) == 0
+
+
+def test_exact_dsv4_wo_a_geometry_decode_and_prefill(monkeypatch):
+    groups, rows, k = 8, 1024, 4096
+    q, scales = _raw_planes(groups * rows, k, seed=61)
+    method, layer = _layer_for(
+        q, scales, groups=groups, monkeypatch=monkeypatch)
+    for m in (1, 9):
+        x = torch.randn(m, groups, k, device=DEV, dtype=torch.bfloat16) * 0.125
+        got = method.apply(layer, x)
+        expected = _reference(x, q, scales, groups=groups)
+        _assert_reassociated_close(got, expected, limit=4e-3)
+
+
+def test_fullgraph_contains_only_the_outer_source_dispatch_node():
+    q, scales = _raw_planes(256, 256, seed=71)
+    method, layer = _layer_for(q, scales)
+    traced = []
+
+    def backend(graph_module, example_inputs):
+        del example_inputs
+        traced.append(graph_module)
+        return graph_module.forward
+
+    def run(value):
+        return method.apply(layer, value)
+
+    compiled = torch.compile(run, backend=backend, fullgraph=True)
+    first = torch.randn(2, 256, device=DEV, dtype=torch.bfloat16)
+    second = torch.randn(2, 256, device=DEV, dtype=torch.bfloat16)
+    _assert_reassociated_close(compiled(first), run(first))
+    _assert_reassociated_close(compiled(second), run(second))
+    assert len(traced) == 1
+    nodes = [node for node in traced[0].graph.nodes
+             if node.op == "call_function" and
+             "prismaquant" in str(node.target)]
+    assert len(nodes) == 1
+    assert "fp8_source_linear_forward" in str(nodes[0].target)
+
+
+@pytest.mark.parametrize("m", [1, 2, 4, 8])
+def test_cuda_graph_replay_uses_changed_inputs_and_matches_eager(m):
+    q, scales = _raw_planes(256, 256, seed=80 + m)
+    method, layer = _layer_for(q, scales)
+    static_x = torch.randn(m, 256, device=DEV, dtype=torch.bfloat16)
+
+    # Warm all Python/module-load work before capture.
+    method.apply(layer, static_x)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = method.apply(layer, static_x)
+
+    previous = None
+    for seed in (901 + m, 1901 + m):
+        generator = torch.Generator(device=DEV).manual_seed(seed)
+        changed = torch.randn(
+            static_x.shape, generator=generator, device=DEV,
+            dtype=torch.bfloat16)
+        static_x.copy_(changed)
+        graph.replay()
+        torch.cuda.synchronize()
+        replayed = captured.clone()
+        eager = method.apply(layer, changed)
+        assert torch.equal(replayed.view(torch.int16), eager.view(torch.int16))
+        if previous is not None:
+            assert not torch.equal(replayed.view(torch.int16), previous)
+        previous = replayed.view(torch.int16).clone()
+
+
+def test_low_level_invalid_contracts_fail_closed():
+    q, scales = _raw_planes(256, 256, seed=91)
+    x = torch.zeros(1, 1, 256, device=DEV, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="BF16 activations"):
+        SOURCE_EXT.fp8_source_gemv(x.float(), q, scales, 1)
+    with pytest.raises(RuntimeError, match="1 <= M <= 8"):
+        SOURCE_EXT.fp8_source_gemv(
+            torch.zeros(9, 1, 256, device=DEV, dtype=torch.bfloat16),
+            q, scales, 1)
+    with pytest.raises(RuntimeError, match="divisible by groups"):
+        SOURCE_EXT.fp8_source_gemv(
+            torch.zeros(1, 3, 256, device=DEV, dtype=torch.bfloat16),
+            q, scales, 3)
+    with pytest.raises(RuntimeError, match="float8_e4m3fn"):
+        SOURCE_EXT.fp8_source_expand_bf16(q.float(), scales)
+    with pytest.raises(RuntimeError, match="scale shape"):
+        SOURCE_EXT.fp8_source_expand_bf16(q, scales[:-1])
+    with pytest.raises(RuntimeError, match="contiguous"):
+        SOURCE_EXT.fp8_source_expand_bf16(q.t(), scales)
+    with pytest.raises(RuntimeError, match="CUDA tensors"):
+        SOURCE_EXT.fp8_source_expand_bf16(q.cpu(), scales.cpu())
+
+
+def test_method_and_loader_invalid_contracts_fail_closed(monkeypatch):
+    q, scales = _raw_planes(256, 256, seed=93)
+    method, layer = _layer_for(q, scales)
+    with pytest.raises(TypeError, match="preserves BF16"):
+        method.apply(layer, torch.zeros(1, 256, device=DEV))
+    with pytest.raises(ValueError, match="does not serve biased"):
+        method.apply(
+            layer, torch.zeros(1, 256, device=DEV, dtype=torch.bfloat16),
+            torch.zeros(256, device=DEV, dtype=torch.bfloat16))
+
+    incomplete = types.SimpleNamespace(fp8_source_gemv=lambda *args: None)
+    monkeypatch.setattr(
+        cuda_ext, "get_fp8_source_w8a16_ext", lambda: incomplete)
+    with pytest.raises(cuda_ext.NativeKernelUnavailableError,
+                       match="fp8_source_expand_bf16"):
+        cuda_ext.require_fp8_source_w8a16_ext(
+            "missing-symbol gate", device=DEV)
+
+    stale = types.SimpleNamespace(
+        fp8_source_gemv=lambda *args: None,
+        fp8_source_expand_bf16=lambda *args: None,
+        __gridbook_jit_capability__=(12, 0),
+    )
+    monkeypatch.setattr(cuda_ext, "get_fp8_source_w8a16_ext", lambda: stale)
+    with pytest.raises(cuda_ext.NativeKernelUnavailableError,
+                       match="built for compute capability 12.0"):
+        cuda_ext.require_fp8_source_w8a16_ext(
+            "stale-capability gate", device=DEV)
+
+
+def test_model_load_refuses_missing_prefill_bridge_and_bad_geometry(
+        monkeypatch):
+    q, scales = _raw_planes(256, 256, seed=95)
+    method = build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight", torch.nn.Parameter(q, requires_grad=False))
+    layer.register_parameter(
+        "weight_scale_inv", torch.nn.Parameter(scales, requires_grad=False))
+    monkeypatch.setattr(
+        cuda_ext, "require_bf16_grouped_ext",
+        lambda operation="": (_ for _ in ()).throw(
+            cuda_ext.NativeKernelUnavailableError("bridge unavailable")))
+    with pytest.raises(cuda_ext.NativeKernelUnavailableError,
+                       match="bridge unavailable"):
+        method.process_weights_after_loading(layer)
+
+    bad_method = build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
+    bad = torch.nn.Module()
+    bad.is_bmm = True
+    bad.bmm_batch_size = 3
+    bad.tp_size = 1
+    bad.register_parameter(
+        "weight", torch.nn.Parameter(q, requires_grad=False))
+    bad.register_parameter(
+        "weight_scale_inv", torch.nn.Parameter(scales, requires_grad=False))
+    with pytest.raises(ValueError, match="dividing N"):
+        bad_method.process_weights_after_loading(bad)
+
+    cpu_method = build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
+    cpu_layer = torch.nn.Module()
+    cpu_layer.register_parameter(
+        "weight", torch.nn.Parameter(q.cpu(), requires_grad=False))
+    cpu_layer.register_parameter(
+        "weight_scale_inv",
+        torch.nn.Parameter(scales.cpu(), requires_grad=False))
+    with pytest.raises(RuntimeError, match="requires CUDA"):
+        cpu_method.process_weights_after_loading(cpu_layer)
+
+
+def _time_ms(fn, *, warmup: int = 2, iterations: int = 5) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end)) / iterations
+
+
+def test_reports_non_gating_representative_dsv4_timings():
+    """Print release-device microtimings; no promotion threshold is inferred."""
+
+    n, k = 8192, 4096
+    q, scales = _raw_planes(n, k, seed=101)
+    decode_x = torch.randn(1, 1, k, device=DEV, dtype=torch.bfloat16)
+    prefill_x = torch.randn(64, k, device=DEV, dtype=torch.bfloat16)
+    ends_dense = torch.tensor([64], device=DEV, dtype=torch.int32)
+    grouped_x = torch.randn(64, 8, k, device=DEV, dtype=torch.bfloat16)
+    grouped_a = grouped_x.permute(1, 0, 2).contiguous().view(8 * 64, k)
+    ends_grouped = torch.arange(
+        1, 9, device=DEV, dtype=torch.int32) * 64
+
+    decode_ms = _time_ms(
+        lambda: SOURCE_EXT.fp8_source_gemv(decode_x, q, scales, 1))
+
+    def dense_prefill():
+        weight = ops.fp8_source_expand_bf16(q, scales)
+        return ops.cb_bf16_grouped_mm(
+            prefill_x, weight.view(1, n, k), ends_dense, 0)
+
+    def grouped_prefill():
+        weight = ops.fp8_source_expand_bf16(q, scales)
+        return ops.cb_bf16_grouped_mm(
+            grouped_a, weight.view(8, 1024, k), ends_grouped, 0)
+
+    dense_ms = _time_ms(dense_prefill)
+    grouped_ms = _time_ms(grouped_prefill)
+    print(
+        "source_fp8_w8a16_non_gating_timing "
+        f"device={torch.cuda.get_device_name()} cc=12.1 "
+        f"decode_M1_N8192_K4096_ms={decode_ms:.4f} "
+        f"dense_M64_N8192_K4096_ms={dense_ms:.4f} "
+        f"wo_a_M64_G8_N1024_K4096_ms={grouped_ms:.4f}",
+        flush=True,
+    )
+    assert decode_ms > 0 and dense_ms > 0 and grouped_ms > 0

--- a/tests/test_fp8_source_w8a16_cuda.py
+++ b/tests/test_fp8_source_w8a16_cuda.py
@@ -161,10 +161,12 @@ def test_expander_is_bit_exact_at_both_partial_block_boundaries():
 
 @pytest.mark.parametrize("m", [1, 2, 4, 8])
 def test_raw_gemv_m1_m2_m4_m8_matches_independent_oracle(m):
-    q, scales = _raw_planes(257, 385, seed=100 + m)
-    x = torch.randn(m, 1, 385, device=DEV, dtype=torch.bfloat16) * 0.125
+    # Partial block128 edges remain supported within the native bridge's
+    # eight-element alignment contract.
+    q, scales = _raw_planes(264, 392, seed=100 + m)
+    x = torch.randn(m, 1, 392, device=DEV, dtype=torch.bfloat16) * 0.125
     got = SOURCE_EXT.fp8_source_gemv(x.contiguous(), q, scales, 1)
-    expected = _reference(x, q, scales).reshape(m, 257)
+    expected = _reference(x, q, scales).reshape(m, 264)
     _assert_reassociated_close(got, expected)
 
 
@@ -350,6 +352,16 @@ def test_low_level_invalid_contracts_fail_closed():
         SOURCE_EXT.fp8_source_gemv(
             torch.zeros(1, 3, 256, device=DEV, dtype=torch.bfloat16),
             q, scales, 3)
+    q_bad_k, scales_bad_k = _raw_planes(256, 255, seed=92)
+    with pytest.raises(RuntimeError, match="K divisible by 8"):
+        SOURCE_EXT.fp8_source_gemv(
+            torch.zeros(1, 1, 255, device=DEV, dtype=torch.bfloat16),
+            q_bad_k, scales_bad_k, 1)
+    q_bad_rows, scales_bad_rows = _raw_planes(258, 256, seed=94)
+    with pytest.raises(RuntimeError, match="per-group N divisible by 8"):
+        SOURCE_EXT.fp8_source_gemv(
+            torch.zeros(1, 3, 256, device=DEV, dtype=torch.bfloat16),
+            q_bad_rows, scales_bad_rows, 3)
     with pytest.raises(RuntimeError, match="float8_e4m3fn"):
         SOURCE_EXT.fp8_source_expand_bf16(q.float(), scales)
     with pytest.raises(RuntimeError, match="scale shape"):

--- a/tests/test_fp8_source_w8a16_geometry.py
+++ b/tests/test_fp8_source_w8a16_geometry.py
@@ -1,0 +1,151 @@
+"""CPU-only admission gates for source-FP8 W8A16 grouped BMM geometry."""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def _module(monkeypatch, name):
+    module = types.ModuleType(name)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _method(monkeypatch):
+    _module(monkeypatch, "vllm")
+    _module(monkeypatch, "vllm.model_executor")
+    _module(monkeypatch, "vllm.model_executor.layers")
+    linear = _module(monkeypatch, "vllm.model_executor.layers.linear")
+    linear.LinearMethodBase = type("LinearMethodBase", (), {})
+    parameter = _module(monkeypatch, "vllm.model_executor.parameter")
+    parameter.BlockQuantScaleParameter = type(
+        "BlockQuantScaleParameter", (), {})
+    parameter.ModelWeightParameter = type("ModelWeightParameter", (), {})
+
+    from gridbook import fp8_source_w8a16 as lane
+
+    return lane, lane.build_fp8_source_w8a16_method(
+        lane.WIRE_FP8_BLOCK128)
+
+
+def _layer(*, groups, rows, k, tp_size, is_bmm=True):
+    layer = torch.nn.Module()
+    total_rows = groups * rows
+    q = torch.empty(
+        total_rows, k, dtype=torch.float8_e4m3fn, device="meta")
+    scales = torch.empty(
+        (total_rows + 127) // 128,
+        (k + 127) // 128,
+        dtype=torch.float8_e8m0fnu,
+        device="meta",
+    )
+    layer.register_parameter(
+        "weight", torch.nn.Parameter(q, requires_grad=False))
+    layer.register_parameter(
+        "weight_scale_inv", torch.nn.Parameter(scales, requires_grad=False))
+    layer.tp_size = tp_size
+    if is_bmm:
+        layer.is_bmm = True
+        layer.bmm_batch_size = groups
+    return layer
+
+
+def _patch_load_edges(monkeypatch, lane):
+    from gridbook import cuda_ext, dsv4_woa, ops
+
+    calls = []
+    monkeypatch.setattr(lane, "_require_source_cuda", lambda tensor: None)
+    monkeypatch.setattr(
+        cuda_ext,
+        "require_fp8_source_w8a16_ext",
+        lambda operation="", device=None: calls.append("source_ext"),
+    )
+    monkeypatch.setattr(
+        cuda_ext,
+        "require_bf16_grouped_ext",
+        lambda operation="": calls.append("grouped_ext"),
+    )
+    monkeypatch.setattr(
+        ops, "register_cb_layer", lambda method, layer: 17)
+    monkeypatch.setattr(
+        dsv4_woa,
+        "install_dsv4_woa_adapter",
+        lambda: calls.append("adapter"),
+    )
+    return dsv4_woa, calls
+
+
+@pytest.mark.parametrize(
+    ("groups", "rows", "k", "tp_size", "got"),
+    (
+        (7, 1024, 4096, 1, "G=7, N=1024, K=4096, TP=1"),
+        (8, 896, 4096, 1, "G=8, N=896, K=4096, TP=1"),
+        (8, 1024, 3968, 1, "G=8, N=1024, K=3968, TP=1"),
+        (8, 1024, 4096, 2, "G=8, N=1024, K=4096, TP=2"),
+    ),
+)
+def test_grouped_geometry_near_miss_refuses_before_native_resolution_or_marker(
+        monkeypatch, groups, rows, k, tp_size, got):
+    lane, method = _method(monkeypatch)
+    dsv4_woa, calls = _patch_load_edges(monkeypatch, lane)
+    layer = _layer(
+        groups=groups, rows=rows, k=k, tp_size=tp_size)
+
+    with pytest.raises(ValueError, match="qualified only") as exc:
+        method.process_weights_after_loading(layer)
+
+    message = str(exc.value)
+    assert "G=8, N=1024, K=4096, TP=1" in message
+    assert got in message
+    assert calls == []
+    assert not hasattr(layer, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR)
+    assert not hasattr(layer, lane._READY_ATTR)
+
+
+def test_exact_grouped_geometry_resolves_both_arms_then_installs_marker(
+        monkeypatch):
+    lane, method = _method(monkeypatch)
+    dsv4_woa, calls = _patch_load_edges(monkeypatch, lane)
+    layer = _layer(groups=8, rows=1024, k=4096, tp_size=1)
+
+    method.process_weights_after_loading(layer)
+
+    assert calls == ["source_ext", "grouped_ext", "adapter"]
+    assert layer._fp8_source_groups == 8
+    assert layer._fp8_source_rows == 1024
+    assert layer._fp8_source_K == 4096
+    assert getattr(layer, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR) == \
+        dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ABI
+
+
+def test_dense_geometry_remains_separate_from_grouped_dsv4_gate(monkeypatch):
+    lane, method = _method(monkeypatch)
+    dsv4_woa, calls = _patch_load_edges(monkeypatch, lane)
+    layer = _layer(
+        groups=1, rows=136, k=256, tp_size=1, is_bmm=False)
+
+    method.process_weights_after_loading(layer)
+
+    assert calls == ["source_ext", "grouped_ext"]
+    assert layer._fp8_source_groups == 1
+    assert layer._fp8_source_rows == 136
+    assert layer._fp8_source_K == 256
+    assert not hasattr(layer, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR)
+
+
+def test_dense_tp_near_miss_refuses_before_native_resolution(monkeypatch):
+    lane, method = _method(monkeypatch)
+    dsv4_woa, calls = _patch_load_edges(monkeypatch, lane)
+    layer = _layer(
+        groups=1, rows=136, k=256, tp_size=2, is_bmm=False)
+
+    with pytest.raises(ValueError, match="dense serving.*TP=1.*TP=2"):
+        method.process_weights_after_loading(layer)
+
+    assert calls == []
+    assert not hasattr(layer, dsv4_woa.DSV4_FP8_SOURCE_W8A16_BMM_ATTR)
+    assert not hasattr(layer, lane._READY_ATTR)

--- a/tests/test_fused_preload.py
+++ b/tests/test_fused_preload.py
@@ -24,13 +24,14 @@ LOADERS = {
     "fp4v2": "get_fused_fp4v2_ext",                   # cb_fused_fp4v2_gemm.cu
     "moe_persistent_b": "get_moe_persistent_b_ext",   # cb_moe_persistent_b.cu
     "mxfp8_dense": "get_mxfp8_dense_ext",             # mxfp8_dense_gemm.cu
+    "fp8_source_w8a16": "get_fp8_source_w8a16_ext",   # fp8_source_w8a16.cu
 }
 
 
 def _patch_all(monkeypatch, calls, *, resident=(), raises=()):
     """Replace EVERY loader with a recording stub.
 
-    All eight must be stubbed in every test: the warm-up really does call all
+    All nine must be stubbed in every test: the warm-up really does call all
     of them now, so an unpatched loader would start a real multi-minute nvcc
     build inside the test run. Any family the implementation has grown past
     this file is stubbed too, so inventory drift is reported by the coverage
@@ -48,8 +49,8 @@ def _patch_all(monkeypatch, calls, *, resident=(), raises=()):
         monkeypatch.setattr(cuda_ext, attr, stub)
 
 
-def test_registry_names_exactly_the_eight_loader_families():
-    """The warm-up inventory is all eight modules — no more, no fewer."""
+def test_registry_names_exactly_the_nine_loader_families():
+    """The warm-up inventory is all nine modules — no more, no fewer."""
     assert dict(cuda_ext._PRELOAD_FAMILIES) == LOADERS
     assert len(cuda_ext._PRELOAD_FAMILIES) == len(LOADERS)  # no duplicate keys
     for attr in LOADERS.values():
@@ -57,7 +58,7 @@ def test_registry_names_exactly_the_eight_loader_families():
 
 
 def test_preload_attempts_every_loader_family(monkeypatch):
-    """All eight independent JIT modules are warmed, each exactly once."""
+    """All nine independent JIT modules are warmed, each exactly once."""
     calls = []
     _patch_all(monkeypatch, calls, resident=set(LOADERS))
 

--- a/tests/test_mixed_fused_linear.py
+++ b/tests/test_mixed_fused_linear.py
@@ -28,9 +28,9 @@ from gridbook.moe_toplevel_loader import (  # noqa: E402
     install_toplevel_cb_expert_loader,
     mixed_fused_loader_active,
 )
-from gridbook.mxfp8_dense_lane import (  # noqa: E402
+from gridbook.fp8_source_w8a16 import (  # noqa: E402
     WIRE_FP8_BLOCK128,
-    build_mxfp8_dense_method,
+    build_fp8_source_w8a16_method,
 )
 
 
@@ -176,7 +176,7 @@ def test_homogeneous_source_fusion_uses_native_merged_shard_loader():
     layer.output_size = 256
     layer.tp_size = 1
     layer.tp_rank = 0
-    method = build_mxfp8_dense_method(WIRE_FP8_BLOCK128)
+    method = build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
     method.create_weights(
         layer, 128, [128, 128], 128, 256, torch.bfloat16,
         weight_loader=layer.weight_loader,
@@ -205,7 +205,7 @@ def _parent() -> torch.nn.Module:
     (
         lambda cfg: [
             ("model.layers.5.ffn.shared_experts.w1",
-             build_mxfp8_dense_method(WIRE_FP8_BLOCK128)),
+             build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)),
             ("model.layers.5.ffn.shared_experts.w3",
              PrismaQuantCBLinearMethod(cfg, K38, "role.w3")),
         ],

--- a/tests/test_mxfp8_dense_bmm.py
+++ b/tests/test_mxfp8_dense_bmm.py
@@ -1,4 +1,4 @@
-"""BMM ownership for DSV4 ``wo_a`` in the Gridbook MXFP8 dense lane."""
+"""Direct-g32 W8A8 BMM ownership in the Gridbook MXFP8 dense lane."""
 from __future__ import annotations
 
 import sys
@@ -57,7 +57,7 @@ class _IdentitySfExtension:
         return mxfp8_reference_mm(a_q, a_sf, b_q, b_sf)
 
 
-def test_block128_bmm_keeps_group_scales_and_outputs_isolated(
+def test_direct_g32_bmm_keeps_group_scales_and_outputs_isolated(
     monkeypatch, isolated_gridbook_runtime_imports
 ):
     del isolated_gridbook_runtime_imports
@@ -65,11 +65,7 @@ def test_block128_bmm_keeps_group_scales_and_outputs_isolated(
 
     from gridbook import dsv4_woa
     from gridbook import mxfp8_dense_lane as lane
-    from gridbook.mxfp8 import (
-        broadcast_block128_scales,
-        dequant_mxfp8,
-        quantize_mxfp8,
-    )
+    from gridbook.mxfp8 import dequant_mxfp8, quantize_mxfp8
 
     extension = _IdentitySfExtension()
     lane._OFFSETS._cache.clear()
@@ -79,7 +75,7 @@ def test_block128_bmm_keeps_group_scales_and_outputs_isolated(
     groups, rows, k = 2, 128, 128
     layer = torch.nn.Module()
     layer.tp_size = 1
-    method = lane.build_mxfp8_dense_method(lane.WIRE_FP8_BLOCK128)
+    method = lane.build_mxfp8_dense_method(lane.WIRE_MXFP8_G32)
     method.create_weights(
         layer, k, [groups * rows], k, groups * rows, torch.bfloat16)
     # Matches vLLM: these BMM attributes appear after ColumnParallelLinear's
@@ -90,12 +86,15 @@ def test_block128_bmm_keeps_group_scales_and_outputs_isolated(
     torch.manual_seed(13)
     layer.weight.data.copy_(
         (torch.randn(groups * rows, k) * 12).to(torch.float8_e4m3fn))
-    scale_bytes = torch.tensor([[124], [130]], dtype=torch.uint8)
-    layer.weight_scale_inv.data.view(torch.uint8).copy_(scale_bytes)
+    scale_bytes = torch.cat([
+        torch.full((rows, k // 32), 124, dtype=torch.uint8),
+        torch.full((rows, k // 32), 130, dtype=torch.uint8),
+    ])
+    layer.weight_scale.data.view(torch.uint8).copy_(scale_bytes)
     weight_before = layer.weight.detach().clone()
 
     method.process_weights_after_loading(layer)
-    assert not hasattr(layer, "weight_scale_inv")
+    assert not hasattr(layer, "weight_scale")
     assert tuple(layer.weight_sf_planes.shape) == (groups, rows * (k // 32))
     assert getattr(layer, dsv4_woa.DSV4_MXFP8_BMM_ATTR) == \
         dsv4_woa.DSV4_MXFP8_BMM_ABI
@@ -105,8 +104,7 @@ def test_block128_bmm_keeps_group_scales_and_outputs_isolated(
     assert tuple(result.shape) == (3, groups, rows)
 
     a_q, a_sf = quantize_mxfp8(x)
-    full_sf = broadcast_block128_scales(
-        scale_bytes, groups * rows, k).reshape(groups, rows, k // 32)
+    full_sf = scale_bytes.reshape(groups, rows, k // 32)
     weights = weight_before.reshape(groups, rows, k)
     expected = torch.stack([
         (dequant_mxfp8(a_q[:, group], a_sf[:, group]) @
@@ -130,7 +128,7 @@ def test_bmm_apply_refuses_unfinalized_planes(
 
     extension = _IdentitySfExtension()
     monkeypatch.setattr(lane, "_require_lane_ext", lambda device=None: extension)
-    method = lane.build_mxfp8_dense_method(lane.WIRE_FP8_BLOCK128)
+    method = lane.build_mxfp8_dense_method(lane.WIRE_MXFP8_G32)
     layer = types.SimpleNamespace(
         is_bmm=True,
         bmm_batch_size=2,

--- a/tests/test_mxfp8_dense_gemm.py
+++ b/tests/test_mxfp8_dense_gemm.py
@@ -4,7 +4,9 @@ The full audit (real DSV4-Flash body tensors, seven distinct shapes, worst
 rel-Frobenius 5.9e-5) ran against the checkpoint on the GB10 and is recorded
 in ``source_passthrough.py``; these tests keep the fast, checkpoint-free core
 of it pinned in CI: SF-plane offsets from the mainloop's own layout, synthetic
-kernel-vs-oracle parity, and the DeepSeek block-128 embedding end-to-end.
+kernel-vs-oracle parity, and the mathematical DeepSeek block-128 embedding.
+That embedding remains reference coverage; serving block128 source weights is
+owned by the separate W8A16 lane and does not enter this W8A8 kernel.
 """
 import pytest
 
@@ -61,9 +63,10 @@ def test_kernel_matches_fp32_oracle(m, n, k):
 
 
 def test_deepseek_block128_embedding_end_to_end():
-    """Block-quantized weights -> broadcast scales -> swizzled plane ->
+    """Reference-only: block weights -> broadcast scales -> swizzled plane ->
     kernel, judged against the block-dequant oracle (NOT the broadcast one),
-    so the whole embedding chain is what is being verified."""
+    so the mathematical embedding is verified without claiming serving
+    ownership for this W8A8 lane."""
     torch.manual_seed(1)
     n, k, m = 136, 576, 64
     w_q = (torch.randn(n, k) * 64).to(torch.float8_e4m3fn)

--- a/tests/test_mxfp8_dense_lane.py
+++ b/tests/test_mxfp8_dense_lane.py
@@ -12,11 +12,12 @@ from gridbook import lane_select  # noqa: E402
 from gridbook import source_passthrough as sp  # noqa: E402
 from gridbook.mxfp8_dense_lane import (  # noqa: E402
     MXFP8_DENSE_FLAG,
-    WIRE_FP8_BLOCK128,
     WIRE_MXFP8_G32,
     build_mxfp8_dense_method,
     mxfp8_dense_enabled,
 )
+
+WIRE_FP8_BLOCK128 = "fp8_e4m3_ue8m0_block128"
 
 
 @pytest.fixture(autouse=True)
@@ -43,14 +44,24 @@ def test_unknown_wire_id_refused_before_any_vllm_import():
         build_mxfp8_dense_method("mxfp8_e5m2_g32")
 
 
-def test_registry_carries_both_wire_spellings():
+def test_block128_hard_refuses_the_w8a8_mxfp8_method():
+    with pytest.raises(ValueError, match="W8A16.*cannot enter.*W8A8"):
+        build_mxfp8_dense_method(WIRE_FP8_BLOCK128)
+
+
+def test_registry_splits_block_w8a16_from_direct_g32_w8a8():
     assert WIRE_FP8_BLOCK128 in sp.FORMATS
     assert WIRE_MXFP8_G32 in sp.FORMATS
     direct = sp.FORMATS[WIRE_MXFP8_G32]
     assert direct.unit_kind == "linear"
     assert direct.audited_backends == frozenset({"Mxfp8DenseLinearMethod"})
     assert direct.audited_capabilities == ((12, 1),)
-    for fmt in (sp.FORMATS[WIRE_FP8_BLOCK128], direct):
+    block = sp.FORMATS[WIRE_FP8_BLOCK128]
+    assert block.audited_backends == frozenset({
+        "Fp8SourceW8A16LinearMethod"})
+    assert block.quantizes_activations is False
+    assert direct.quantizes_activations is True
+    for fmt in (block, direct):
         assert fmt.method_factory in sp._FACTORIES
 
 
@@ -68,14 +79,11 @@ def test_parse_declaration_accepts_mxfp8_linear_units():
     assert resolved["model.layers.3.mlp.shared_experts.w1"].id == WIRE_MXFP8_G32
 
 
-@pytest.mark.parametrize("factory_name", [
-    "gridbook.source_passthrough:_build_gridbook_mxfp8_block128_method",
-    "gridbook.source_passthrough:_build_gridbook_mxfp8_direct_method",
-])
-def test_opt_in_gate_refuses_with_flag_named(factory_name):
+def test_direct_g32_opt_in_gate_refuses_with_flag_named():
     """OPT-IN as a load-time refusal: correctness is audited, the serve-parity
     bench is pending, and the lane must not enable itself."""
-    factory = sp._FACTORIES[factory_name]
+    factory = sp._FACTORIES[
+        "gridbook.source_passthrough:_build_gridbook_mxfp8_direct_method"]
     with pytest.raises(sp.SourcePassthroughError) as exc:
         factory(None, "model.layers.3.self_attn.wq_a")
     msg = str(exc.value)
@@ -89,7 +97,7 @@ def test_opt_in_gate_opens_with_flag_and_fails_only_on_vllm(monkeypatch):
     accident of a missing dependency."""
     monkeypatch.setenv(MXFP8_DENSE_FLAG, "1")
     factory = sp._FACTORIES[
-        "gridbook.source_passthrough:_build_gridbook_mxfp8_block128_method"]
+        "gridbook.source_passthrough:_build_gridbook_mxfp8_direct_method"]
     try:
         method = factory(None, "u")
     except ModuleNotFoundError as exc:
@@ -98,7 +106,7 @@ def test_opt_in_gate_opens_with_flag_and_fails_only_on_vllm(monkeypatch):
         assert type(method).__name__ == "Mxfp8DenseLinearMethod"
 
 
-def test_audited_and_broken_sets_stay_disjoint_for_mxfp8_entries():
+def test_audited_and_broken_sets_stay_disjoint_for_fp8_source_entries():
     for wire in (WIRE_FP8_BLOCK128, WIRE_MXFP8_G32):
         fmt = sp.FORMATS[wire]
         assert not (fmt.audited_backends & set(fmt.known_broken_backends))

--- a/tests/test_mxfp8_format.py
+++ b/tests/test_mxfp8_format.py
@@ -1,10 +1,12 @@
-"""MXFP8 reference semantics and the DeepSeek block-128 embedding (CPU-only).
+"""MXFP8 reference semantics and a block-128 embedding proof (CPU-only).
 
 The embedding claim these tests pin: DeepSeek's FP8 convention (E4M3 values,
 one UE8M0 scale per 128x128 tile) embeds EXACTLY into MXFP8 (same values, one
 UE8M0 scale per 32 K-elements) by scale replication — 128 = 4 * 32, so a chunk
 never straddles a tile, and the map ``SF_mx[n, c] = S_ds[n // 128, c // 4]``
-is total, arithmetic-free and bit-exact.
+is total, arithmetic-free and bit-exact. This is a mathematical/reference
+property, not the operational route: source block-FP8 is served by the separate
+W8A16 lane and is never activation-quantized through the MXFP8 W8A8 method.
 """
 import pytest
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -21,6 +21,7 @@ import ast
 import os
 from pathlib import Path
 import re
+import runpy
 import subprocess
 
 import gridbook
@@ -41,6 +42,8 @@ SDIST_ONLY_GLOBS = ("gridbook/csrc/tools/*",
 WHEEL_REQUIRED = (
     "cb_gemv.cu",
     "cb_gemv_v2.cu",
+    "fp8_source_w8a16.cu",
+    "mxfp8_dense_gemm.cu",
     "cb_bf16_grouped_gemm.cu",
     "cb_fused_gemm.cu",
     "cb_fused_fp4_gemm.cu",
@@ -119,6 +122,29 @@ def test_sdist_only_split_is_declared_in_all_three_places():
     declared = re.search(r"SDIST_ONLY_GLOBS = \[(.*?)\]", gate, flags=re.S)
     assert declared is not None, "check_dist.py has no SDIST_ONLY_GLOBS list"
     assert declared.group(1).count("f\"{PKG}/") == len(SDIST_ONLY_GLOBS)
+
+
+def test_native_serving_floor_mirrors_are_exactly_equal():
+    """The three literal source floors must advance in the same change.
+
+    A package-data glob catches files that exist in a checkout, but it cannot
+    keep an installed-wheel probe or a future checkout's non-vacuous floor in
+    sync. Normalizing and comparing the mirrors makes the documented lockstep
+    relationship executable.
+    """
+    if not _source_checkout():
+        pytest.skip("release scripts are not shipped in the wheel")
+
+    dist = runpy.run_path(str(ROOT / ".github/scripts/check_dist.py"))
+    installed = runpy.run_path(
+        str(ROOT / ".github/scripts/check_installed.py")
+    )
+    dist_floor = {
+        path.removeprefix("gridbook/") for path in dist["REQUIRED"]
+    }
+    installed_floor = set(installed["REQUIRED_SOURCES"])
+    metadata_floor = {f"csrc/{path}" for path in WHEEL_REQUIRED}
+    assert dist_floor == installed_floor == metadata_floor
 
 
 def test_cpu_gate_locates_source_utilities_without_ci_environment(tmp_path):

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -34,8 +34,10 @@ def test_packaged_contract_loads_and_validates():
     contract = load_runtime_contract()
     assert contract == raw
     assert contract["schema"] == RUNTIME_CONTRACT_SCHEMA
+    assert contract["contract_version"] == 3
     assert contract["abi_features"] == {
         "routed_moe_per_role_codebook_lut": 1,
+        "source_fp8_block128_w8a16": 1,
     }
 
 
@@ -143,7 +145,7 @@ def _wrong_schema(contract):
 
 
 def _wrong_contract_version(contract):
-    contract["contract_version"] = 1
+    contract["contract_version"] = 2
 
 
 def _canonical_not_accepted(contract):
@@ -188,6 +190,14 @@ def _wrong_per_role_lut_capability(contract):
     contract["abi_features"]["routed_moe_per_role_codebook_lut"] = 2
 
 
+def _missing_source_fp8_w8a16_capability(contract):
+    del contract["abi_features"]["source_fp8_block128_w8a16"]
+
+
+def _wrong_source_fp8_w8a16_capability(contract):
+    contract["abi_features"]["source_fp8_block128_w8a16"] = 2
+
+
 def _unsupported_format_mode(contract):
     contract["formats"][0]["mode"] = "full"
 
@@ -207,6 +217,9 @@ def _unsupported_format_mode(contract):
         (_missing_per_role_lut_capability,
          "routed_moe_per_role_codebook_lut"),
         (_wrong_per_role_lut_capability, "must be 1"),
+        (_missing_source_fp8_w8a16_capability,
+         "source_fp8_block128_w8a16"),
+        (_wrong_source_fp8_w8a16_capability, "must be 1"),
         (_unsupported_format_mode, "unsupported grid/mode pair"),
     ],
 )

--- a/tests/test_source_passthrough.py
+++ b/tests/test_source_passthrough.py
@@ -93,6 +93,13 @@ class Mxfp8DenseLinearMethod:
 Mxfp8DenseLinearMethod.__module__ = "gridbook.mxfp8_dense_lane"
 
 
+class Fp8SourceW8A16LinearMethod:
+    """Gridbook's terminal block128 source-FP8 W8A16 lane."""
+
+
+Fp8SourceW8A16LinearMethod.__module__ = "gridbook.fp8_source_w8a16"
+
+
 def _declaration(units, version=1):
     return {SCHEMA_KEY: {"version": version, "units": units}}
 
@@ -281,42 +288,27 @@ def test_format_with_empty_audited_set_refuses_everything():
 def test_fp8_block_verdict_is_gridbook_owned_route():
     """The VERDICT pin — this test SHOULD fail when the verdict changes.
 
-    Every vLLM 0.24 rung for UE8M0 128x128 blocks on sm_121 measured broken
-    (the known_broken_backends record each symptom), so the audited route is
-    Gridbook's own MXFP8 dense lane: the block form embeds exactly into MXFP8
-    (128 = 4 * 32, scale replication, bit-exact) and the stock sm120
-    block-scaled collective serves it.  Correctness audit 2026-08-03 on
-    sm_121: kernel-vs-fp32-oracle rel-Frobenius worst 5.9e-5 over the seven
-    distinct ordinary DSV4-Flash body shapes at M in {1, 64, 512}, under the
-    at-most-1e-4 numeric contract rather than a bit-exact contract; the
-    DeepSeek-embedding path (block scales -> broadcast -> plane -> kernel)
-    worst 1.2e-4 vs the block-dequant oracle.  The grouped wo_a artifact
-    geometry (G=8, N=1024, K=4096) is separately checked on the immutable eugr
-    vLLM 0.26.1rc1.dev515+g653ebb52d.d20260808 baseline: M=1 max-abs 0.03125
-    and relative Frobenius 1.2460984e-5; M=64 max-abs 0.25 and relative
-    Frobenius 4.4897934e-5.
-
-    Note (same date): the activation quantizer's exponent rule was moved from
-    ``ceil(log2(...))`` to the producer-matching frexp form after a measured
-    boundary defect (15 saturations / 6e6 group maxima).  The parity numbers
-    above stand unchanged as KERNEL claims: kernel and oracle consumed the
-    same quantized operands in every comparison, so the quantizer defect
-    cancelled identically on both sides.
+    Every stock vLLM rung for UE8M0 128x128 blocks on sm_121 remains recorded
+    as broken.  The Gridbook-owned route now preserves BF16 activations and
+    the raw checkpoint planes; evidence is pending, so the verdict pin is the
+    explicit method/activation contract rather than a stale W8A8 claim.
     """
     fmt = FORMATS[FP8_BLOCK]
-    assert fmt.audited_backends == frozenset({"Mxfp8DenseLinearMethod"})
+    assert fmt.audited_backends == frozenset({
+        "Fp8SourceW8A16LinearMethod"})
+    assert fmt.quantizes_activations is False
     # The vLLM delegation outcomes stay recorded: a refusal for one of those
     # classes must name the measured symptom, not a generic UNKNOWN.
     assert {"DeepGemmFp8BlockScaledMMKernel", "CutlassFp8BlockScaledMMKernel",
             "TritonFp8BlockScaledMMKernel"} <= set(fmt.known_broken_backends)
-    assert "GRIDBOOK_MXFP8_DENSE" in fmt.remedy
+    assert "source_fp8_block128_w8a16" in fmt.remedy
 
 
 def test_gridbook_native_method_is_itself_the_audited_backend():
     require_native_passthrough_backend(
         prefix="model.layers.0.self_attn.q_proj",
         source_format=FORMATS[FP8_BLOCK],
-        method=Mxfp8DenseLinearMethod(),
+        method=Fp8SourceW8A16LinearMethod(),
     )
 
 

--- a/tests/test_source_passthrough.py
+++ b/tests/test_source_passthrough.py
@@ -272,8 +272,8 @@ def test_format_with_empty_audited_set_refuses_everything():
 
     Uses a synthetic format rather than a real registry entry, so this stays
     true whatever the registry's current verdicts are — the fp8-block entry
-    carried the empty set until Gridbook's own MXFP8 lane was audited, and the
-    verdict pin for that entry lives in
+    carried the empty set until Gridbook's source-FP8 W8A16 lane was admitted,
+    and the verdict pin for that entry lives in
     ``test_fp8_block_verdict_is_gridbook_owned_route`` below.
     """
     blocked = FORMATS[FP8_BLOCK]._replace(audited_backends=frozenset())

--- a/tests/test_source_passthrough_dispatch.py
+++ b/tests/test_source_passthrough_dispatch.py
@@ -314,7 +314,7 @@ def test_passthrough_linear_unit_dispatches_through_the_same_guard(monkeypatch):
 
 def test_fp8_block_broken_vllm_rung_still_named_and_refused(monkeypatch):
     """A measured-broken vLLM rung refuses BY NAME even now that the format's
-    audited route is Gridbook's own MXFP8 lane: if dispatch ever resolves one
+    audited route is Gridbook's source-FP8 W8A16 lane: if dispatch resolves one
     of the broken classes, the operator gets the diagnosed symptom rather
     than a generic UNKNOWN."""
     monkeypatch.setattr(config_mod, "_live_device_capability",


### PR DESCRIPTION
## What changed

- add the dedicated raw-resident DeepSeek block-FP8 W8A16 loader and CUDA path
- preserve BF16 activations while keeping E4M3 weights and UE8M0 scales resident
- cover exact DSv4 dense and grouped geometry, strict dtype/ABI/JIT identity, graph replay, and route telemetry
- bump Gridbook to 0.8.5 and document the release contract

## Why

The DSv4Flash source checkpoint stores ordinary body Linears as block-128 E4M3 plus one-byte UE8M0 scales. Re-encoding those weights as direct G32 MXFP8 would dynamically quantize activations and violate the intended W8A16 source-passthrough contract. This release gives those source bytes their own fail-closed native route.

## Validation

- full CPU suite: 1044 passed, 141 skipped
- strict distribution check: passed with zero warnings
- installed-wheel GB10/sm121 GPU gate: 91 passed, 0 skipped in 71.23 seconds
- exact wheel SHA-256: `51122fab1533d538230836b103cef9f438dbea015a75c671437e52392cf90d4d`

Full DSv4 artifact eager/graph serving, native-parity performance, and served quality remain post-export ship gates in PrismaQuant.
