### PR TITLE
release: integrate DSV4 DSpark and exact GEMV v2

### DIFF
--- a/.github/scripts/check_dist.py
+++ b/.github/scripts/check_dist.py
@@ -162,6 +162,8 @@ SDIST_REQUIRED_UTILITIES = [
     "scripts/prepare_lfm_fused_validation.py",
     "scripts/validate_fused_nvfp4_ab.py",
     "scripts/validate_fused_nvfp4_three_arm.py",
+    "scripts/validate_moe_persistent_b_ab.py",
+    "scripts/validate_moe_gemv_v2_ab.py",
 ]
 
 _errors: list[str] = []

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,26 @@ jobs:
       environment: ${{ steps.meta.outputs.environment }}
       repository_url: ${{ steps.meta.outputs.repository_url }}
       project_url: ${{ steps.meta.outputs.project_url }}
+      wheel_sha256: ${{ steps.meta.outputs.wheel_sha256 }}
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          # The release tag must be proven reachable from the public release
+          # branch.  A one-commit checkout cannot establish that ancestry.
+          fetch-depth: 0
+
+      - name: Tag commit must be reachable from master
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            +refs/heads/master:refs/remotes/origin/master
+          tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
+          master_commit="$(git rev-parse refs/remotes/origin/master)"
+          if ! git merge-base --is-ancestor "${tag_commit}" "${master_commit}"; then
+            echo "::error::${GITHUB_REF_NAME} targets ${tag_commit}, which is not reachable from origin/master ${master_commit}"
+            exit 1
+          fi
+          echo "${GITHUB_REF_NAME}: ${tag_commit} is reachable from origin/master ${master_commit}"
 
       - uses: actions/setup-python@v7.0.0
         with:
@@ -61,7 +79,7 @@ jobs:
         id: meta
         run: |
           python - "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT" <<'PY'
-          import glob, os, sys
+          import glob, hashlib, os, sys
           from packaging.utils import parse_wheel_filename
           from packaging.version import Version
 
@@ -85,6 +103,10 @@ jobs:
                                      else "https://upload.pypi.org/legacy/"))
           print("project_url=" + ("https://test.pypi.org/p/gridbook" if pre
                                   else "https://pypi.org/p/gridbook"))
+          with open(wheels[0], "rb") as handle:
+              wheel_sha256 = hashlib.file_digest(handle, "sha256").hexdigest()
+          print(f"wheel_sha256={wheel_sha256}")
+          print(f"wheel sha256: {wheel_sha256}", file=sys.stderr)
           print(f"{built} -> {'TestPyPI' if pre else 'PyPI'}", file=sys.stderr)
           PY
 
@@ -113,6 +135,22 @@ jobs:
         with:
           name: dist
           path: dist
+
+      - name: Downloaded wheel must match the build receipt
+        env:
+          EXPECTED_WHEEL_SHA256: ${{ needs.build.outputs.wheel_sha256 }}
+        run: |
+          python - "$EXPECTED_WHEEL_SHA256" <<'PY'
+          import glob, hashlib, sys
+          wheels = glob.glob("dist/*.whl")
+          if len(wheels) != 1:
+              sys.exit(f"expected exactly one wheel, got {wheels}")
+          with open(wheels[0], "rb") as handle:
+              actual = hashlib.file_digest(handle, "sha256").hexdigest()
+          if actual != sys.argv[1]:
+              sys.exit(f"wheel digest changed after build: {actual} != {sys.argv[1]}")
+          print(f"verified wheel sha256: {actual}")
+          PY
 
       - name: Install CPU torch
         run: |
@@ -156,6 +194,22 @@ jobs:
           name: dist
           path: dist
 
+      - name: Downloaded wheel must match the verified build
+        env:
+          EXPECTED_WHEEL_SHA256: ${{ needs.build.outputs.wheel_sha256 }}
+        run: |
+          python - "$EXPECTED_WHEEL_SHA256" <<'PY'
+          import glob, hashlib, sys
+          wheels = glob.glob("dist/*.whl")
+          if len(wheels) != 1:
+              sys.exit(f"expected exactly one wheel, got {wheels}")
+          with open(wheels[0], "rb") as handle:
+              actual = hashlib.file_digest(handle, "sha256").hexdigest()
+          if actual != sys.argv[1]:
+              sys.exit(f"wheel digest changed before publish: {actual} != {sys.argv[1]}")
+          print(f"verified wheel sha256: {actual}")
+          PY
+
       # Pinned to an exact release rather than the `release/v1` branch that
       # PyPA's own docs suggest: a branch ref is re-pointable, and this action
       # holds an OIDC token that can upload under our project name.
@@ -178,6 +232,22 @@ jobs:
         with:
           name: dist
           path: dist
+
+      - name: Release wheel must match the published build
+        env:
+          EXPECTED_WHEEL_SHA256: ${{ needs.build.outputs.wheel_sha256 }}
+        run: |
+          python - "$EXPECTED_WHEEL_SHA256" <<'PY'
+          import glob, hashlib, sys
+          wheels = glob.glob("dist/*.whl")
+          if len(wheels) != 1:
+              sys.exit(f"expected exactly one wheel, got {wheels}")
+          with open(wheels[0], "rb") as handle:
+              actual = hashlib.file_digest(handle, "sha256").hexdigest()
+          if actual != sys.argv[1]:
+              sys.exit(f"wheel digest changed before GitHub Release: {actual} != {sys.argv[1]}")
+          print(f"verified wheel sha256: {actual}")
+          PY
 
       # gh is preinstalled on GitHub-hosted runners, so the release step needs
       # no third-party action and no extra pin. GH_REPO is required because this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 0.8.6 — 2026-08-13
+
+- **Load separately quantized DeepSeek-V4 DSpark drafts without rewriting
+  namespaces.** DSpark constructs quantization methods under
+  `model.layers.{L+stage}`, registers parameters under
+  `model.layers.{stage}`, and stores draft tensors under `mtp.{stage}`.
+  Gridbook now reuses DSpark's own `_remap_dspark_name` at the top-level load
+  boundary, including routed-expert stacks and mixed fused roles, so those
+  three namespaces reconcile explicitly and fail closed on ambiguity.
+
+- DSpark construction now binds Gridbook's lazy `quant_config.json` and
+  `cb_codebooks.pqcb` lookup to vLLM's explicit
+  `speculative_config.draft_model_config`. The target body keeps its own
+  `model_config` authority even when speculation is configured; a missing or
+  malformed explicit draft config fails before draft initialization. This
+  prevents a separately quantized draft from accidentally opening the target
+  model's sidecars.
+
+- The optional `gridbook.dspark-target-bridge.v1` record binds activation
+  scalar targets to physical checkpoint tensors when an activation execution
+  contract exists. Weight-only CB drafts do not invent an activation bridge;
+  their construction-to-registered loader mapping is still covered by the
+  new `abi_features.dspark_construction_physical_bridge = 1` runtime feature.
+  The packaged loader allow-list now includes the unforked vLLM DSpark module.
+  Adding this closed feature advances the producer/runtime contract from v3 to
+  v4; consumers must not reinterpret the expanded key set as the older schema.
+
+- This release adds no new quantization format. Target-only serving remains the
+  DSV4-Flash shipping default. On the exact qualified candidate
+  stack, native MXFP4 DSpark improved the fixed eager 8 x 128 suite by only
+  `0.95%` while adding `10.13 GiB` of model residency, and K12-CB regressed
+  throughput by `10.81%`; DSpark therefore remains an opt-in experimental
+  companion rather than a production default. The final clean-commit image
+  still has to repeat the release smoke before tagging.
+
+- The optional smem-resident FP4-CB decode GEMV now preserves the inherited
+  default's exact reduction order on DSV4 K=2048/4096 via eight named virtual
+  warp accumulators. The final-source cc 12.1 gate (source SHA256
+  `d72b15ecaad14e7af07f8af555259f5d1423cee2dacce160c13b3caf7b8bc92b`)
+  passed 30/30 eager/graph operator tests for k12/k16/k18 and both decode
+  contracts, measured a bit-exact 1.8175–1.9977x v1 direct-op speedup, and
+  produced zero full-vocabulary KL, NLL, PPL, and target-logprob delta over 240
+  same-process DSV4 positions. This is a release-shape candidate behind
+  explicit `PRISMAQUANT_CB_GEMV=v2`, with every `PRISMAQUANT_CB_W2_*` override
+  absent; the global default remains `inherited`, and final clean-wheel served
+  graph/throughput qualification remains open. Exact evidence paths are in
+  `docs/RELEASING.md`.
+
+- Routed dispatch now handles vLLM's `VLLM_MOE_SKIP_PADDING` convention at
+  Gridbook's opaque MoE boundary. The documented expert-id `-1` padding
+  sentinel is mapped to a valid placeholder expert and its router weight is
+  replaced with exact zero using device-only tensor operations; every other
+  expert id remains unchanged, caller tensors are not mutated, and the
+  separately scheduled shared-expert path is untouched. Previously a fully
+  padded profile batch reached Gridbook's routed-count `scatter_add_` with
+  `-1` indices and raised a CUDA device-side bounds assertion, later reported
+  at the next codebook-expansion API call.
+
+- Dense CB methods now reject `is_bmm` layers during weight finalization.
+  DeepSeek-V4 `attn.wo_a` is a grouped BMM whose result shape cannot be
+  represented by the dense CB method; released DSpark sidecars must keep its
+  three projections on the already-qualified source-FP8 W8A16 route. A future
+  grouped-CB implementation needs its own numeric and performance gate.
+
 ## 0.8.5 — 2026-08-12
 
 - **Correct source block-FP8 serving to W8A16.** The

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
 repository-code: "https://github.com/RobTand/gridbook"
 url: "https://github.com/RobTand/gridbook"
 license: Apache-2.0
-version: "0.8.5"
-date-released: 2026-08-12
+version: "0.8.6"
+date-released: 2026-08-13
 keywords:
   - quantization
   - vector-quantization

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,8 @@ recursive-include tests *.py
 include scripts/prepare_lfm_fused_validation.py
 include scripts/validate_fused_nvfp4_ab.py
 include scripts/validate_fused_nvfp4_three_arm.py
+include scripts/validate_moe_persistent_b_ab.py
+include scripts/validate_moe_gemv_v2_ab.py
 
 # Developer tools that live inside the package directory but are NOT package
 # data: standalone main() binaries (gridbook/csrc/tools/) that nothing loads at

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,21 @@ Two things banked from an attempt that was reverted before it shipped:
 - [ ] **K1.4 — Complete graph and alternate-schedule qualification.** Run the
   exact-byte 27B streaming gate for `FULL_DECODE_ONLY` CUDA graphs, and qualify
   `cb_gemv_v2` on `sm_120` with same-session quality, telemetry, long prefill,
-  concurrency, and soak coverage before considering a default change.
+  concurrency, and soak coverage before considering a default change. The
+  source-distributed `scripts/validate_moe_gemv_v2_ab.py` now provides the
+  fail-closed same-engine quality component for the exact dsv4flash0731
+  artifact: fixed 8x16 full-vocabulary teacher forcing, exact 35 FP4/8 FP8
+  inventory, per-request inherited/v2/FP8 dispatch counts, and exception-safe
+  restoration. **Source-tree DSV4 operator and quality components passed on
+  2026-08-13** for `cb_gemv_v2.cu` SHA256
+  `d72b15ecaad14e7af07f8af555259f5d1423cee2dacce160c13b3caf7b8bc92b`:
+  30/30 exact operator/graph tests, a bit-exact 1.8175–1.9977x v1 direct-op
+  benchmark across k12/k16/k18 x K2048/4096, and zero full-vocabulary
+  KL/NLL/PPL/target-logprob delta over 240 same-process positions. The item
+  remains OPEN: the global default is still `inherited`, and the final clean
+  wheel/image must still pass served graph replay, throughput, concurrency,
+  long-prefill, soak, and memory gates. Evidence paths are recorded in
+  `docs/RELEASING.md`.
 - [ ] **K1.5 — Pack expert blocks *within* a chunk, not only across a whole
   layer.** The sm12x grouped-BF16 lane's swizzle-group-aligned expert order is
   gated on `chunk >= E`, because a narrower chunk indexes blocks as
@@ -297,11 +311,20 @@ Two things banked from an attempt that was reverted before it shipped:
 
 #### Before DSV4 Flash (integration, not new kernels)
 
-- [x] **D0.1 — Establish the exact serving contract.** Done for the body, MTP
-  and DSpark, against vLLM **0.24.0** and the released
-  `deepseek-ai/DeepSeek-V4-Flash-0731` config. `deepseek_v4` is now a
-  registered producer profile and
-  `vllm.models.deepseek_v4.nvidia.model` a registered top-level loader module.
+- [x] **D0.1 — Establish the exact serving contract.** The body was first
+  audited against vLLM **0.24.0**; the body plus DSpark integration is now
+  requalified on the immutable 2026-08-13 EUGR image
+  `sha256:58862b388e0fab05a5c9b673f21d1d7b41a1123953a2d9ace49aae6c79319869`
+  with vLLM `0.26.1rc1.dev693+g7f7a32cfe.d20260812` at
+  `7f7a32cfec0f1bc5b73c37200b86631523a1ea8f`, torch `2.13.0+cu130`, and
+  FlashInfer `0.6.18` at
+  `9ffd99510d92b883f154fc9f2e3d5aac93e231ca`. The startup canary requires
+  native SM120 DSV4 `(head_dim=64, topk=256)` dispatch and
+  `VLLM_MOE_SKIP_PADDING=True`. This uses the released
+  `deepseek-ai/DeepSeek-V4-Flash-0731` config. `deepseek_v4` is a registered
+  producer profile; both `vllm.models.deepseek_v4.nvidia.model` and
+  `vllm.models.deepseek_v4.nvidia.dspark` are registered top-level loader
+  modules.
   What the inspection actually established, each of which changed the wiring:
   - **The architecture is not where the contract could name it.** vLLM 0.24
     ships DSV4 as a per-platform *package*; `DeepseekV4ForCausalLM` is DEFINED
@@ -333,14 +356,22 @@ Two things banked from an attempt that was reverted before it shipped:
     KV (`fused_wqa_wkv` is built `disable_tp=True`). No narrowly scoped TP
     implementation is required, so none was added and the existing rejection
     above one stands.
-  - **MTP/DSpark are passthrough, not served.** `DeepseekV4ForCausalLM.
-    load_weights` builds `AutoWeightsLoader(self, skip_substrs=["mtp."])`, so
-    all 4,705 `mtp.*` tensors are dropped before any parameter lookup; the
-    drafter `DeepSeekV4MTPModel` is reachable only through
-    `--speculative-config`; and `dspark` appears **nowhere** in the vLLM
-    package, so none of the four `dspark_*` config keys is read. The contract
-    therefore preserves them as producer passthrough and claims none of them —
-    it invents no support vLLM lacks.
+  - **MTP/DSpark stays isolated from the target body and is an explicit 0.8.6
+    integration candidate.** `DeepseekV4ForCausalLM.load_weights` still builds
+    `AutoWeightsLoader(self, skip_substrs=["mtp."])`, so all 4,705 `mtp.*`
+    tensors are dropped before body-only parameter lookup. Under
+    `--speculative-config`, the qualified vLLM runtime instead constructs the
+    separate `DSparkDeepseekV4ForCausalLM` entrypoint from
+    `vllm.models.deepseek_v4.nvidia.dspark`. Runtime-contract v4 registers that
+    defining module; Gridbook scopes sidecar lookup to the explicit draft model
+    config, reuses DSpark's own physical-to-registered name mapper, and keeps
+    construction prefixes distinct. Exact-artifact eager load, generation,
+    residency, acceptance, and paired-throughput classification now pass on
+    the qualified candidate image. Target-only remains the shipping default:
+    native MXFP4 DSpark improved the fixed 8 x 128 suite only from `10.2389` to
+    `10.3364` tok/s while increasing residency from `95.12` to `105.25` GiB,
+    and K12-CB regressed to `9.1319` tok/s. DSpark remains opt-in experimental,
+    not a served-parity or graph/128k claim.
   - **Not every DSV4 Linear is CB-eligible.** `ffn.gate`, both
     `compressor.fused_wkv_wgate`s, `indexer.weights_proj`, `lm_head` and
     `embed_tokens` are built with no quant config. `attn.wo_a` is created and
@@ -354,9 +385,11 @@ Two things banked from an attempt that was reverted before it shipped:
     documented in [`docs/PLUGIN.md`](docs/PLUGIN.md) and
     [`docs/RELEASING.md`](docs/RELEASING.md).
 
-  Remaining work is release evidence, not another operator contract:
-  exact-artifact load/generate, served parity, graph replay, and performance
-  must be recorded through the DSV4-Flash release gate before promotion.
+  Remaining work is release provenance, not another operator contract: rebuild
+  from the clean 0.8.6 commit, repeat the target-only exact-artifact smoke, and
+  bind the final image/wheel identities. Graph replay and DSpark performance
+  parity remain separate promotion gates; they do not change the target-only
+  release default.
 - [ ] **D0.2 — Complete packed-expert native delegation if the assignment needs
   it.** Reuse Gridbook's existing top-level expert-loader path, canonical
   producer packers/metadata, and a version-attested upstream vLLM backend for

--- a/docker/Dockerfile.gridbook-pinned
+++ b/docker/Dockerfile.gridbook-pinned
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE=gridbook:local
 FROM ${BASE_IMAGE}
 
-ARG GRIDBOOK_REF=v0.8.5
+ARG GRIDBOOK_REF=v0.8.6
 
 USER root
 RUN test -n "${GRIDBOOK_REF}" \

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -100,18 +100,23 @@ serving image, using [`docker/Dockerfile.gridbook-pinned`](../docker/Dockerfile.
 docker build \
   -f docker/Dockerfile.gridbook-pinned \
   --build-arg BASE_IMAGE=gridbook:local \
-  --build-arg GRIDBOOK_REF=v0.8.5 \
-  -t gridbook:v0.8.5-pinned .
+  --build-arg GRIDBOOK_REF=v0.8.6 \
+  -t gridbook:v0.8.6-pinned .
 ```
 
 `GRIDBOOK_REF` is parameterized so the same recipe works for a release tag or,
 during a pre-tag rehearsal, the exact release commit SHA. For a release image,
-use the immutable `v0.8.5` tag. The direct-VCS requirement causes pip to write
+use the immutable `v0.8.6` tag. The direct-VCS requirement causes pip to write
 the requested ref and resolved 40-character commit to the installed
 distribution's PEP 610 `direct_url.json`; the Docker build reads that record
 back and fails if the requested revision or resolved commit is absent. This is
 the attestation-clean path: provisioning happens in an auditable image layer,
 not as an unrecorded mutation when the server starts.
+
+This generic recipe retains the repository's vLLM 0.24 base by default and is
+not the DeepSeek-V4 DSpark-qualified image. DSV4-Flash must use the exact EUGR,
+vLLM, torch, and FlashInfer tuple plus the `(64, 256)` startup canary recorded
+in [`PLUGIN.md`](PLUGIN.md) and [`RELEASING.md`](RELEASING.md).
 
 Then serve from the derived image with the same arguments shown above. On the
 0.6B smoke, the one-time image build took **383 s**, while an actual serve start

--- a/docs/KERNELS.md
+++ b/docs/KERNELS.md
@@ -562,15 +562,34 @@ k48 L1 cliff), applied to the MoE M≤16 grouped-decode regime. It opts in to th
 rowpack request at 48 KB), so the k20/k24 staged configurations are only
 expressible in the new kernel. The loader admits only the native Blackwell
 target capabilities (12.0/12.1) with at least 99 KiB opt-in shared memory; this
-PR's execution battery covers cc 12.1, not cc 12.0. It
-is **not** bit-exact against the default
-grouped schedule — a native schedule-reassociation class — and it is
-**not** a default: unset means `inherited`. Explicit `auto` or `v2` reaches it
-only where the hardware gate and compiled occupancy predicate both pass;
+PR's execution battery covers cc 12.1, not cc 12.0. On the DSV4 release widths
+K=2048/4096 (8/16 superblocks), compile-time virtual-warp specializations
+reproduce the inherited default kernel's eight accumulator chains, lane
+reductions, serial warp sum, and final BF16 round bit-for-bit. This exactness
+contract requires every `PRISMAQUANT_CB_W2_*` override to be absent. Other
+widths retain the ascending rowpack reduction and may reassociate against the
+inherited default. The alternate kernel is **not** the global default: unset
+means `inherited`. Explicit `auto` or `v2` reaches it only where the hardware
+gate and compiled occupancy predicate both pass;
 `PRISMAQUANT_CB_GEMV=inherited` is the kill switch. The
 selection resolves once per process and is fixed per (layer, stack) at load, so
 the call-site branch is a trace-time constant and FULL-decode cudagraphs are
 unaffected.
+
+The final-source cc 12.1 operator gate for source SHA
+`d72b15ecaad14e7af07f8af555259f5d1423cee2dacce160c13b3caf7b8bc92b`
+passed 30/30, including eager and CUDA-graph exactness for k12/k16/k18 at both
+release widths, both decode contracts, and every dictionary residency. Its
+captured v1 direct-operator benchmark was bit-exact and measured
+**1.8175–1.9977x** over inherited across the six cells. The same-process DSV4
+model gate was valid and passed with exact zero full-vocabulary KL, NLL, PPL,
+and target-logprob
+deltas over 240 scored positions. Evidence:
+`/home/rob/dq-runs/dsv4-flash-0731/mtp-throughput-research/gemv-v2-bitexact-operator-v4/{run.log,benchmark.json}`
+and
+`/home/rob/dq-runs/dsv4-flash-0731/mtp-throughput-research/gemv-v2-bitexact-quality-ab-v2/report.json`.
+These are source-tree qualification results, not the final clean-wheel served
+graph/throughput gate; that gate remains open.
 
 MoE **prefill** used to be that per-expert loop, whose launch storm dominated
 TTFT. The production quality lane now expands bounded expert chunks with native
@@ -956,11 +975,11 @@ too.
 
 | Path | Status |
 |---|---|
-| Source block-FP8 W8A16, dense + DSV4 grouped `wo_a` | **0.8.5 candidate; release evidence pending.** Raw E4M3/UE8M0 stays resident; BF16 activations are unchanged; actual flattened decode-token `M<=8` uses native CUDA GEMV and larger M uses bounded native BF16 expansion plus the owned CUTLASS grouped bridge. Grouped BMM is admitted only at `(G=8,N=1024,K=4096,tp=1)`; dense geometry is gated separately and also remains `tp=1` only. Direct MXFP8 g32 remains the separate opt-in W8A8 lane. Do not claim shipped served parity or performance until the exact-artifact gates in RELEASING are recorded |
+| Source block-FP8 W8A16, dense + DSV4 grouped `wo_a` | **Implemented in 0.8.5; target-only DSV4 candidate load/generation passed on the exact 0.8.6 runtime; final clean-commit replay pending.** Raw E4M3/UE8M0 stays resident; BF16 activations are unchanged; actual flattened decode-token `M<=8` uses native CUDA GEMV and larger M uses bounded native BF16 expansion plus the owned CUTLASS grouped bridge. Grouped BMM is admitted only at `(G=8,N=1024,K=4096,tp=1)`; dense geometry is gated separately and also remains `tp=1` only. Direct MXFP8 g32 remains the separate opt-in W8A8 lane. DSpark is experimental and is not the release default; do not claim its served parity, graph, or 128k performance until the separate gates in RELEASING are recorded |
 | FP8-CB decode (dense) | **Shipped**, at/above native parity |
 | FP4-CB v2 decode (dense) | **Shipped**: bit-matched CUDA GEMV (13/13 parity against the historical Triton result plus the independent expansion reference). The decode chain is compute-bound at GEMV shapes (ncu SM 71%/mem 44%) under the bit-exact contract — the measured ceiling, not a staging problem |
 | MoE grouped decode GEMV | **Shipped**: fp8 66–95% of peak; fp4-v2 w2 schedule redesigned (+50%, 37–47% of peak; reassociation served-gated with an env-switched legacy path). A rowpack variant measured NEGATIVE and stays opt-in-off as a documented result |
-| MoE grouped decode GEMV, smem-resident dictionary | **Opt-in** (`PRISMAQUANT_CB_GEMV=v2`), never a default. Wins 1.13–1.58× on k13/k16/k20 in a 16-cell GB10 sweep; loses on k24 at K≥2048 (occupancy wall), where a compiled predicate routes the cell back to the shipped kernel. Reassociation-class output difference vs the default schedule (9/204 synthetic cells, worst `max_rel` 5.88e-03) — **not** bit-exact. Live GB10 validation on Jason Wong's 117B Laguna release dispatched all 94 expert stacks to v2 with no fallback and measured 24.993 vs 23.585 tok/s (+5.97%); long-prefill, concurrency, and soak requests completed without Gridbook errors |
+| MoE grouped decode GEMV, smem-resident dictionary | **Opt-in** (`PRISMAQUANT_CB_GEMV=v2`), never the global default. On DSV4 K=2048/4096 with all `PRISMAQUANT_CB_W2_*` overrides absent, the virtual-warp specialization is bit-exact to inherited for k12/k16/k18 and measured 1.8175–1.9977x in the final-source captured v1 direct-op benchmark; the same-process DSV4 quality gate produced zero full-vocabulary KL/NLL/PPL/target-logprob delta over 240 positions. Other widths retain rowpack order and may reassociate. The compiled predicate still routes k24 at K≥2048 to inherited. Historical Laguna validation measured +5.97%; final clean-wheel served graph/throughput qualification remains open |
 | Transient-expand prefill (dense) | **Shipped**; ~1.44× native at large M (traffic-bound) |
 | FP8-CB fused decode-in-prologue prefill | **Bit-exact; dispatch-eligible at M=9–128 and measured wins at M=32/64/128**; native transient expansion + CUTLASS serves ineligible and large-M shapes. **Rung surface: `k ∈ {28,32,36,40,44,48}` — the multiples of 4 in the product range, which is the complete set the packed-B TMA box (`type_size = 4k` must be 16-byte aligned) and the mainloop's uniform `CbSubW = k/4` sub-table width admit.** The other 15 integer rungs are served (decode GEMV + expand/CUTLASS bridge), just not by this lane; the compiled set is reported by `cb_fused_kbits()` and dispatch derives eligibility from it rather than from a literal ladder |
 | FP4-CB v2 fused mid-M prefill (dense) | **Opt-in** (`PRISMAQUANT_CB_FP4_FUSED_MIDM`), contract-preserving. The in-prologue decode is proven **bit-identical to `cb_expand_v2` for the whole decoded tile at all 13 K12–K24 rungs** (one-hot read-out, no tolerance), so only the FP32 reduction order moves. Measured 1.06–4.37× the shipping expand + bridge route at M ∈ {9,16,32,64,128} on 27B/DSV4-class shapes, every cell bit-equal to the same-config oracle — a wider band than the fp8 twin because the fp4 quality expand writes BF16 (4× the fp8 expand's transient bytes). Served NATIVE-PARITY protocol **not run**; an unexplained M ≤ 12 latency cliff is open. Ineligible shapes (M ≤ 8, M > 128, multi-dictionary fused modules, uncompiled rungs) fall through to today's exact path unchanged |

--- a/docs/NATIVE-PARITY.md
+++ b/docs/NATIVE-PARITY.md
@@ -150,7 +150,7 @@ fields may not. The manifest is the authoritative identity for mixed menus; a
 single average bpp or headline format is not.
 
 For source block-FP8, `fp8_e4m3_ue8m0_block128` identifies the serialized
-**weight** representation only. Its Gridbook 0.8.5 assignment must say
+**weight** representation only. Every Gridbook 0.8.5+ assignment must say
 `quant_contract: "W8A16"`: the runtime consumes BF16 activations unchanged. The
 assignment's backend must name the complete owned dispatch chain, for example
 `gridbook-fp8-source-w8a16(fp8_source_gemv|fp8_source_expand_bf16+cb_bf16_grouped_mm)`,
@@ -196,7 +196,7 @@ used as evidence for W4A4 merely because both reuse a native weight family.
 The same rule is release-critical for the source block-FP8 correction. Historical
 block-128 results obtained by replicating scales into MXFP8 and dynamically
 quantizing activations are W8A8 results. They do not validate W8A16 quality,
-logits, CUDA-graph behavior, or speed. A 0.8.5 release claim needs a fresh
+logits, CUDA-graph behavior, or speed. Any 0.8.5+ release claim needs a fresh
 same-artifact run whose manifest, logs, and server evidence prove unchanged BF16
 activations and the W8A16 kernel chain above.
 

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -50,10 +50,13 @@ gated activations are attested during model load and invoke their registered
 
 The producer/runtime boundary is machine-readable at
 `gridbook/runtime_contract.json` and loadable without torch or vLLM through
-`gridbook.runtime_contract.load_runtime_contract()`. Closed schema v3 also
-attests `abi_features.source_fp8_block128_w8a16 = 1`, so a producer can require
-the BF16-activation source route without inferring semantics from the package
-version. It declares accepted quantization names, serialized packing/type-size
+`gridbook.runtime_contract.load_runtime_contract()`. Closed schema v4 also
+attests `abi_features.source_fp8_block128_w8a16 = 1` and
+`abi_features.dspark_construction_physical_bridge = 1`, so a producer can
+require the BF16-activation source route or the complete DSpark sidecar loader
+and construction/physical namespace ABI (including weight-only drafts) without
+inferring semantics from the package version. It
+declares accepted quantization names, serialized packing/type-size
 rules, supported CB rung
 families, and producer-profile loader coverage. The plugin derives its own
 registration aliases and top-level loader-module list from this file rather
@@ -142,19 +145,25 @@ per-platform vLLM package is a submodule rather than the package itself.
 | `hy_v3` | `HYV3ForCausalLM`, `HYV3MTP` | `vllm.model_executor.models.hy_v3`, `…hy_v3_mtp` |
 | `laguna` | `LagunaForCausalLM` | `vllm.model_executor.models.laguna` |
 | `qwen3_5`, `qwen3_5_dense`, `qwen3` | Qwen3.5-MoE `ForCausalLM` / `ForConditionalGeneration` + MTP | `vllm.model_executor.models.qwen3_5`, `…qwen3_5_mtp`, `…lfm2_moe` |
-| `deepseek_v4` | `DeepseekV4ForCausalLM` | `vllm.models.deepseek_v4.nvidia.model` |
+| `deepseek_v4` | `DeepseekV4ForCausalLM`, `DSparkDeepseekV4ForCausalLM` | `vllm.models.deepseek_v4.nvidia.model`, `…nvidia.dspark` |
 
 #### DeepSeek-V4 (`deepseek_v4`)
 
-Established against immutable eugr Spark image
-`eugr/spark-vllm@sha256:7bf752a9fa225b528b27c6a1118cb1727cddd7c383096d83281010c4f8b407bc`
-(vLLM `0.26.1rc1.dev515+g653ebb52d.d20260808`, torch `2.11.0+cu130`) and the
-released DSV4-Flash config (43 layers, all MoE, 256 routed experts + 1 shared,
-top-6, MLA with `q_lora_rank`/`o_lora_rank` 1024 and `o_groups` 8). Single GPU,
-`tp=1`, and on GB10 the class selects a FlashInfer SM120 MLA backend that
-**requires
+The current passing integration contract is the immutable eugr Spark image
+`eugr/spark-vllm@sha256:58862b388e0fab05a5c9b673f21d1d7b41a1123953a2d9ace49aae6c79319869`:
+vLLM `0.26.1rc1.dev693+g7f7a32cfe.d20260812` at commit
+`7f7a32cfec0f1bc5b73c37200b86631523a1ea8f`, torch `2.13.0+cu130`, and
+FlashInfer `0.6.18` at commit
+`9ffd99510d92b883f154fc9f2e3d5aac93e231ca`. The startup preflight must find
+the native `(head_dim=64, topk=256)` entry in FlashInfer's SM120 DSV4 decode
+dispatch and `VLLM_MOE_SKIP_PADDING=True`; Gridbook makes the resulting `-1`
+routed-padding sentinel inert at its opaque MoE boundary. This contract uses
+the released DSV4-Flash config (43 layers, all MoE, 256 routed experts + 1
+shared, top-6, MLA with `q_lora_rank`/`o_lora_rank` 1024 and `o_groups` 8), one
+GB10, and `tp=1`. The FlashInfer SM120 MLA backend **requires
 `--kv-cache-dtype fp8`** — `auto` aborts model construction, independently of
-Gridbook.
+Gridbook. Older EUGR/vLLM/FlashInfer combinations are not interchangeable with
+this qualified tuple merely because they expose the same Python classes.
 
 - **Native CB.** The routed expert stacks
   (`…ffn.experts.routed_experts.w13/w2`), the MLA projections `attn.wq_a` +
@@ -187,19 +196,79 @@ Gridbook.
   `attn`/`ffn` and loads `w1`/`w3`/`w2`; config resolution bridges those exact
   structural aliases. Both the expert loader and config-side target resolution
   handle either outer namespace spelling.
-- **Passthrough, not served: MTP and DSpark.** The artifact preserves
-  `mtp.*` (4,705 tensors across the three DSpark stages `mtp.0/1/2`) verbatim.
-  `DeepseekV4ForCausalLM.load_weights` builds
-  `AutoWeightsLoader(self, skip_substrs=["mtp."])`, so **every one of them is
-  dropped before any parameter lookup** at plain serving time. The drafter
-  class `DeepSeekV4MTPModel` exists but is reachable only under
-  `--speculative-config`, and it consumes the payload in its source format —
-  Gridbook writes no CB stacks there and registers no loader for it. `dspark`
-  appears nowhere in the vLLM package, so `dspark_block_size`,
-  `dspark_target_layer_ids`, `dspark_markov_rank` and `dspark_noise_token_id`
-  are read by nothing at serving time. Gridbook claims none of this and adds no
-  support vLLM lacks. If a future artifact ever does ship CB expert stacks for
-  an MTP layer, `cb_fill_guard` fails the load and names the module path to add.
+- **MTP / DSpark is isolated from the target body.** The target artifact can
+  preserve `mtp.*` (4,705 tensors across the three DSpark stages `mtp.0/1/2`).
+  `DeepseekV4ForCausalLM.load_weights` still builds
+  `AutoWeightsLoader(self, skip_substrs=["mtp."])`, so every one is dropped at
+  body-only serving time and the target-body path is unchanged. Under DSpark
+  speculative serving, the separate `DSparkDeepseekV4ForCausalLM` class in
+  `vllm.models.deepseek_v4.nvidia.dspark` consumes that payload.
+- **Target-only is the 0.8.6 shipping default; DSpark is experimental.** Omit
+  `--speculative-config` for the release launch. On the exact runtime above,
+  the same target artifact, eager 12,288-token configuration, and fixed
+  sequential 8-prompt x 128-output-token suite measured `10.2389` output tok/s
+  without MTP. The native MXFP4 draft measured `10.3364` tok/s (`+0.95%`) but
+  raised model residency from `95.12` to `105.25` GiB; its acceptance was
+  `42.289%` overall, `78.916%` at position zero, and `2.114` accepted
+  speculative tokens per draft cycle. A K12-CB hybrid draft measured only
+  `9.1319` tok/s (`-10.81%`). Those results prove that the loader can serve a
+  coherent DSpark draft, but neither draft earns production-default status or
+  justifies its memory cost. They are not graph-mode, concurrency, or 128k
+  context claims.
+- **Three DSpark namespaces stay distinct.** Decoder layers are constructed
+  with quantization prefixes `model.layers.43/44/45` (more generally,
+  `num_hidden_layers + stage`), registered by the three-element `ModuleList` as
+  `model.layers.0/1/2`, and stored in the checkpoint as `mtp.0/1/2`. A DSpark
+  Gridbook quantization config therefore declares the construction prefixes.
+  At load time the wrapper calls the model's own callable
+  `_remap_dspark_name` to obtain the registered prefix before running the
+  existing mixed-fused and stacked-expert resolvers. It does not reproduce or
+  guess that mapping. Mixed-fusion carriers retain their construction prefix;
+  the transaction router derives the corresponding registered role prefix from
+  the carrier's actual `named_parameters()` path and rejects inconsistent
+  metadata.
+- **Contracted activation scalars are explicitly bridged.** Contracted FP4-CB
+  config targets remain in the construction namespace while serialized
+  `input_global_scale` tensors and their digest-bound contract names remain
+  physical `mtp.*`. `dspark_target_bridge` declares that one-to-one mapping
+  for the complete activation contract (including a delegated stock-NVFP4
+  target) with `L`, stage count, and same-tail validation. Gridbook accepts no
+  inferred layer offset, undeclared construction target, incomplete map, or
+  physical target outside the activation contract; delegated source-format
+  `main_proj` is never included. Before consuming the
+  checkpoint stream, the loader also compares stamped `L`/stage count with
+  `config.num_hidden_layers` and the instantiated model's
+  `num_dspark_layers`.
+- **Stock ownership is preserved.** Stacked Gridbook expert planes and
+  independently owned mixed-fusion planes are intercepted exactly as for the
+  target body. Every other tensor is delegated under its original checkpoint
+  name; draft tensors therefore retain their physical `mtp.*` spelling. This
+  includes ordinary direct/fused dense CB planes, source-format tensors,
+  model-level heads, non-MTP tensors, and the unwired confidence head. DSpark's
+  stock loader remains their sole mapping/filtering authority. The
+  draft reuses the existing Gridbook Linear/MoE methods and CUDA kernels; this
+  loader registration adds no format or kernel.
+- **Draft sidecars have draft authority.** vLLM intentionally leaves the
+  target `model_config` installed while constructing the separate DSpark
+  model. Gridbook scopes the explicit
+  `speculative_config.draft_model_config` to that exact DSpark constructor, so
+  its pointer `quant_config.json` and `cb_codebooks.pqcb` resolve from the
+  draft rather than `/model`. Merely enabling speculation never redirects the
+  target body, and absent or malformed draft authority fails before the
+  constructor consumes weights.
+- **Grouped `wo_a` is source W8A16, not dense CB.** The three DSpark
+  `attn.wo_a` projections are grouped BMMs. The generic dense CB method has no
+  grouped output contract and therefore rejects `is_bmm` at load instead of
+  returning a shape-incorrect `[T,G,G*N]` result. These projections retain
+  their E4M3/UE8M0 source planes and use the qualified grouped W8A16 adapter;
+  the other eligible draft projections may use CB.
+
+- **Evidence and provenance.** The DSpark figures above are pre-release
+  integration/performance classification, not clean-tag provenance. Public
+  release documentation does not treat operator-local paths or a rehearsal
+  wheel identity as durable evidence. The clean committed wheel and derived
+  image must satisfy the target-only 256k gate in
+  [`RELEASING.md`](RELEASING.md); DSpark keeps its separate experimental gate.
 - **Passed through unquantized.** Hyper-connection parameters (`hc_mult` 4:
   `hc_head_*`, `layers.N.hc_attn_*`, `layers.N.hc_ffn_*`), the hash-routing
   tables (`num_hash_layers` 3: `ffn.gate.tid2eid`), `ffn.gate` and its
@@ -308,7 +377,10 @@ quality expansion plus an optional alternate decode GEMV:
 - **`cb_gemv_v2`** is the optional smem-resident-dictionary decode schedule
   selected by `PRISMAQUANT_CB_GEMV=auto|v2`. The default `inherited` decode
   schedule still loads and prepares this extension because it needs
-  `cb_expand_v2` for quality prefill.
+  `cb_expand_v2` for quality prefill. On DSV4 K=2048/4096, and only with all
+  `PRISMAQUANT_CB_W2_*` overrides absent, its virtual-warp specialization is
+  bit-exact to the inherited default for the k12/k16/k18 release surface;
+  other widths keep rowpack reduction order and may reassociate.
 
 **`gridbook/csrc/cb_fused_gemm.cu`** (CUTLASS, separate JIT ext) — prefill:
 
@@ -387,7 +459,7 @@ tooling and model cards — see the README's naming section.)
 |---|---|---|
 | `PRISMAQUANT_CB_EXT_DIR` | `~/.cache/prismaquant-cb-ext` | Root of the JIT build cache. Point it at a persistent, writable directory in containers so a cold start does not rebuild every module it reaches. Each of the nine modules owns a SUBDIRECTORY of it — `main`, `v2`, and the identity-keyed `bf16_grouped/<digest>`, `fused/<digest>`, `fused_fp4/<digest>`, `fused_fp4v2/<digest>`, `moe_persistent_b/<digest>`, `mxfp8_dense/<digest>`, `fp8_source_w8a16/<digest>` — so no two ninja workspaces share artefacts and a changed source, header, lane macro, target or toolchain ABI lands in a new directory instead of serving a stale kernel. Upgrading Gridbook therefore costs ONE rebuild per affected module; the old directories are inert and can be deleted. |
 | `PRISMAQUANT_CUTLASS_INCLUDE` | unset (vLLM's bundled copy) | The `include` directory — the one holding `cutlass/cutlass.h` — that all **four** CUTLASS-compiling modules build against: grouped-BF16, fused FP8-CB, fused NVFP4-CB and the fused FP4-CB v2 mid-M lane. Set it to build in a venv with no vLLM wheel, or against a CUTLASS newer than the bundled tree. Unset, the path is discovered under `vllm/third_party/` *without importing vLLM* (importing it merely to locate files would eagerly initialize optional compiler backends, Triton among them). A set-but-wrong value **fails** with the missing header named; it never falls back silently, because compiling against a different CUTLASS than the one asked for is the surprise this override exists to prevent. |
-| `PRISMAQUANT_CB_GEMV` | `inherited` | Which grouped FP4-CB **decode GEMV** serves a layer: `inherited` \| `auto` \| `v2`. All FP4-v2 quality paths build/load `cb_gemv_v2.cu` and run its cc 12.0/12.1 device prepare because that module also owns the required exact expander. Unset/`inherited` keeps the shipped decode schedule; `auto` or `v2` may additionally use the module's smem-resident decode GEMV where its occupancy predicate says it wins. That alternate decode is **not** bit-exact against `inherited` (reassociation class). FP8-only serves do not need the v2 module. An unknown spelling raises; changing it mid-process raises. |
+| `PRISMAQUANT_CB_GEMV` | `inherited` | Which grouped FP4-CB **decode GEMV** serves a layer: `inherited` \| `auto` \| `v2`. All FP4-v2 quality paths build/load `cb_gemv_v2.cu` and run its cc 12.0/12.1 device prepare because that module also owns the required exact expander. Unset/`inherited` keeps the shipped decode schedule; `auto` or `v2` may additionally use the module's smem-resident decode GEMV where its occupancy predicate says it wins. On DSV4 K=2048/4096 with every `PRISMAQUANT_CB_W2_*` override absent, that alternate is bit-exact to the inherited default for k12/k16/k18; other widths retain rowpack reduction order and may reassociate. It is a DSV4 release-shape quality/performance candidate, not the global default, and the final clean-wheel served graph/throughput gate remains open. FP8-only serves do not need the v2 module. An unknown spelling raises; changing it mid-process raises. |
 | `PRISMAQUANT_CB_FUSED_FP4` | off | Dense fp4-CB native-FP4 prefill opt-in. `1`/`midm` use a fully attested artifact scalar for all prefill shapes / `16 < M <= 128`. `static_lsq`/`static_lsq_midm` keep that exact `G` and the native E2M1/SFA payload, but fit the existing per-row EVT residual by least squares; they add no model metadata, weight copy, decoder, or GEMM. `rowwise`/`rowwise_midm` instead derive an independent full-range scalar per runtime row and are the only fused choices accepted for legacy artifacts. All dense modes use one occupancy selector: TileM256 is chosen only for `M >= 256` and `ceil(M/256) * ceil(N/128) >= ceil(2*SM_count/3)`; otherwise TileM128 runs. The `*_midm` modes therefore always remain TileM128. All values are experimental and default-off; unknown spellings and mid-process changes fail. **Tops the dense precedence chain** — it changes the served activation contract, so it outranks `PRISMAQUANT_CB_FP4_FUSED_MIDM` and `PRISMAQUANT_CB_BF16_SM120` (see [Lane precedence](#lane-precedence--which-flag-wins-when-several-are-set)). A selected mode that the **load-time** gate finds ineligible **fails the load**; a mode that passes that gate and then declines a concrete **call** (in practice the rowwise / static-LSQ quantizers' half-precision guard) **raises** naming the activation dtype and shape. Neither falls through to the exact BF16 route: that route's activation bucket is the fp32-emulated group QDQ rather than the format's native ue4m3 scale factors, so serving it would silently substitute the contract the flag exists to make explicit. The K24 short exact gate passed, but long-context evidence is mixed and no >=4B/MoE served validation exists; see the [dated audit](audits/fused_nvfp4_enablement_2026-07-31.md). |
 | `PRISMAQUANT_CB_FUSED_FP4_MOE` | off | Grouped-MoE fp4-CB native-FP4 prefill opt-in. Static `1`/`128` and `256` select TileM 128 and 256 and require both attested stage scalars. `static_lsq`/`static_lsq128` and `static_lsq256` select those same tiles while reusing the shared fixed-`G` LSQ quantizer. `rowwise`/`rowwise128` and `rowwise256` use independent runtime row scales and may serve legacy artifacts. **Tops the routed precedence chain** — it changes the served activation contract, so it outranks `PRISMAQUANT_CB_MOE_PERSISTENT_B` and `PRISMAQUANT_CB_BF16_SM120` (see [Lane precedence](#lane-precedence--which-flag-wins-when-several-are-set)). An ineligible selection **fails the load**, naming the cached eligibility reason; a mode that passes that gate and then misses at **call** time **raises** (`became unavailable after model load`). Neither returns to the exact native BF16 quality bridge — that bridge serves a different activation contract, and Gridbook does not substitute one silently. Unknown spellings and mid-process changes fail. Keep this off pending the dated audit's routed-quality, workload, and routing-policy gates. |
 | `PRISMAQUANT_CB_BF16_SM120` | off | `1` routes the quality-preserving BF16 grouped bridge (every default NVFP4-CB prefill — dense `E=1` and routed MoE — plus the FP8-CB fallback) to the **sm12x-native** CUTLASS 3.x collective instead of the default SM80-schedule `DefaultGemmGrouped`. Compiled only for cc 12.0/12.1; resolved at model load and **fails the load** if unavailable rather than silently serving the other lane. Same operands, same single bf16 round, different FP32 reduction order — bit-gated against the torch reference, served protocol NOT run. The lane's collective has two A-source modes (bit-identical to each other, gated `torch.equal`): the row-padded copy, and an **in-mainloop A-row gather** that never materializes the padded activation; with the gather mode and the swizzle-group-aligned expert order, measured (GB10, pingpong 64×128×64): 1.13–1.37× the default bridge, and vs segmented BF16 matmuls **1.03–1.05× at T=128 and 1.10–1.15× at T=512** (the padded-copy mode's 0.83–0.92× T=512 deficit is closed at the construction level). The routed path still pays one host read of the per-expert block offsets per layer. **The swizzle-group packing is coupled to the expert-chunk size and is off unless ONE chunk covers the layer** (`chunk >= E`): the decoded BF16 transient is chunked over experts by `PRISMAQUANT_CB_PREFILL_EXPERT_CHUNK`, or by `PRISMAQUANT_CB_PREFILL_CHUNK_BYTES` (1 GiB) divided by one expert's `w13` BF16 bytes (`2·inter·hidden·2`), and a narrower chunk indexes blocks as `block_off[c0]..block_off[c1]`, which assumes expert-major contiguity. So a layer whose experts do not fit one chunk — the `E=128` cells in the benchmark run at `chunks=2` — takes the gather but NOT the packing, and lowering `..._CHUNK_BYTES` disables it the same way. The measured order win is an `E=32` result. Packing within a chunk is queued in [ROADMAP](../ROADMAP.md#p1--close-the-remaining-native-parity-gaps). **Lowest lane in both precedence chains**: a fused NVFP4 mode or, on the routed path, `PRISMAQUANT_CB_MOE_PERSISTENT_B` will serve instead where set — this lane is still attested at load either way (see [Lane precedence](#lane-precedence--which-flag-wins-when-several-are-set)). Unknown spellings and mid-process changes raise. See [KERNELS](KERNELS.md#sm12x-native-grouped-bf16-opt-in-prismaquant_cb_bf16_sm120) and the [benchmark table](BENCHMARKS.md#2026-08-02-sm12x-grouped-bf16-lane-in-mainloop-a-row-gather--swizzle-aligned-tile-order-proposal-data). |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -41,9 +41,20 @@ is nothing to store.
 | `pypi` | final releases |
 | `testpypi` | pre-release tags |
 
-Recommended: add yourself as a **required reviewer** on `pypi`. That puts a
-human approval click in front of the single irreversible step in the whole
-pipeline, and it costs nothing.
+The `pypi` environment must have a **required reviewer**. The repository is
+currently configured with `RobTand` as that reviewer, so a final release needs
+a deliberate approval click before the irreversible upload. `testpypi` does
+not need this production approval barrier.
+
+The release workflow independently proves that the peeled tag commit is
+reachable from `origin/master` before it builds anything. This prevents an
+accidental final tag on a feature or stale branch from reaching either publish
+environment; the environment approval remains the independent last barrier.
+
+The workflow also computes the wheel SHA-256 once in its build job and checks
+that exact digest again after every artifact download: installed-wheel verify,
+PyPI publish, and GitHub Release. The Actions artifact digest is the digest of
+an outer archive and is not the wheel digest.
 
 ### 1.2 PyPI pending publisher
 
@@ -201,22 +212,113 @@ Python fallback helper. The retained `cb_persistent_tc.cu` source is not part
 of this gate: its serving selector, custom op, and package loader were deleted,
 and it remains available only to the explicitly opted-in research test.
 
-#### 0.8.5 source block-FP8 W8A16 gate
+#### Alternate CB-GEMV-v2 DSV4 quality gate
+
+`PRISMAQUANT_CB_GEMV=v2` remains experimental and must not be enabled on a
+production DSV4 endpoint, selected by `auto`, or made the default from synthetic
+kernel parity alone.  Before any such change, run the source-distributed
+`scripts/validate_moe_gemv_v2_ab.py` inside the exact release image against the
+exact dsv4flash0731 target artifact and producer-sealed input JSON:
+
+```bash
+python3 scripts/validate_moe_gemv_v2_ab.py \
+  --model /model \
+  --prompt-token-ids-json /inputs/dsv4-wikitext-inputs-v1.json \
+  --output /evidence/dsv4-gemv-v2-ab.json \
+  --kv-cache-dtype fp8 \
+  --max-mean-kl 0.0001 \
+  --max-mean-nll-regression 0.00498754 \
+  --max-ppl-relative-regression 0.005
+```
+
+The harness hashes the complete local artifact and compares its config,
+quantization config, codebook sidecar, 112 GB safetensors payload, and byte
+count to the dsv4flash0731 release identity.  It derives a fixed 8-prompt x
+16-token decode profile from the complete producer-sealed 8x512 WikiText
+payload and independently requires its tensor and JSON value digests.  The
+profile, two repeats, full-vocabulary scoring, and per-source arm-order
+crossover are not operator-tunable.
+
+A valid report must prove one eager vLLM engine and one PID with both native
+modules resident before measurement; the process selector pinned to `v2`; the
+decode contract pinned to `v1`; and all `PRISMAQUANT_CB_W2_*` overrides absent,
+so the control is the real inherited default rather than `rowpack`. The parser
+and engine loader must both attest the DSV4 sparse-MLA requirement
+`kv_cache_dtype=fp8`; `auto` is invalid. Its loaded
+inventory must be exactly 35 target FP4-CB layers plus 8 target FP8-CB layers.
+Every request must traverse M=16 on all 43 layers and attest exactly 70
+inherited FP4 stack calls in the baseline or 70 v2 calls in the candidate,
+plus the unchanged 24 per-role FP8 calls.  Missing calls, selector fallback,
+occupancy-wall fallback, FP8 drift, an unscoped call, a non-finite or
+wrong-cardinality vocabulary row, repeat-digest drift, or incomplete
+exception-safe restoration fails the measurement.
+
+Require `status=ok`, `measurement_valid=true`,
+`configured_gates_pass=true`, all three thresholds above present and passing,
+and retain the JSON beside the clean-wheel evidence. This is the model-quality
+gate only. On the exact DSV4 K=2048/4096 specialization no arithmetic delta is
+expected; the configured tolerances remain fail-closed corruption backstops.
+
+The 2026-08-13 source-tree gate for
+`cb_gemv_v2.cu` SHA256
+`d72b15ecaad14e7af07f8af555259f5d1423cee2dacce160c13b3caf7b8bc92b`
+passed 30/30 operator tests, including CUDA-graph exact replay across
+k12/k16/k18, both release widths, both decode contracts, and all dictionary
+residencies. The final-source v1 direct-op benchmark was bit-exact and measured
+1.8175–1.9977x over inherited. The same-process report has `status=ok`,
+`measurement_valid=true`, `configured_gates_pass=true`, and exact zero
+full-vocabulary KL, NLL regression, PPL regression, and target-logprob delta
+over 240 positions. Retained evidence:
+
+- `/home/rob/dq-runs/dsv4-flash-0731/mtp-throughput-research/gemv-v2-bitexact-operator-v4/run.log`
+- `/home/rob/dq-runs/dsv4-flash-0731/mtp-throughput-research/gemv-v2-bitexact-operator-v4/benchmark.json`
+- `/home/rob/dq-runs/dsv4-flash-0731/mtp-throughput-research/gemv-v2-bitexact-quality-ab-v2/report.json`
+
+This qualifies v2 only as an explicit `PRISMAQUANT_CB_GEMV=v2` DSV4
+release-shape candidate; the global default remains `inherited`. K1.4 remains
+open until the final clean wheel and
+image also pass served graph replay, throughput, concurrency, long-prefill,
+soak, and memory gates with v2 enabled; neither the eager quality harness nor
+the direct-operator graph replay may be cited as those served results.
+
+#### Source block-FP8 W8A16 and 0.8.6 DSpark integration gate
 
 The compile check proves that the wheel carries and builds the ABI. It does not
 prove activation semantics, bounded residency, DSV4 grouping, graph behavior,
-quality, or speed. Before tagging 0.8.5, run the focused GPU suite against that
+quality, or speed. Before tagging a release that changes this route or its
+DSpark loader integration, run the focused GPU suite against that
 same installed wheel on the Spark release device. Stage these test files and
 their test-only helpers outside the checkout and run from that staging
 directory, so the repository cannot shadow the wheel:
 
+For 0.8.6 the qualified runtime tuple is exact, not a minimum-version range:
+
+- EUGR base
+  `eugr/spark-vllm@sha256:58862b388e0fab05a5c9b673f21d1d7b41a1123953a2d9ace49aae6c79319869`;
+- vLLM `0.26.1rc1.dev693+g7f7a32cfe.d20260812`, commit
+  `7f7a32cfec0f1bc5b73c37200b86631523a1ea8f`;
+- torch `2.13.0+cu130`; and
+- FlashInfer `0.6.18`, commit
+  `9ffd99510d92b883f154fc9f2e3d5aac93e231ca`.
+
+The preflight must assert that FlashInfer's SM120 DSV4 decode dispatch contains
+`(head_dim=64, topk=256)` and that `VLLM_MOE_SKIP_PADDING=True`. A runtime that
+merely imports the DSpark class does not satisfy this gate.
+
 ```bash
 python -m pytest -q \
+  tests/test_cb_fill_guard.py \
+  tests/test_codebook_provenance_config.py \
+  tests/test_deepseek_v4_contract.py \
+  tests/test_dspark_cb_loader.py \
   tests/test_fp8_source_w8a16.py \
   tests/test_fp8_source_w8a16_cuda.py \
   tests/test_source_passthrough.py \
   tests/test_dsv4_woa.py \
-  tests/test_mixed_fused_linear.py
+  tests/test_layer_registry.py \
+  tests/test_mixed_fused_linear.py \
+  tests/test_nvfp4_static_runtime.py \
+  tests/test_runtime_contract.py
 ```
 
 Zero failures and zero relevant skips are required. The gate must cover all of
@@ -248,12 +350,52 @@ assignment must say W8A16; direct MXFP8 g32 assignments, if any, must remain
 W8A8. Retain the bound producer/export compatibility evidence plus closed
 startup/dispatch logs proving:
 
-1. the v3 feature source_fp8_block128_w8a16=1 was required by the producer;
+1. the current runtime contract feature
+   `source_fp8_block128_w8a16=1` was required by the producer (and a DSpark
+   sidecar additionally requires `dspark_construction_physical_bridge=1`);
 2. source decode dispatched fp8_source_gemv;
 3. source prefill dispatched fp8_source_expand_bf16 followed by
    cb_bf16_grouped_mm;
 4. DSV4 wo_a used the grouped W8A16 adapter; and
 5. no source unit fell back or entered mxfp8_dense_mm/activation QDQ.
+
+The production launch for 0.8.6 is **target-only 256k** and must omit
+`--speculative-config`. The clean-wheel gate must set `--max-model-len 262144`
+and record the resolved engine value as exactly `262144`. The startup record
+must also prove all of the following on the one-Spark release device:
+
+1. the allocated KV cache reports capacity for at least `262144` tokens and
+   maximum concurrency of at least `1.0` at that request length;
+2. eager mode is off, the intended decode graph is captured successfully, and
+   generation replays it without a graph break or fallback;
+3. fixed coherent generation and the release tool-call smoke both pass; and
+4. Gridbook's route telemetry proves the expected CB/source-W8A16 chains with
+   no error, fallback, activation QDQ on W8A16, or dynamically quantized
+   MXFP8 substitution.
+
+That exact-artifact startup, generation/tool smoke, graph evidence, and
+throughput record are the release gate. Merely accepting `--max-model-len` is
+not proof of 256k capacity. This clean 256k replay is currently **open**: this
+document intentionally records no clean source, wheel, or image digest until
+the run exists.
+
+Exercise DSpark separately as an opt-in experiment: require coherent
+generation, bounded residency, the stamped draft-sidecar authority,
+position-zero acceptance at or above the predeclared threshold, and paired
+throughput against the target-only run. A functional draft that does not beat
+the paired target-only throughput remains experimental and must not appear in
+the default serve command. Neither a native-source nor a CB draft is allowed to
+weaken the target-only release gate. Persistent-B likewise remains disabled in
+the release launch unless its canonical-input full-vocabulary quality gate and
+the separate served NATIVE-PARITY gate both pass.
+
+Pre-release runs from a dirty candidate wheel may classify a path and discover
+integration defects, but cannot close provenance. After the 0.8.6 source is
+committed, rebuild the wheel and derived image, record the source commit plus
+wheel/image digests, and repeat the complete target-only 256k gate above. If
+the release notes retain measured DSpark numbers, rerun that exact paired suite
+too or state explicitly that the numbers are pre-release classification
+evidence.
 
 The source method writes this proof through Gridbook's existing latest-route
 telemetry: `contract=bf16_preserved`; decode names `fp8_source_gemv`; prefill
@@ -269,7 +411,8 @@ the results. Record every block and the exact GPU/runtime/image identities.
 Historical W8A8 block-128 results are a different activation contract and
 cannot satisfy any W8A16 quality or performance cell. Until these artifacts are
 attached and their predeclared limits pass, the route is implemented but the
-0.8.5 release gate is open; do not tag or claim served parity/performance.
+current exact-artifact release gate is open; do not tag or claim served
+parity/performance.
 
 The fused FP4 extension also requires the GPU operator/SASS suite from an
 installed wheel. Stage `tests/test_fused_fp4_prefill.py` outside the checkout,
@@ -309,10 +452,16 @@ Tags are `v` + the PEP 440 version. The workflow refuses to publish if the tag
 and the built version disagree.
 
 ```bash
-git commit -am "release 0.1.0rc1"
+git status --short
+# Stage the reviewed release allowlist explicitly.  Never use `git commit -am`:
+# release utilities and their tests are source-only new files and would be
+# silently omitted.
+git add -- <reviewed-release-paths...>
+git diff --cached --name-status
+git commit -m "release 0.1.0rc1"
 git push
 # wait for CI to go green on master, then:
-git tag v0.1.0rc1
+git tag -a v0.1.0rc1 -m "gridbook 0.1.0rc1"
 git push origin v0.1.0rc1     # <- this, and only this, starts a release
 ```
 
@@ -329,6 +478,27 @@ Order of operations for a first launch:
    ```
    then re-run the compile check from §2.2 against the *downloaded* wheel.
 2. `v0.1.0` → PyPI. The name is claimed at that moment.
+
+For a final GPU-serving release, do **not** approve the `pypi` deployment as
+soon as the CPU jobs turn green. The approval pause is the exact-wheel GPU
+gate:
+
+1. Wait for `build` and `verify` to pass and for `publish` to request the
+   environment approval.
+2. Download the workflow's `dist` artifact into a fresh directory with
+   `gh run download <run-id> -R RobTand/gridbook -n dist -D <fresh-dir>`.
+3. Compare the wheel SHA-256 with the `build` receipt in the workflow log.
+   Do not use the Actions artifact digest; that identifies the outer ZIP.
+4. Install that exact CI wheel into the release image and repeat §2.2 plus the
+   exact-artifact GPU gate for the release architecture. A locally rebuilt
+   wheel is not a substitute because byte-reproducible builds are not yet a
+   project contract.
+5. Approve `pypi` only after that exact wheel passes. On failure, reject the
+   deployment, cancel the workflow, and remove the still-unpublished tag after
+   confirming PyPI has no such version.
+6. After publish, require the local CI-wheel digest, PyPI JSON digest, and
+   GitHub Release asset `digest` to agree before another project pins the
+   wheel.
 
 ### 2.4 After the release
 
@@ -396,7 +566,7 @@ that logic for no extra signal. One mechanical fact drives
 Every optional monorepo dependency in `test_cb_kernels.py` is now guarded, so
 the installed-wheel matrix collects every test module. Current CI runs the
 suite on Python 3.10–3.13 from outside the checkout, with one pytest process per
-file. Three tests also exercise validation entry points that intentionally ship
+file. Five tests also exercise validation entry points that intentionally ship
 only in the sdist. `run_cpu_tests.sh` exports `GRIDBOOK_SOURCE_ROOT`, resolved
 from its own checkout location, so those utilities remain available after the
 tests are staged and the same command works outside GitHub (where the ambient
@@ -410,17 +580,23 @@ wheel.
 build ──► verify ──► publish (pypi | testpypi) ──► github-release
 ```
 
-- **`build`** — same build + `twine check` + `check_dist.py` as CI, then asserts
-  the tag matches the version baked into the wheel, and decides PyPI vs TestPyPI
-  from whether that version is a PEP 440 pre-release.
+- **`build`** — first rejects a tag commit that is not reachable from
+  `origin/master`; then runs the same build + `twine check` + `check_dist.py`
+  as CI, asserts the tag matches the version baked into the wheel, records its
+  SHA-256, and decides PyPI vs TestPyPI from whether that version is a PEP 440
+  pre-release.
 - **`verify`** — installs the exact wheel about to be published and re-runs the
-  install gate and the CPU tests against it.
+  install gate and the CPU tests against it. It first rechecks the build-job
+  wheel digest after artifact download.
 - **`publish`** — `pypa/gh-action-pypi-publish` with `id-token: write` and no
   other permission. Trusted Publishing (OIDC): no API token, no repository
-  secret. `skip-existing` is deliberately **not** set, so a duplicate version is
-  a loud failure rather than a silent no-op.
+  secret. The final `pypi` environment requires a deliberate approval, and the
+  downloaded wheel digest is checked again. `skip-existing` is deliberately
+  **not** set, so a duplicate version is a loud failure rather than a silent
+  no-op.
 - **`github-release`** — `gh release create` with `--generate-notes`, attaching
-  both artifacts, marked `--prerelease` for pre-release versions.
+  both artifacts, marked `--prerelease` for pre-release versions, after one
+  final wheel-digest check.
 
 There is no `push: branches:` trigger and no `release:` trigger. Merging this
 workflow, or any later commit to `master`, can never attempt an upload — the

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -439,6 +439,17 @@ the following vocabulary:
       }
     }
   },
+  // REQUIRED only when DSpark construction targets carry contracted FP4-CB
+  // activation scalars under physical mtp.* checkpoint names:
+  "dspark_target_bridge": {
+    "schema": "gridbook.dspark-target-bridge.v1",
+    "num_hidden_layers": 43,
+    "n_mtp_layers": 3,
+    "construction_to_physical": {
+      "model.layers.43.ffn.experts.gate_up_proj":
+        "mtp.0.ffn.experts.gate_up_proj"
+    }
+  },
   "ignore": ["model.norm", "lm_head", "..."],   // non-CB modules -> unquantized
   "provenance": {                                // RECOMMENDED, not required to decode
     "codebook_sha256": { "cb_codebook.lattice.NVFP4_CB_K16.sub0": "...", "...": "..." },
@@ -452,6 +463,19 @@ the following vocabulary:
   `sub0..sub{n_sub-1}` (`product`).
 - Targets sharing one `(codebook_ref, format)` **SHOULD** be grouped into one
   config group.
+- `dspark_target_bridge` is an explicit namespace attestation, not a name
+  heuristic. Its construction keys **MUST** be declared targets in
+  `config_groups` and cover the complete activation contract (custom FP4-CB
+  plus any delegated stock-NVFP4 activation target); its physical values
+  **MUST** be exactly
+  `execution_contracts.nvfp4_w4a4.target_names`. Every mapping is one-to-one,
+  preserves the complete target tail, uses `model.layers.(L+s)` -> `mtp.s`,
+  and satisfies `s < n_mtp_layers`. A consumer **MUST** reject an unknown
+  schema, topology mismatch, unused/missing target, changed tail, or duplicate
+  physical target. Before copying weights it **MUST** also compare stamped `L`
+  and `n_mtp_layers` with the instantiated draft model. Targets outside that
+  activation contract do not appear in this map; DSpark `main_proj` remains a
+  delegated source-format special case and is excluded.
 
 ### 5.1 Per-role codebooks on routed expert stacks (since 0.8.3)
 

--- a/gridbook/__init__.py
+++ b/gridbook/__init__.py
@@ -14,7 +14,7 @@ package without vLLM installed.
 # Single source of truth for package and release metadata. Gridbook is the sole
 # owner of its runtime; producer repositories consume a released version or an
 # immutable commit and never mirror this package tree.
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 
 
 def register() -> None:

--- a/gridbook/_fused_nvfp4_validation.py
+++ b/gridbook/_fused_nvfp4_validation.py
@@ -19,7 +19,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 
 MEASURED_PHASE_ORDER = ("timing", "quality")
@@ -234,13 +234,19 @@ def prepare_validation(
     harness_path: Path,
     helpers: Any,
     extension_none_message: str,
+    extension_loader: str = "get_fused_fp4_ext",
+    required_symbol: str | None = None,
+    validation_name: str = "fused NVFP4",
+    prompt_loader: (
+        Callable[[Any, Any], tuple[list[list[int]], dict[str, Any]]] | None
+    ) = None,
 ) -> ValidationBootstrap:
     """Load and attest shared runtime, artifact, tokenizer, and dataset state."""
 
     import torch
 
     if not torch.cuda.is_available():
-        raise RuntimeError("fused NVFP4 validation requires a CUDA GPU")
+        raise RuntimeError(f"{validation_name} validation requires a CUDA GPU")
 
     import gridbook
 
@@ -249,18 +255,25 @@ def prepare_validation(
     from gridbook import cuda_ext, linear, moe, moe_toplevel_loader
 
     extension_started = time.monotonic()
-    fused_extension = cuda_ext.get_fused_fp4_ext()
-    extension_load_s = time.monotonic() - extension_started
-    if fused_extension is None:
-        raise RuntimeError(extension_none_message)
-    required_symbol = (
-        "cb_fused_fp4_prefill_mm_scaled"
-        if args.mode == "dense"
-        else "cb_fused_fp4_moe_grouped"
-    )
-    if not hasattr(fused_extension, required_symbol):
+    try:
+        load_extension = getattr(cuda_ext, extension_loader)
+    except AttributeError as exc:
         raise RuntimeError(
-            f"fused FP4 extension lacks required {args.mode} symbol "
+            f"Gridbook has no validation extension loader {extension_loader!r}"
+        ) from exc
+    loaded_extension = load_extension()
+    extension_load_s = time.monotonic() - extension_started
+    if loaded_extension is None:
+        raise RuntimeError(extension_none_message)
+    if required_symbol is None:
+        required_symbol = (
+            "cb_fused_fp4_prefill_mm_scaled"
+            if args.mode == "dense"
+            else "cb_fused_fp4_moe_grouped"
+        )
+    if not hasattr(loaded_extension, required_symbol):
+        raise RuntimeError(
+            f"{validation_name} extension lacks required {args.mode} symbol "
             f"{required_symbol!r}"
         )
 
@@ -289,15 +302,17 @@ def prepare_validation(
             "path": str(helpers_path),
             **helpers._required_file_record(helpers_path),
         }
-    extension_path_raw = getattr(fused_extension, "__file__", None)
+    extension_path_raw = getattr(loaded_extension, "__file__", None)
     if extension_path_raw is None:
-        raise RuntimeError("loaded fused FP4 extension has no filesystem __file__")
+        raise RuntimeError(
+            f"loaded {validation_name} extension has no filesystem __file__"
+        )
     extension_path = Path(extension_path_raw).resolve()
     extension_file = helpers._required_file_record(extension_path)
     extension = {
         "preloaded_before_model": True,
         "load_seconds": extension_load_s,
-        "module": getattr(fused_extension, "__name__", None),
+        "module": getattr(loaded_extension, "__name__", None),
         "path": str(extension_path),
         "bytes": extension_file["bytes"],
         "sha256": extension_file["sha256"],
@@ -394,7 +409,11 @@ def prepare_validation(
         }
         del teacher_tokenizer
 
-    prompts, dataset = helpers._load_wikitext_windows(args, tokenizer)
+    prompts, dataset = (
+        prompt_loader(args, tokenizer)
+        if prompt_loader is not None
+        else helpers._load_wikitext_windows(args, tokenizer)
+    )
     quality_kl_mode = (
         helpers.KL_FULL_VOCAB
         if args.teacher_full_vocab_kl
@@ -456,6 +475,15 @@ def load_candidate_engine(
         "enable_prefix_caching": False,
         "seed": args.seed,
     }
+    tokenizer_mode = getattr(args, "tokenizer_mode", None)
+    if tokenizer_mode is not None:
+        llm_kwargs["tokenizer_mode"] = tokenizer_mode
+    kv_cache_memory_bytes = getattr(args, "kv_cache_memory_bytes", None)
+    if kv_cache_memory_bytes is not None:
+        llm_kwargs["kv_cache_memory_bytes"] = kv_cache_memory_bytes
+    kv_cache_dtype = getattr(args, "kv_cache_dtype", None)
+    if kv_cache_dtype is not None:
+        llm_kwargs["kv_cache_dtype"] = kv_cache_dtype
     chunked_prefill_request = args.enable_chunked_prefill
     if chunked_prefill_request is not None:
         llm_kwargs["enable_chunked_prefill"] = bool(
@@ -471,11 +499,20 @@ def load_candidate_engine(
         probe.restore()
         raise
     model_load_s = time.monotonic() - load_started
-    quality_sampling = bootstrap.sampling_params_class(
+    quality_sampling_kwargs = dict(
         max_tokens=1,
         temperature=0.0,
         prompt_logprobs=bootstrap.quality_logprobs,
         detokenize=False,
+    )
+    if bootstrap.quality_logprobs == -1:
+        # Full-vocabulary list[dict[int, Logprob]] creates one Python object
+        # graph per vocab cell.  vLLM's FlatLogprobs keeps the same values and
+        # Sequence API in primitive lists, which is the only representation
+        # with bounded-enough overhead for cardinality gates on large vocabs.
+        quality_sampling_kwargs["flat_logprobs"] = True
+    quality_sampling = bootstrap.sampling_params_class(
+        **quality_sampling_kwargs
     )
     timing_sampling = bootstrap.sampling_params_class(
         max_tokens=1,
@@ -760,6 +797,9 @@ def shared_report_settings(
         "prefix_caching": False,
         "chunked_prefill": bool(args.enable_chunked_prefill),
         "gpu_memory_utilization": args.gpu_memory_utilization,
+        "tokenizer_mode": getattr(args, "tokenizer_mode", None),
+        "kv_cache_memory_bytes": getattr(args, "kv_cache_memory_bytes", None),
+        "kv_cache_dtype": getattr(args, "kv_cache_dtype", None),
         "max_num_batched_tokens": args.max_num_batched_tokens,
         "top_k": args.top_k,
         "quality_prompt_logprobs_request": bootstrap.quality_logprobs,

--- a/gridbook/config.py
+++ b/gridbook/config.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -283,6 +284,135 @@ def _canonical_target(name: str) -> str:
     return _canonical_prefix(name)
 
 
+_DSPARK_TARGET_BRIDGE_SCHEMA = "gridbook.dspark-target-bridge.v1"
+_DSPARK_CANONICAL_INDEX = r"(?:0|[1-9]\d*)"
+_DSPARK_CANONICAL_TAIL = (
+    r"[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:[.](?:[A-Za-z_][A-Za-z0-9_]*|0|[1-9]\d*))*"
+)
+_DSPARK_CONSTRUCTION_TARGET_RE = re.compile(
+    rf"^model[.]layers[.](?P<layer>{_DSPARK_CANONICAL_INDEX})[.]"
+    rf"(?P<rest>{_DSPARK_CANONICAL_TAIL})$"
+)
+_DSPARK_PHYSICAL_TARGET_RE = re.compile(
+    rf"^mtp[.](?P<stage>{_DSPARK_CANONICAL_INDEX})[.]"
+    rf"(?P<rest>{_DSPARK_CANONICAL_TAIL})$"
+)
+
+
+def _parse_dspark_target_bridge(config: dict, contract: dict | None
+                                ) -> dict[str, str]:
+    """Validate the explicit DSpark construction -> physical target map.
+
+    Quantization dispatch constructs DSpark's layers under
+    ``model.layers.{num_hidden_layers + stage}``, while activation-contract
+    scalars are serialized under the checkpoint's ``mtp.{stage}`` namespace.
+    The bridge is producer metadata, not a runtime guess: its topology and
+    every same-tail mapping are checked here, and its physical values must be
+    exactly the digest-bound activation contract target set.
+    """
+    raw = config.get("dspark_target_bridge")
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("dspark_target_bridge must be an object")
+    expected_fields = {
+        "schema", "num_hidden_layers", "n_mtp_layers",
+        "construction_to_physical",
+    }
+    missing = sorted(expected_fields - set(raw))
+    extra = sorted(set(raw) - expected_fields)
+    if missing or extra:
+        raise ValueError(
+            "dspark_target_bridge fields mismatch: "
+            f"missing={missing}, unknown={extra}"
+        )
+    if raw["schema"] != _DSPARK_TARGET_BRIDGE_SCHEMA:
+        raise ValueError(
+            f"dspark_target_bridge.schema={raw['schema']!r}; expected "
+            f"{_DSPARK_TARGET_BRIDGE_SCHEMA!r}"
+        )
+    num_hidden = raw["num_hidden_layers"]
+    n_mtp = raw["n_mtp_layers"]
+    if (isinstance(num_hidden, bool) or not isinstance(num_hidden, int)
+            or num_hidden <= 0):
+        raise ValueError(
+            "dspark_target_bridge.num_hidden_layers must be a positive integer"
+        )
+    if (isinstance(n_mtp, bool) or not isinstance(n_mtp, int) or n_mtp <= 0):
+        raise ValueError(
+            "dspark_target_bridge.n_mtp_layers must be a positive integer"
+        )
+    if contract is None:
+        raise ValueError(
+            "dspark_target_bridge requires the nvfp4_w4a4 execution contract"
+        )
+    mapping = raw["construction_to_physical"]
+    if not isinstance(mapping, dict) or not mapping:
+        raise ValueError(
+            "dspark_target_bridge.construction_to_physical must be a "
+            "non-empty object"
+        )
+
+    result: dict[str, str] = {}
+    for construction, physical in mapping.items():
+        if (not isinstance(construction, str) or not construction
+                or not isinstance(physical, str) or not physical):
+            raise ValueError(
+                "dspark_target_bridge mappings require non-empty string keys "
+                "and values"
+            )
+        canonical = _canonical_target(construction)
+        if canonical != construction:
+            raise ValueError(
+                f"dspark construction target {construction!r} is not in the "
+                f"canonical namespace; use {canonical!r}"
+            )
+        construction_match = _DSPARK_CONSTRUCTION_TARGET_RE.fullmatch(
+            construction
+        )
+        physical_match = _DSPARK_PHYSICAL_TARGET_RE.fullmatch(physical)
+        if construction_match is None or physical_match is None:
+            raise ValueError(
+                f"invalid DSpark target bridge {construction!r} -> "
+                f"{physical!r}; expected model.layers.N.<tail> -> "
+                "mtp.S.<tail>"
+            )
+        stage = int(physical_match.group("stage"))
+        layer = int(construction_match.group("layer"))
+        if stage >= n_mtp:
+            raise ValueError(
+                f"DSpark physical target {physical!r} has stage {stage}, "
+                f"outside n_mtp_layers={n_mtp}"
+            )
+        if layer != num_hidden + stage:
+            raise ValueError(
+                f"DSpark construction target {construction!r} has layer "
+                f"{layer}; expected num_hidden_layers + stage = "
+                f"{num_hidden + stage}"
+            )
+        if construction_match.group("rest") != physical_match.group("rest"):
+            raise ValueError(
+                f"DSpark target bridge {construction!r} -> {physical!r} "
+                "changes the target tail"
+            )
+        result[construction] = physical
+
+    if len(set(result.values())) != len(result):
+        raise ValueError(
+            "dspark_target_bridge physical targets must be one-to-one"
+        )
+    contract_targets = set(contract["target_names"])
+    if set(result.values()) != contract_targets:
+        raise ValueError(
+            "dspark_target_bridge physical targets must exactly equal the "
+            "nvfp4_w4a4 execution contract target_names; "
+            f"bridge_only={sorted(set(result.values()) - contract_targets)}, "
+            f"contract_only={sorted(contract_targets - set(result.values()))}"
+        )
+    return result
+
+
 def _sidecar_revision(model_config: Any, model_dir: str) -> str | None:
     """Return one immutable revision for every sidecar of a Hub model.
 
@@ -374,6 +504,10 @@ class PrismaQuantConfig(QuantizationConfig):
         self._nvfp4_activation_contract: dict | None = None
         self._nvfp4_activation_scales: dict[str, float] | None = None
         self._target_physical_name: dict[str, str] = {}
+        # Producer-declared DSpark construction topology, rechecked against
+        # the instantiated draft model by the top-level loader before copying
+        # any tensor. None is the permanent non-DSpark/legacy state.
+        self._dspark_target_bridge_topology: tuple[int, int] | None = None
         # Delegated (non-CB) target -> the stock group that declares it. The
         # D0.2 preflight needs the *declaration*, and the declaration lives in
         # the config group, not in whatever tensors happen to be on disk.
@@ -393,8 +527,18 @@ class PrismaQuantConfig(QuantizationConfig):
     def _get_sidecar_source(self) -> tuple[str, str | None]:
         if self._sidecar_source is None:
             from vllm.config import get_current_vllm_config
+            from .moe_toplevel_loader import (
+                active_dspark_draft_model_config,
+            )
 
-            model_config = get_current_vllm_config().model_config
+            # vLLM retains the target model_config while constructing a
+            # separate DSpark draft.  Only the DSpark class's exact
+            # construction context can override this source; the existence of
+            # speculative_config by itself changes nothing for body/legacy
+            # configs.
+            model_config = active_dspark_draft_model_config()
+            if model_config is None:
+                model_config = get_current_vllm_config().model_config
             try:
                 model_dir = os.fspath(model_config.model)
             except TypeError as exc:
@@ -500,7 +644,8 @@ class PrismaQuantConfig(QuantizationConfig):
 
     @staticmethod
     def _validate_cb_activation_scheme(
-        scheme: dict, target: str, contract: dict | None
+        scheme: dict, target: str, contract: dict | None,
+        *, physical_target: str | None = None,
     ) -> None:
         """Validate a custom scheme's top-level activation-contract link."""
 
@@ -521,10 +666,12 @@ class PrismaQuantConfig(QuantizationConfig):
                 f"{_NVFP4_ACTIVATION_CONTRACT_KEY!r}, but the top-level "
                 "execution contract is absent"
             )
+        contract_target = physical_target or target
         if (reference is not None and contract is not None
-                and target not in contract["target_names"]):
+                and contract_target not in contract["target_names"]):
             raise ValueError(
-                f"CB target {target!r}: activation_contract scalar is absent "
+                f"CB target {target!r}: physical activation target "
+                f"{contract_target!r} is absent "
                 "from execution_contracts.nvfp4_w4a4.target_names"
             )
         if contract is not None and grid == "fp4" and reference is None:
@@ -648,6 +795,19 @@ class PrismaQuantConfig(QuantizationConfig):
 
     # -- lazy resolution of the (possibly pointer) quant config --------------
     def _ensure_resolved(self) -> None:
+        # Pointer configs necessarily bind their model source below when they
+        # open quant_config.json.  An inline config can otherwise finish
+        # resolution without touching either sidecar, then first ask for its
+        # codebook during post-load finalization after the DSpark constructor's
+        # draft-authority ContextVar has been restored.  Pin that authority
+        # while it is available, even when this config was already resolved;
+        # ordinary target configs still see no DSpark context and retain the
+        # historical current-vLLM-config path.
+        if self._sidecar_source is None:
+            from .moe_toplevel_loader import active_dspark_draft_model_config
+
+            if active_dspark_draft_model_config() is not None:
+                self._get_sidecar_source()
         if self._resolved:
             return
         cfg = self._raw_config
@@ -659,11 +819,28 @@ class PrismaQuantConfig(QuantizationConfig):
                 cfg = json.load(fh)
             self.codebook_file = cfg.get("codebook_file", self.codebook_file)
         self._nvfp4_activation_contract = _parse_nvfp4_activation_contract(cfg)
+        dspark_target_bridge = _parse_dspark_target_bridge(
+            cfg, self._nvfp4_activation_contract
+        )
+        if dspark_target_bridge:
+            bridge_record = cfg["dspark_target_bridge"]
+            self._dspark_target_bridge_topology = (
+                int(bridge_record["num_hidden_layers"]),
+                int(bridge_record["n_mtp_layers"]),
+            )
 
         # Preserve the producer's physical spelling before resolver namespace
-        # canonicalization.  Digest membership is over these exact names.
-        physical_by_canonical: dict[str, str] = {}
+        # canonicalization. Digest membership is over these exact names. The
+        # DSpark bridge covers the complete activation contract (including a
+        # delegated stock-NVFP4 target); custom CB targets add the legacy
+        # identity mapping when no bridge is present.
+        physical_by_canonical: dict[str, str] = dict(dspark_target_bridge)
+        declared_targets: set[str] = set()
         for group in cfg["config_groups"].values():
+            declared_targets.update(
+                _canonical_target(str(target))
+                for target in group.get("targets", [])
+            )
             scheme = group.get("scheme")
             if scheme is None:
                 continue
@@ -671,18 +848,34 @@ class PrismaQuantConfig(QuantizationConfig):
                 raise ValueError("CB config group scheme must be an object")
             for raw_target in group.get("targets", []):
                 target = str(raw_target)
+                canonical = _canonical_target(target)
+                physical = dspark_target_bridge.get(canonical, target)
                 self._validate_cb_activation_scheme(
-                    scheme, target, self._nvfp4_activation_contract
+                    scheme,
+                    target,
+                    self._nvfp4_activation_contract,
+                    physical_target=physical,
                 )
                 if scheme.get("activation_contract") is None:
                     continue
-                canonical = _canonical_target(target)
-                previous = physical_by_canonical.setdefault(canonical, target)
-                if previous != target:
+                previous = physical_by_canonical.setdefault(
+                    canonical, physical
+                )
+                if previous != physical:
                     raise ValueError(
-                        f"contracted CB targets {previous!r} and {target!r} "
-                        f"collapse to runtime namespace {canonical!r}"
+                        f"contracted CB runtime target {canonical!r} maps to "
+                        f"conflicting physical targets {previous!r} and "
+                        f"{physical!r}"
                     )
+        if dspark_target_bridge:
+            bridge_keys = set(dspark_target_bridge)
+            undeclared = bridge_keys - declared_targets
+            if undeclared:
+                raise ValueError(
+                    "dspark_target_bridge construction targets must be "
+                    "declared by config_groups; "
+                    f"undeclared={sorted(undeclared)}"
+                )
         # Normalise stored namespaces ONCE, here, so all downstream resolution
         # (ours and the delegated CT config's) sees canonical target names.
         cfg = dict(cfg)
@@ -800,6 +993,9 @@ class PrismaQuantConfig(QuantizationConfig):
             CompressedTensorsConfig,
         )
         ct_dict = dict(self._full_config)
+        # Gridbook-only construction/physical namespace metadata is consumed
+        # above and must not leak into compressed-tensors' closed vocabulary.
+        ct_dict.pop("dspark_target_bridge", None)
         ct_dict["quant_method"] = "compressed-tensors"
         ct_dict["config_groups"] = dict(stock_groups)
         # Passthrough units join CB targets in CT's ignore: both are owned by

--- a/gridbook/csrc/cb_gemv_v2.cu
+++ b/gridbook/csrc/cb_gemv_v2.cu
@@ -37,16 +37,16 @@
 // the k20 (16 KB) and k24 (64 KB) staged-dictionary configurations expressible
 // at all.
 //
-// NUMERICS — NOT bit-exact against the default inherited schedule. The byte
-// format, the decode semantics, the wv rounding (v1: w = bf16_rn(f32(cb)*sc);
-// v2 contract: raw values with sc applied to the lane partial), the FMA chain
-// order, the ascending-superblock per-warp accumulation and the 32-lane tree
-// reduce are all IDENTICAL to cb_gemv.cu's `cb_moe_gemv_fp4_v2_rowpack_kernel`
-// (PRISMAQUANT_CB_W2_SCHED=rowpack), against which this kernel is bit-exact.
-// The inherited DEFAULT schedule sums in a different order, so v2-vs-default is
-// a REASSOCIATION-class difference, the same class as the CUDA-vs-Triton gate
-// in tests/test_cuda_gemv.py. Measured on a 204-cell synthetic sweep: 9 cells
-// differ, worst max_rel 5.88e-03. Do not describe this kernel as bit-exact.
+// NUMERICS. The byte format, decode semantics and wv rounding are identical to
+// cb_gemv.cu (v1: w = bf16_rn(f32(cb)*sc); v2 contract: raw values with sc
+// applied to the lane partial). On the exact DSV4 K=2048/4096 shapes (8/16
+// superblocks), a compile-time specialization emulates the inherited DEFAULT
+// kernel's eight independent warp accumulators and final w=0..7 sum while one
+// physical warp still owns each output row. It is therefore required to be
+// bit-exact to the shipped default there. Other shapes retain the original
+// ascending-superblock rowpack reduction and are bit-exact to
+// `cb_moe_gemv_fp4_v2_rowpack_kernel` instead; those may reassociate against
+// the inherited default. Keep the two contracts separate in tests and claims.
 //
 // Scope: fp4 grid, product mode n_sub=2, two-tier v2 scale plane
 // (type_size = 4k+9), stacked [E, N, row_bytes] MoE experts. Signed/full/fp8
@@ -99,6 +99,106 @@ struct Split2 {
   }
 };
 
+// One superblock of the per-lane FP4-CB dot product.  Keeping this helper
+// shared by the ordinary rowpack schedule and the exact DSV4 specialization
+// below makes the byte extraction, dictionary gather, weight rounding and FMA
+// instructions identical; only the accumulator that receives superblock s is
+// selected by the caller.
+template <int DS>
+DEVINL void cb_gemv_v2_accumulate_superblock(
+    const int s, const int lane, const int head_off,
+    const uint8_t* __restrict__ slot,
+    const uint16_t* __restrict__ xr, const int type_size,
+    const uint16_t* __restrict__ cb, const float* __restrict__ compose,
+    const uint16_t* __restrict__ dict, const Split2& sp,
+    const int k_bits, const int scale_off, const int v2,
+    float& acc) {
+  const int sb_off = head_off + s * type_size;
+  const int bitpos = sb_off * 8 + lane * k_bits;
+  const int b0 = bitpos >> 3;
+  const int rem = ((b0 & 3) << 3) + (bitpos & 7);
+  const uint32_t* s32 = reinterpret_cast<const uint32_t*>(slot);
+  const int widx = b0 >> 2;
+  const uint32_t w0_ = s32[widx];
+  const uint32_t w1_ = s32[widx + 1];
+  const uint32_t w2_ = (rem + k_bits > 64) ? s32[widx + 2] : 0u;
+  const int grp = lane >> 1;
+  const uint8_t super_e = slot[sb_off + scale_off];
+  const uint8_t sub_byte = slot[sb_off + scale_off + 1 + (grp >> 1)];
+  const uint64_t lo = ((uint64_t)w1_ << 32) | (uint64_t)w0_;
+  uint64_t code = lo >> rem;
+  if (rem + k_bits > 64) code |= (uint64_t)w2_ << (64 - rem);
+  code &= (k_bits >= 64) ? ~0ull : ((1ull << k_bits) - 1ull);
+
+  const uint32_t code16 =
+      (uint32_t)((sub_byte >> ((grp & 1) * 4)) & 0xFu);
+  const float sc = __ldg(compose + (int)super_e * 16 + (int)code16);
+
+  const uint32_t i0 = (uint32_t)code & sp.m0;
+  const uint32_t i1 = (uint32_t)(code >> sp.w0) & sp.m1;
+  uint2 q0, q1;
+  if constexpr (DS != 0) {
+    q0 = *reinterpret_cast<const uint2*>(dict + (int64_t)i0 * 4);
+  } else {
+    q0 = __ldg(reinterpret_cast<const uint2*>(cb + (int64_t)i0 * 4));
+  }
+  if constexpr (DS == 2) {
+    q1 = *reinterpret_cast<const uint2*>(dict + sp.e1 + (int64_t)i1 * 4);
+  } else {
+    q1 = __ldg(reinterpret_cast<const uint2*>(cb + sp.e1 +
+                                              (int64_t)i1 * 4));
+  }
+  float wv[8];
+  if (v2) {
+    wv[0] = bf16_to_f32((uint16_t)(q0.x & 0xffffu));
+    wv[1] = bf16_to_f32((uint16_t)(q0.x >> 16));
+    wv[2] = bf16_to_f32((uint16_t)(q0.y & 0xffffu));
+    wv[3] = bf16_to_f32((uint16_t)(q0.y >> 16));
+    wv[4] = bf16_to_f32((uint16_t)(q1.x & 0xffffu));
+    wv[5] = bf16_to_f32((uint16_t)(q1.x >> 16));
+    wv[6] = bf16_to_f32((uint16_t)(q1.y & 0xffffu));
+    wv[7] = bf16_to_f32((uint16_t)(q1.y >> 16));
+  } else {
+    wv[0] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q0.x & 0xffffu)) * sc));
+    wv[1] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q0.x >> 16)) * sc));
+    wv[2] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q0.y & 0xffffu)) * sc));
+    wv[3] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q0.y >> 16)) * sc));
+    wv[4] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q1.x & 0xffffu)) * sc));
+    wv[5] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q1.x >> 16)) * sc));
+    wv[6] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q1.y & 0xffffu)) * sc));
+    wv[7] = bf16_to_f32(f32_to_bf16_rn(
+        bf16_to_f32((uint16_t)(q1.y >> 16)) * sc));
+  }
+
+  const int64_t xbase = ((int64_t)s << 8) + (lane << 3);
+  const uint4 xv = __ldg(reinterpret_cast<const uint4*>(xr + xbase));
+  const uint32_t xw[4] = {xv.x, xv.y, xv.z, xv.w};
+  if (v2) {
+    float ppart = 0.0f;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      ppart = fmaf(wv[2 * i], bf16_to_f32((uint16_t)(xw[i] & 0xffffu)),
+                   ppart);
+      ppart = fmaf(wv[2 * i + 1], bf16_to_f32((uint16_t)(xw[i] >> 16)),
+                   ppart);
+    }
+    acc = fmaf(sc, ppart, acc);
+  } else {
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      acc = fmaf(wv[2 * i], bf16_to_f32((uint16_t)(xw[i] & 0xffffu)), acc);
+      acc = fmaf(wv[2 * i + 1], bf16_to_f32((uint16_t)(xw[i] >> 16)), acc);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Grouped MoE fp4-v2 decode GEMV, smem-resident dictionary + whole-row stage.
 //   x        [Xrows, K] bf16 (as u16), act-QDQ'd outside (same as inherited)
@@ -124,7 +224,13 @@ struct Split2 {
 //   1 HALF  : sub0 in smem, sub1 by __ldg — halves both the smem bill and the
 //             divergent-gather rate.  The k24 compromise.
 // sub0 has 2^ceil(k/2) entries (elements [0, e1)), sub1 the rest.
-template <int WARPS, int DS>
+// INHERITED_NSB is zero for the existing rowpack reduction.  The 8/16
+// specializations preserve the shipped inherited kernel's eight-warp FP32
+// reduction order on the exact DSV4 w2/w13 shapes while retaining v2's one
+// physical warp per output row and its shared-dictionary/whole-row staging.
+// Eight named accumulators are intentional: a runtime-indexed array can spill
+// to local memory and would erase the decode win this specialization protects.
+template <int WARPS, int DS, int INHERITED_NSB = 0>
 __global__ __launch_bounds__(WARPS * 32) void cb_gemv_v2_kernel(
     const uint16_t* __restrict__ x,
     const uint8_t* __restrict__ qw,
@@ -138,6 +244,11 @@ __global__ __launch_bounds__(WARPS * 32) void cb_gemv_v2_kernel(
     const int rpb, const int slot_bytes, const int cb_elems,
     const int64_t last_row_byte,   // total bytes of qw (OOB guard for u64 tail)
     const int v2) {
+  static_assert(INHERITED_NSB == 0 || WARPS == 8,
+                "inherited-order specialization requires eight physical warps");
+  static_assert(INHERITED_NSB == 0 || INHERITED_NSB == 8 ||
+                    INHERITED_NSB == 16,
+                "unsupported inherited-order superblock count");
   const int n_sb = (int)(K >> 8);
   const int64_t row_bytes = (int64_t)n_sb * type_size;
   const int64_t nblk_per_pair = (Nout + rpb - 1) / rpb;
@@ -196,102 +307,60 @@ __global__ __launch_bounds__(WARPS * 32) void cb_gemv_v2_kernel(
     }
     __syncwarp();
 
-    // --- Phase 2: decode superblocks ascending (inherited rowpack order) ----
-    float acc = 0.0f;
-    for (int s = 0; s < n_sb; ++s) {
-      const int sb_off = off8 + s * type_size;
-      const int bitpos = sb_off * 8 + lane * k_bits;
-      const int b0 = bitpos >> 3;
-      const int rem = ((b0 & 3) << 3) + (bitpos & 7);
-      const uint32_t* s32 = reinterpret_cast<const uint32_t*>(slot);
-      const int widx = b0 >> 2;
-      const uint32_t w0_ = s32[widx];
-      const uint32_t w1_ = s32[widx + 1];
-      const uint32_t w2_ = (rem + k_bits > 64) ? s32[widx + 2] : 0u;
-      const int grp = lane >> 1;
-      const uint8_t super_e = slot[sb_off + scale_off];
-      const uint8_t sub_byte = slot[sb_off + scale_off + 1 + (grp >> 1)];
-      const uint64_t lo = ((uint64_t)w1_ << 32) | (uint64_t)w0_;
-      uint64_t code = lo >> rem;
-      if (rem + k_bits > 64) code |= (uint64_t)w2_ << (64 - rem);
-      code &= (k_bits >= 64) ? ~0ull : ((1ull << k_bits) - 1ull);
-
-      const uint32_t code16 = (uint32_t)((sub_byte >> ((grp & 1) * 4)) & 0xFu);
-      const float sc = __ldg(compose + (int)super_e * 16 + (int)code16);
-
-      // Sub-index gathers -> SMEM (the entire point of this kernel) or, when
-      // the dict is too large to stage without starving occupancy, __ldg.
-      const uint32_t i0 = (uint32_t)code & sp.m0;
-      const uint32_t i1 = (uint32_t)(code >> sp.w0) & sp.m1;
-      uint2 q0, q1;
-      if (DS != 0) {
-        q0 = *reinterpret_cast<const uint2*>(dict + (int64_t)i0 * 4);
-      } else {
-        q0 = __ldg(reinterpret_cast<const uint2*>(cb + (int64_t)i0 * 4));
+    if constexpr (INHERITED_NSB == 8 || INHERITED_NSB == 16) {
+      // Emulate the inherited 8-warp schedule with eight virtual warp
+      // accumulators.  For NSB=16, vacc[w] receives s=w and then s=w+8,
+      // exactly the FMA chain of inherited physical warp w; for NSB=8 it
+      // receives just s=w.  Each accumulator then gets the same lane tree,
+      // followed by the same w=0..7 serial sum and one BF16 output round.
+      float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+      float acc4 = 0.0f, acc5 = 0.0f, acc6 = 0.0f, acc7 = 0.0f;
+#define CBV2_ACC(S, A) cb_gemv_v2_accumulate_superblock<DS>(                 \
+        (S), lane, off8, slot, xr, type_size, cb, compose, dict, sp,       \
+        k_bits,                                                            \
+        scale_off, v2, (A))
+      CBV2_ACC(0, acc0); CBV2_ACC(1, acc1);
+      CBV2_ACC(2, acc2); CBV2_ACC(3, acc3);
+      CBV2_ACC(4, acc4); CBV2_ACC(5, acc5);
+      CBV2_ACC(6, acc6); CBV2_ACC(7, acc7);
+      if constexpr (INHERITED_NSB == 16) {
+        CBV2_ACC(8, acc0);  CBV2_ACC(9, acc1);
+        CBV2_ACC(10, acc2); CBV2_ACC(11, acc3);
+        CBV2_ACC(12, acc4); CBV2_ACC(13, acc5);
+        CBV2_ACC(14, acc6); CBV2_ACC(15, acc7);
       }
-      if (DS == 2) {
-        q1 = *reinterpret_cast<const uint2*>(dict + sp.e1 + (int64_t)i1 * 4);
-      } else {
-        q1 = __ldg(reinterpret_cast<const uint2*>(cb + sp.e1 +
-                                                  (int64_t)i1 * 4));
-      }
-      float wv[8];
-      if (v2) {
-        wv[0] = bf16_to_f32((uint16_t)(q0.x & 0xffffu));
-        wv[1] = bf16_to_f32((uint16_t)(q0.x >> 16));
-        wv[2] = bf16_to_f32((uint16_t)(q0.y & 0xffffu));
-        wv[3] = bf16_to_f32((uint16_t)(q0.y >> 16));
-        wv[4] = bf16_to_f32((uint16_t)(q1.x & 0xffffu));
-        wv[5] = bf16_to_f32((uint16_t)(q1.x >> 16));
-        wv[6] = bf16_to_f32((uint16_t)(q1.y & 0xffffu));
-        wv[7] = bf16_to_f32((uint16_t)(q1.y >> 16));
-      } else {
-        wv[0] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q0.x & 0xffffu)) * sc));
-        wv[1] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q0.x >> 16)) * sc));
-        wv[2] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q0.y & 0xffffu)) * sc));
-        wv[3] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q0.y >> 16)) * sc));
-        wv[4] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q1.x & 0xffffu)) * sc));
-        wv[5] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q1.x >> 16)) * sc));
-        wv[6] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q1.y & 0xffffu)) * sc));
-        wv[7] = bf16_to_f32(f32_to_bf16_rn(
-            bf16_to_f32((uint16_t)(q1.y >> 16)) * sc));
-      }
-
-      // FMA against x: one 16-byte L2 load per lane (identical to inherited).
-      const int64_t xbase = ((int64_t)s << 8) + (lane << 3);
-      const uint4 xv = __ldg(reinterpret_cast<const uint4*>(xr + xbase));
-      const uint32_t xw[4] = {xv.x, xv.y, xv.z, xv.w};
-      if (v2) {
-        float ppart = 0.0f;
+#undef CBV2_ACC
 #pragma unroll
-        for (int i = 0; i < 4; ++i) {
-          ppart = fmaf(wv[2 * i], bf16_to_f32((uint16_t)(xw[i] & 0xffffu)),
-                       ppart);
-          ppart = fmaf(wv[2 * i + 1], bf16_to_f32((uint16_t)(xw[i] >> 16)),
-                       ppart);
-        }
-        acc = fmaf(sc, ppart, acc);
-      } else {
-#pragma unroll
-        for (int i = 0; i < 4; ++i) {
-          acc = fmaf(wv[2 * i], bf16_to_f32((uint16_t)(xw[i] & 0xffffu)), acc);
-          acc = fmaf(wv[2 * i + 1], bf16_to_f32((uint16_t)(xw[i] >> 16)), acc);
-        }
+      for (int off = 16; off > 0; off >>= 1) {
+        acc0 += __shfl_down_sync(0xffffffffu, acc0, off);
+        acc1 += __shfl_down_sync(0xffffffffu, acc1, off);
+        acc2 += __shfl_down_sync(0xffffffffu, acc2, off);
+        acc3 += __shfl_down_sync(0xffffffffu, acc3, off);
+        acc4 += __shfl_down_sync(0xffffffffu, acc4, off);
+        acc5 += __shfl_down_sync(0xffffffffu, acc5, off);
+        acc6 += __shfl_down_sync(0xffffffffu, acc6, off);
+        acc7 += __shfl_down_sync(0xffffffffu, acc7, off);
       }
+      if (lane == 0) {
+        float total = 0.0f;
+        total += acc0; total += acc1; total += acc2; total += acc3;
+        total += acc4; total += acc5; total += acc6; total += acc7;
+        y[p * Nout + n] = f32_to_bf16_rn(total);
+      }
+    } else {
+      // Existing rowpack order for every shape not explicitly specialized.
+      float acc = 0.0f;
+      for (int s = 0; s < n_sb; ++s) {
+        cb_gemv_v2_accumulate_superblock<DS>(
+            s, lane, off8, slot, xr, type_size, cb, compose, dict, sp,
+            k_bits,
+            scale_off, v2, acc);
+      }
+#pragma unroll
+      for (int off = 16; off > 0; off >>= 1)
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+      if (lane == 0) y[p * Nout + n] = f32_to_bf16_rn(acc);
     }
-
-    // 32-lane tree reduce (identical to inherited rowpack), direct write.
-#pragma unroll
-    for (int off = 16; off > 0; off >>= 1)
-      acc += __shfl_down_sync(0xffffffffu, acc, off);
-    if (lane == 0) y[p * Nout + n] = f32_to_bf16_rn(acc);
     __syncwarp();
   }
 }
@@ -460,6 +529,12 @@ static void cbv2_prepare_device(int device) {
   CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 0>));
   CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 1>));
   CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 2>));
+  CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 0, 8>));
+  CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 1, 8>));
+  CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 2, 8>));
+  CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 0, 16>));
+  CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 1, 16>));
+  CBV2_SET_MAX_SMEM((cb_gemv_v2_kernel<8, 2, 16>));
   CBV2_SET_MAX_SMEM((cb_expand_v2_kernel<8>));
 #undef CBV2_SET_MAX_SMEM
 
@@ -527,6 +602,7 @@ torch::Tensor cb_gemv_v2(torch::Tensor x, torch::Tensor qw_stack,
   TORCH_CHECK(K > 0 && K % 256 == 0 &&
               K <= std::numeric_limits<int>::max(),
               "decoded K must be a positive int-sized multiple of 256");
+  const int n_sb = (int)(K >> 8);
   TORCH_CHECK(row_bytes <= std::numeric_limits<int>::max() - 32,
               "packed row is too wide for the kernel's slot indexing");
   TORCH_CHECK(x.size(1) == K, "x width != decoded row width");
@@ -648,9 +724,9 @@ torch::Tensor cb_gemv_v2(torch::Tensor x, torch::Tensor qw_stack,
               P <= std::numeric_limits<int>::max() / nbp,
               "CB-GEMV-v2 launch grid exceeds CUDA's x dimension");
   const int v2 = pq_env_is("PRISMAQUANT_CB_DECODE_CONTRACT", "v2") ? 1 : 0;
-#define LAUNCH_CBV2(DS)                                                      \
-  cb_gemv_v2_kernel<WARPS, DS><<<(unsigned)(P * nbp), WARPS * 32, smem,      \
-                                 stream>>>(                                  \
+#define LAUNCH_CBV2(DS, NSB)                                                 \
+  cb_gemv_v2_kernel<WARPS, DS, NSB>                                          \
+      <<<(unsigned)(P * nbp), WARPS * 32, smem, stream>>>(                   \
       reinterpret_cast<const uint16_t*>(x.data_ptr()),                       \
       qw_stack.data_ptr<uint8_t>(),                                          \
       reinterpret_cast<const uint16_t*>(cb_flat.data_ptr()),                 \
@@ -659,9 +735,19 @@ torch::Tensor cb_gemv_v2(torch::Tensor x, torch::Tensor qw_stack,
       reinterpret_cast<uint16_t*>(y.data_ptr()),                             \
       P, Nout, K, (int)k_bits, (int)type_size, (int)rpb, slot_bytes,         \
       (int)cb_elems, qw_stack.numel(), (int)v2)
-  if (ds == 2) { LAUNCH_CBV2(2); }
-  else if (ds == 1) { LAUNCH_CBV2(1); }
-  else { LAUNCH_CBV2(0); }
+  if (n_sb == 8) {
+    if (ds == 2) { LAUNCH_CBV2(2, 8); }
+    else if (ds == 1) { LAUNCH_CBV2(1, 8); }
+    else { LAUNCH_CBV2(0, 8); }
+  } else if (n_sb == 16) {
+    if (ds == 2) { LAUNCH_CBV2(2, 16); }
+    else if (ds == 1) { LAUNCH_CBV2(1, 16); }
+    else { LAUNCH_CBV2(0, 16); }
+  } else {
+    if (ds == 2) { LAUNCH_CBV2(2, 0); }
+    else if (ds == 1) { LAUNCH_CBV2(1, 0); }
+    else { LAUNCH_CBV2(0, 0); }
+  }
 #undef LAUNCH_CBV2
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return y;

--- a/gridbook/linear.py
+++ b/gridbook/linear.py
@@ -372,6 +372,20 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
         layer._cb_fp4_input_global_scale_f32 = float(expected_scales[0])
 
     def process_weights_after_loading(self, layer):
+        # vLLM stamps grouped-BMM geometry only after the Linear constructor
+        # (and therefore after get_quant_method/create_weights).  A dense CB
+        # method must not reinterpret [T,G,K] as T*G independent dense rows:
+        # that would multiply every group by all G output blocks and return
+        # [T,G,G*N] instead of the required [T,G,N].  Keep this load-time and
+        # fail-closed until Gridbook owns a measured grouped-CB kernel.  The
+        # released DeepSeek-V4 wo_a route is source FP8 W8A16, whose grouped
+        # BMM contract is separately qualified.
+        if bool(getattr(layer, "is_bmm", False)):
+            raise RuntimeError(
+                f"{self.prefix}: dense CB Linear does not implement grouped "
+                "BMM semantics; declare this projection as source FP8 W8A16 "
+                "instead of serving a shape-incorrect CB fallback"
+            )
         dev = layer.cb_qweight.device
         codebooks = self.quant_config.get_codebooks()
 

--- a/gridbook/moe.py
+++ b/gridbook/moe.py
@@ -90,6 +90,11 @@ _CB_ROLES = ("gate", "up", "down")
 _FP8_GROUPED_POLICY = "fp8_cb_grouped"
 _FP8_GROUPED_CONTRACT = "fp8_per_token_dynamic"
 
+# Native routed decode/prefill boundary.  Keep this public because validation
+# reports must attest the exact branch used by the serving runtime rather than
+# restating a literal that can drift from it.
+MOE_PREFILL_M_THRESHOLD = 16
+
 
 def _moe_shape(layer, topk_ids) -> str:
     """Compact routed problem shape for the dispatch record.
@@ -752,7 +757,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         act = getattr(layer, "_cb_native_activation", layer.activation.value)
         num_tokens = x.shape[0]
 
-        if num_tokens <= 16:
+        if num_tokens <= MOE_PREFILL_M_THRESHOLD:
             if not self._cuda_moe_ok(layer):
                 from .cuda_ext import NativeKernelUnavailableError
                 raise NativeKernelUnavailableError(

--- a/gridbook/moe_gemv_select.py
+++ b/gridbook/moe_gemv_select.py
@@ -30,10 +30,12 @@ import threading
 #     (csrc/cb_gemv_v2.cu). Opts in to the sm_121a 99 KB dynamic-smem budget
 #     and stages the product sub-tables when they fit, which is what buys the
 #     decode-efficiency delta on the low rungs.
-# Same byte format, same decode semantics, same FMA chain as the inherited
-# ROWPACK schedule (csrc/cb_gemv_v2.cu:40-49); only WHERE the dictionary is
-# read from changes. It is NOT bit-exact against the inherited DEFAULT
-# schedule — that is a reassociation-class difference.
+# Same byte format and decode semantics. On the DSV4 release widths
+# K=2048/4096 (8/16 superblocks), v2 uses a compile-time virtual-warp
+# specialization that reproduces the inherited DEFAULT kernel's eight
+# accumulator chains and final reduction bit-for-bit. That exactness contract
+# requires every PRISMAQUANT_CB_W2_* override to be absent. Other widths retain
+# v2's ascending rowpack reduction and may reassociate against inherited.
 #
 # Selector (resolve once per process, whitelist, fail loud, one log line):
 #   inherited  — the SHIPPING DEFAULT, kill switch and A/B control. Never

--- a/gridbook/moe_toplevel_loader.py
+++ b/gridbook/moe_toplevel_loader.py
@@ -56,10 +56,19 @@ no new per-arch loader:
   ``layers.N.ffn.experts.gate_up_proj.cb_qweight`` lands on the registered
   param without a Gridbook-side rewrite.
 
-Its MTP/DSpark payload does NOT come through here: ``DeepseekV4ForCausalLM.
-load_weights`` builds ``AutoWeightsLoader(self, skip_substrs=["mtp."])``, so all
-``mtp.*`` tensors are dropped before any parameter lookup. See the
-``deepseek_v4`` notes in ``docs/PLUGIN.md``.
+The target body's MTP payload does NOT come through here:
+``DeepseekV4ForCausalLM.load_weights`` builds
+``AutoWeightsLoader(self, skip_substrs=["mtp."])``, so all ``mtp.*`` tensors
+are dropped before any parameter lookup.  The separate DSpark draft class does
+load that payload.  Its constructor and loader deliberately use different
+namespaces: quantization dispatch sees construction prefixes
+``model.layers.{num_hidden_layers + i}``, while registered parameters are
+``model.layers.{i}`` and checkpoint tensors are ``mtp.{i}``.  For interception
+only, the wrapper calls the draft model's own ``_remap_dspark_name`` before the
+existing mixed-fused / expert resolvers.  Any tensor those Gridbook paths do
+not own is delegated under its original ``mtp.*`` name so DSpark's stock loader
+remains the sole owner of ordinary dense, head, and passthrough loading.  See
+the ``deepseek_v4`` notes in ``docs/PLUGIN.md``.
 
 **Shared-expert (``shared_mlp``) CB tensors.** ``config.py`` aliases the
 architecture's collapsed parent prefix (and its MTP ``.mtp_block`` form) so a
@@ -104,7 +113,9 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from functools import wraps
+import os
 import re
+from typing import Any
 import torch
 
 from .cb_fill_guard import mark_filled
@@ -121,12 +132,80 @@ MIXED_FUSED_LOADER_ABI = 1
 _ACTIVE_MIXED_FUSED_LOADER_ABI: ContextVar[int | None] = ContextVar(
     "gridbook_active_mixed_fused_loader_abi", default=None
 )
+# vLLM's DSpark loader intentionally keeps the target ModelConfig on the
+# current VllmConfig while it constructs the separate draft model.  That is
+# correct for DSpark's target-layer metadata, but it is not the source of the
+# draft checkpoint's Gridbook sidecars.  Bind the *explicit* speculative draft
+# ModelConfig only around the exact DSpark construction lifetime; config.py
+# reads this lazily and every non-DSpark class retains the historical global
+# model_config path.
+_ACTIVE_DSPARK_DRAFT_MODEL_CONFIG: ContextVar[Any | None] = ContextVar(
+    "gridbook_active_dspark_draft_model_config", default=None
+)
+_DSPARK_DRAFT_MODULE = "vllm.models.deepseek_v4.nvidia.dspark"
 
 
 def mixed_fused_loader_active() -> bool:
     """Whether the model currently constructing has the loader ABI."""
 
     return _ACTIVE_MIXED_FUSED_LOADER_ABI.get() == MIXED_FUSED_LOADER_ABI
+
+
+def active_dspark_draft_model_config() -> Any | None:
+    """Return the draft ModelConfig during structural DSpark construction.
+
+    The value is deliberately unavailable before and after ``__init__``.  A
+    Gridbook config that resolves a pointer sidecar during that construction
+    can therefore select the draft source without making the mere presence of
+    ``speculative_config`` affect target/body model loading.
+    """
+
+    return _ACTIVE_DSPARK_DRAFT_MODEL_CONFIG.get()
+
+
+def _is_dspark_draft_construction(model: Any) -> bool:
+    """Whether this exact registered model class is the DSpark draft."""
+
+    cls = type(model)
+    return (
+        cls.__module__ == _DSPARK_DRAFT_MODULE
+        and callable(getattr(cls, "_remap_dspark_name", None))
+    )
+
+
+def _require_dspark_draft_model_config() -> Any:
+    """Resolve the sole sidecar authority for a DSpark draft, fail closed."""
+
+    try:
+        from vllm.config import get_current_vllm_config
+
+        current = get_current_vllm_config()
+    except Exception as exc:  # noqa: BLE001 - convert context absence clearly
+        raise RuntimeError(
+            "DSpark Gridbook construction has no current vLLM config from "
+            "which to resolve speculative_config.draft_model_config"
+        ) from exc
+
+    speculative_config = getattr(current, "speculative_config", None)
+    draft_config = getattr(speculative_config, "draft_model_config", None)
+    if draft_config is None:
+        raise RuntimeError(
+            "DSpark Gridbook construction requires vLLM "
+            "speculative_config.draft_model_config"
+        )
+    try:
+        draft_source = os.fspath(draft_config.model)
+    except (AttributeError, TypeError) as exc:
+        raise RuntimeError(
+            "DSpark speculative_config.draft_model_config.model is not a "
+            "filesystem path or Hub ID"
+        ) from exc
+    if not isinstance(draft_source, str) or not draft_source:
+        raise RuntimeError(
+            "DSpark speculative_config.draft_model_config.model is not a "
+            "nonempty string path or Hub ID"
+        )
+    return draft_config
 
 
 def installed_module_paths() -> set[str]:
@@ -316,6 +395,52 @@ _MIXED_GROUP_ATTR = "_gridbook_mixed_fused_group"
 _MIXED_SOURCE_ATTR = "_gridbook_mixed_fused_source"
 _MIXED_PLANE_ATTR = "_gridbook_mixed_fused_plane"
 _MIXED_FILLED_ATTR = "_gridbook_mixed_fused_filled"
+_MIXED_CARRIER_MARKER = "._gridbook_mixed_roles."
+
+
+def _registered_mixed_source(param_name: str, group: str,
+                             source: str) -> str | None:
+    """Derive a role's registered source name from its actual parameter path.
+
+    DSpark constructs a fused module under ``model.layers.43/44/45`` but its
+    three-element ModuleList registers the same modules under layers ``0/1/2``.
+    Mixed-carrier metadata truthfully retains the construction prefix, while
+    ``named_parameters()`` is authoritative for the registered prefix used by
+    the loader.  The carrier marker is the structural join between those two
+    facts.  No layer offset is inferred here.
+
+    A standalone carrier fixture can have no owning-module prefix; in that
+    case there is no registered alias to derive and the construction route is
+    retained unchanged.  Any partially matching or internally inconsistent
+    full path fails closed.
+    """
+    if _MIXED_CARRIER_MARKER not in param_name:
+        return None
+    registered_group, marker, _ = param_name.partition(_MIXED_CARRIER_MARKER)
+    if not marker or not registered_group:
+        raise ValueError(
+            f"mixed fused parameter {param_name!r} has malformed carrier path"
+        )
+    if registered_group == group:
+        return source
+
+    construction_parent, separator, construction_leaf = group.rpartition(".")
+    registered_parent, registered_separator, registered_leaf = \
+        registered_group.rpartition(".")
+    if (not separator or not registered_separator
+            or construction_leaf != registered_leaf):
+        raise ValueError(
+            f"mixed fused parameter {param_name!r} is registered under "
+            f"{registered_group!r}, incompatible with construction group "
+            f"{group!r}"
+        )
+    construction_stem = construction_parent + "."
+    if not source.startswith(construction_stem):
+        raise ValueError(
+            f"mixed fused source {source!r} is not a sibling of construction "
+            f"group {group!r}"
+        )
+    return registered_parent + "." + source[len(construction_stem):]
 
 
 def _mixed_plane_candidates(name: str) -> tuple[str, tuple[str, ...]] | None:
@@ -364,12 +489,19 @@ class _MixedFusedTransactions:
                 raise ValueError(
                     f"mixed fused parameter {param_name!r} has incomplete "
                     "routing metadata")
-            route = (source, plane)
-            previous = self._routes.setdefault(route, param_name)
-            if previous != param_name:
-                raise ValueError(
-                    f"mixed fused route {route!r} is ambiguous between "
-                    f"{previous!r} and {param_name!r}")
+            registered_source = _registered_mixed_source(
+                param_name, group, source
+            )
+            route_sources = {source}
+            if registered_source is not None:
+                route_sources.add(registered_source)
+            for route_source in route_sources:
+                route = (route_source, plane)
+                previous = self._routes.setdefault(route, param_name)
+                if previous != param_name:
+                    raise ValueError(
+                        f"mixed fused route {route!r} is ambiguous between "
+                        f"{previous!r} and {param_name!r}")
             self._expected.setdefault(group, set()).add(param_name)
         self._pending: dict[str, dict[str, tuple[str, torch.Tensor]]] = {}
         self._committed: set[str] = set()
@@ -607,6 +739,70 @@ def _spec_layer_rename(model):
     return rename
 
 
+def _dspark_rename(model):
+    """Return DSpark's physical-to-registered name mapping, when available.
+
+    The DSpark checkpoint uses ``mtp.{stage}.*`` while the live draft module
+    registers those parameters below ``model.layers.{stage}.*`` (with a few
+    model-level heads).  The model's own ``_remap_dspark_name`` is the
+    authoritative mapping and is intentionally reused instead of duplicated
+    here.  ``None`` from that method means the stock loader owns or drops the
+    tensor; preserving the original name makes the Gridbook wrapper inert for
+    those cases and lets delegation retain DSpark's exact semantics.
+
+    Detection is structural rather than tied to a vLLM version or class name:
+    a callable ``_remap_dspark_name`` is the complete capability contract.
+    """
+    remap = getattr(model, "_remap_dspark_name", None)
+    if not callable(remap):
+        return None
+
+    def rename(name: str) -> str:
+        if not name.startswith("mtp."):
+            return name
+        mapped = remap(name)
+        return name if mapped is None else mapped
+
+    return rename
+
+
+def _validate_dspark_target_bridge_model(model) -> None:
+    """Match a declared bridge topology to the instantiated DSpark model.
+
+    Config validation proves the map is internally consistent; this load-time
+    gate proves its producer-stamped ``L``/``n`` are the topology the selected
+    runtime actually constructed.  It runs before the checkpoint generator is
+    consumed, so a mismatch cannot leave a partially populated draft.
+    """
+    quant_config = getattr(model, "quant_config", None)
+    expected = getattr(
+        quant_config, "_dspark_target_bridge_topology", None
+    )
+    if expected is None:
+        return
+    if not callable(getattr(model, "_remap_dspark_name", None)):
+        raise RuntimeError(
+            "dspark_target_bridge was declared for a model without callable "
+            "_remap_dspark_name"
+        )
+    config = getattr(model, "config", None)
+    inner = getattr(model, "model", None)
+    live_hidden = getattr(config, "num_hidden_layers", None)
+    live_mtp = getattr(inner, "num_dspark_layers", None)
+    if (isinstance(live_hidden, bool) or not isinstance(live_hidden, int)
+            or isinstance(live_mtp, bool) or not isinstance(live_mtp, int)):
+        raise RuntimeError(
+            "dspark_target_bridge requires instantiated model topology "
+            "config.num_hidden_layers and model.num_dspark_layers"
+        )
+    live = (live_hidden, live_mtp)
+    if tuple(expected) != live:
+        raise RuntimeError(
+            f"dspark_target_bridge topology {tuple(expected)} does not match "
+            f"the instantiated DSpark model topology {live}"
+        )
+
+
 def _hf_mapper_rename(model):
     """A ``checkpoint name -> vLLM module-tree name`` callable built from the
     model's OWN ``hf_to_vllm_mapper`` (a vLLM ``WeightsMapper``), or ``None``
@@ -686,9 +882,21 @@ def _install_mixed_fused_construction_gate(model_cls: type) -> None:
                 "wrapper on this overriding class"
             )
         token = _ACTIVE_MIXED_FUSED_LOADER_ABI.set(loader_abi)
+        dspark_token = None
         try:
+            # A callable remapper is DSpark's structural construction
+            # capability.  No target/body class exposes it, so speculative
+            # configuration alone can never redirect an ordinary Gridbook
+            # checkpoint to the draft's sidecars.
+            if _is_dspark_draft_construction(self):
+                draft_config = _require_dspark_draft_model_config()
+                dspark_token = _ACTIVE_DSPARK_DRAFT_MODEL_CONFIG.set(
+                    draft_config
+                )
             return orig_init(self, *args, **kwargs)
         finally:
+            if dspark_token is not None:
+                _ACTIVE_DSPARK_DRAFT_MODEL_CONFIG.reset(dspark_token)
             _ACTIVE_MIXED_FUSED_LOADER_ABI.reset(token)
 
     init._gridbook_mixed_fused_init_abi = MIXED_FUSED_LOADER_ABI
@@ -720,6 +928,7 @@ def install_toplevel_cb_expert_loader(model_cls: type) -> None:
         return
 
     def load_weights(self, weights):  # noqa: ANN001, ANN202
+        _validate_dspark_target_bridge_model(self)
         # named_parameters() here carries the same module-nesting prefix as the
         # incoming checkpoint names (both ``model.…`` at the top level), so the
         # suffix-rewritten target is a direct key.
@@ -728,14 +937,17 @@ def install_toplevel_cb_expert_loader(model_cls: type) -> None:
         reverse_fusion = _build_reverse_fusion(
             getattr(self, "packed_modules_mapping", None))
         # Spec-layer (MTP) drafters nest a spec layer's block tensors under
-        # ``.mtp_block.``; ``rename`` maps an incoming checkpoint name to the
-        # served param naming before resolution (identity for a body model).
+        # ``.mtp_block.``; DSpark instead maps physical ``mtp.i.*`` tensors to
+        # registered ``model.layers.i.*`` params. ``rename`` reuses each
+        # model's own mapping before Gridbook resolution (identity for a body
+        # model). Delegation below still yields the original checkpoint name.
         # Multimodal wrappers rename the checkpoint prefix
         # (``model.language_model.`` -> ``language_model.model.``) via their own
         # WeightsMapper, which the original loader applies only internally;
         # apply it FIRST so our anchors match the registered param names.
         rename = _compose_renames(_hf_mapper_rename(self),
-                                  _spec_layer_rename(self))
+                                  _spec_layer_rename(self),
+                                  _dspark_rename(self))
         mixed_transactions = _MixedFusedTransactions(params_dict)
         loaded: set[str] = set()
         def _passthrough():

--- a/gridbook/ops.py
+++ b/gridbook/ops.py
@@ -664,10 +664,35 @@ def _fp8_source_linear_forward_fake(x, layer_id):
                        dtype=x.dtype, device=x.device)
 
 
+def _neutralize_moe_padding_sentinel(
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Make vLLM's ``-1`` padded routes inert without a device-to-host read.
+
+    With ``VLLM_MOE_SKIP_PADDING``, vLLM preserves the static token shape and
+    marks every routed slot of a padded token with expert id ``-1``.  Gridbook
+    owns several routed implementations, all behind :func:`cb_moe_forward`;
+    normalizing at that opaque boundary keeps every implementation safe and
+    keeps the pointwise work out of Dynamo's graph.
+
+    Only the documented ``-1`` sentinel is rewritten.  Every other id remains
+    unchanged; validation of generally corrupt router output is a separate
+    contract and is not implied here.  The corresponding weight is set to
+    exact zero (rather than multiplied by a mask, which would preserve NaN),
+    making the padded routed contribution inert.  This does not touch ``x``
+    or the separately scheduled shared-expert path.
+    """
+    padding = topk_ids == -1
+    return (topk_weights.masked_fill(padding, 0),
+            topk_ids.masked_fill(padding, 0))
+
+
 @torch.library.custom_op("prismaquant::cb_moe_forward", mutates_args=())
 def cb_moe_forward(x: torch.Tensor, topk_weights: torch.Tensor,
                    topk_ids: torch.Tensor, layer_id: int) -> torch.Tensor:
     method, layer = _lookup_cb_layer(layer_id)
+    topk_weights, topk_ids = _neutralize_moe_padding_sentinel(
+        topk_weights, topk_ids)
     return method._apply_inline(layer, x, topk_weights, topk_ids)
 
 

--- a/gridbook/runtime_contract.json
+++ b/gridbook/runtime_contract.json
@@ -1,7 +1,8 @@
 {
-  "schema": "gridbook.runtime-contract.v3",
-  "contract_version": 3,
+  "schema": "gridbook.runtime-contract.v4",
+  "contract_version": 4,
   "abi_features": {
+    "dspark_construction_physical_bridge": 1,
     "routed_moe_per_role_codebook_lut": 1,
     "source_fp8_block128_w8a16": 1
   },
@@ -166,7 +167,8 @@
       "vllm.model_executor.models.qwen3_5",
       "vllm.model_executor.models.qwen3_5_mtp",
       "vllm.model_executor.models.lfm2_moe",
-      "vllm.models.deepseek_v4.nvidia.model"
+      "vllm.models.deepseek_v4.nvidia.model",
+      "vllm.models.deepseek_v4.nvidia.dspark"
     ]
   }
 }

--- a/gridbook/runtime_contract.py
+++ b/gridbook/runtime_contract.py
@@ -11,7 +11,7 @@ from importlib.resources import files
 from typing import Any, Mapping
 
 
-RUNTIME_CONTRACT_SCHEMA = "gridbook.runtime-contract.v3"
+RUNTIME_CONTRACT_SCHEMA = "gridbook.runtime-contract.v4"
 _RESOURCE_NAME = "runtime_contract.json"
 
 #: The vLLM package roots a ``top_level_loader_modules`` entry may name. The
@@ -107,14 +107,24 @@ def validate_runtime_contract(contract: Any) -> None:
         _fail("contract.schema", f"must be {RUNTIME_CONTRACT_SCHEMA!r}")
     contract_version = _positive_int(
         root["contract_version"], "contract.contract_version")
-    if contract_version != 3:
-        _fail("contract.contract_version", "must be 3 for this schema")
+    if contract_version != 4:
+        _fail("contract.contract_version", "must be 4 for this schema")
 
     features = _object(root["abi_features"], "contract.abi_features")
     _keys(features, "contract.abi_features", {
+        "dspark_construction_physical_bridge",
         "routed_moe_per_role_codebook_lut",
         "source_fp8_block128_w8a16",
     })
+    dspark_bridge = _positive_int(
+        features["dspark_construction_physical_bridge"],
+        "contract.abi_features.dspark_construction_physical_bridge",
+    )
+    if dspark_bridge != 1:
+        _fail(
+            "contract.abi_features.dspark_construction_physical_bridge",
+            "must be 1",
+        )
     per_role_lut = _positive_int(
         features["routed_moe_per_role_codebook_lut"],
         "contract.abi_features.routed_moe_per_role_codebook_lut",

--- a/scripts/validate_fused_nvfp4_ab.py
+++ b/scripts/validate_fused_nvfp4_ab.py
@@ -1743,53 +1743,89 @@ def _kl_convention(kl_mode: str) -> str:
     raise ValueError(f"unknown KL mode {kl_mode!r}")
 
 
-def _quality_summary(
-    pairs: Sequence[Mapping[str, Any]], *, kl_mode: str = KL_COARSE_TOPK
-) -> dict[str, Any]:
-    arm_targets: dict[str, list[float]] = {arm: [] for arm in ARMS}
-    coverages: dict[str, list[float]] = {arm: [] for arm in ARMS}
-    forward_kl: list[float] = []
-    reverse_kl: list[float] = []
-    target_abs_delta: list[float] = []
-    confident_forward: list[float] = []
-    per_prompt = []
-    for pair in pairs:
-        baseline: PromptScore = pair["scores"]["baseline"]
-        fused: PromptScore = pair["scores"]["fused"]
-        if len(baseline.rows) != len(fused.rows):
-            raise RuntimeError("paired arms returned different prompt-score lengths")
-        prompt_fwd, prompt_rev = [], []
-        for b_row, f_row, b_target, f_target in zip(
-            baseline.rows,
-            fused.rows,
-            baseline.target_logprobs,
-            fused.target_logprobs,
-        ):
-            fwd = _row_kl(b_row, f_row, kl_mode)
-            rev = _row_kl(f_row, b_row, kl_mode)
-            forward_kl.append(fwd)
-            reverse_kl.append(rev)
-            prompt_fwd.append(fwd)
-            prompt_rev.append(rev)
-            target_abs_delta.append(abs(b_target - f_target))
-            if math.exp(max(b_row.logprobs)) > 0.5:
-                confident_forward.append(fwd)
-        for arm, score in (("baseline", baseline), ("fused", fused)):
-            arm_targets[arm].extend(score.target_logprobs)
-            coverages[arm].extend(row.coverage for row in score.rows)
-        per_prompt.append({
-            "prompt_index": pair["prompt_index"],
-            "pair_order": pair["pair_order"],
-            "positions": len(baseline.rows),
-            "baseline_mean_nll": baseline.mean_nll,
-            "fused_mean_nll": fused.mean_nll,
-            "mean_nll_delta_fused_minus_baseline": (
-                fused.mean_nll - baseline.mean_nll
-            ),
-            "baseline_to_fused_kl_mean": statistics.fmean(prompt_fwd),
-            "fused_to_baseline_kl_mean": statistics.fmean(prompt_rev),
-        })
+def _new_quality_accumulator(*, kl_mode: str) -> dict[str, Any]:
+    """Create the scalar-only state consumed by the shared quality scorer.
 
+    Keeping this state public to sibling validation entry points lets a
+    full-vocabulary harness add one paired prompt at a time and release its
+    cardinality-sized rows immediately.  The ordinary path below uses the
+    same API, so incremental and retained scoring cannot drift numerically.
+    """
+
+    if kl_mode not in (KL_COARSE_TOPK, KL_FULL_VOCAB):
+        raise ValueError(f"unknown KL mode {kl_mode!r}")
+    return {
+        "kl_mode": kl_mode,
+        "arm_targets": {arm: [] for arm in ARMS},
+        "coverages": {arm: [] for arm in ARMS},
+        "forward_kl": [],
+        "reverse_kl": [],
+        "target_abs_delta": [],
+        "confident_forward": [],
+        "per_prompt": [],
+    }
+
+
+def _accumulate_quality_pair(
+    accumulator: MutableMapping[str, Any], pair: Mapping[str, Any]
+) -> None:
+    """Score one pair into scalar state without retaining either row set."""
+
+    kl_mode = accumulator["kl_mode"]
+    baseline: PromptScore = pair["scores"]["baseline"]
+    fused: PromptScore = pair["scores"]["fused"]
+    if len(baseline.rows) != len(fused.rows):
+        raise RuntimeError("paired arms returned different prompt-score lengths")
+    if (
+        len(baseline.target_logprobs) != len(baseline.rows)
+        or len(fused.target_logprobs) != len(fused.rows)
+    ):
+        raise RuntimeError("paired arms returned different target-score lengths")
+    prompt_fwd, prompt_rev = [], []
+    for b_row, f_row, b_target, f_target in zip(
+        baseline.rows,
+        fused.rows,
+        baseline.target_logprobs,
+        fused.target_logprobs,
+    ):
+        fwd = _row_kl(b_row, f_row, kl_mode)
+        rev = _row_kl(f_row, b_row, kl_mode)
+        accumulator["forward_kl"].append(fwd)
+        accumulator["reverse_kl"].append(rev)
+        prompt_fwd.append(fwd)
+        prompt_rev.append(rev)
+        accumulator["target_abs_delta"].append(abs(b_target - f_target))
+        if math.exp(max(b_row.logprobs)) > 0.5:
+            accumulator["confident_forward"].append(fwd)
+    for arm, score in (("baseline", baseline), ("fused", fused)):
+        accumulator["arm_targets"][arm].extend(score.target_logprobs)
+        accumulator["coverages"][arm].extend(
+            row.coverage for row in score.rows
+        )
+    accumulator["per_prompt"].append({
+        "prompt_index": pair["prompt_index"],
+        "pair_order": pair["pair_order"],
+        "positions": len(baseline.rows),
+        "baseline_mean_nll": baseline.mean_nll,
+        "fused_mean_nll": fused.mean_nll,
+        "mean_nll_delta_fused_minus_baseline": (
+            fused.mean_nll - baseline.mean_nll
+        ),
+        "baseline_to_fused_kl_mean": statistics.fmean(prompt_fwd),
+        "fused_to_baseline_kl_mean": statistics.fmean(prompt_rev),
+    })
+
+
+def _finish_quality_accumulator(
+    accumulator: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Finalize the same schema returned by :func:`_quality_summary`."""
+
+    kl_mode = accumulator["kl_mode"]
+    arm_targets = accumulator["arm_targets"]
+    coverages = accumulator["coverages"]
+    if any(not arm_targets[arm] for arm in ARMS):
+        raise RuntimeError("quality summary contains no scored targets")
     arm_metrics = {}
     for arm in ARMS:
         mean_nll = -statistics.fmean(arm_targets[arm])
@@ -1807,17 +1843,32 @@ def _quality_summary(
             "mean_nll_fused_minus_baseline": nll_delta,
             "ppl_fused_over_baseline": ppl_ratio,
             "ppl_relative_regression": ppl_ratio - 1.0,
-            "target_logprob_abs_delta": summarize_values(target_abs_delta),
-            "kl_baseline_to_fused": summarize_values(forward_kl),
-            "kl_fused_to_baseline": summarize_values(reverse_kl),
+            "target_logprob_abs_delta": summarize_values(
+                accumulator["target_abs_delta"]
+            ),
+            "kl_baseline_to_fused": summarize_values(
+                accumulator["forward_kl"]
+            ),
+            "kl_fused_to_baseline": summarize_values(
+                accumulator["reverse_kl"]
+            ),
             "kl_baseline_to_fused_confident_positions": summarize_values(
-                confident_forward
+                accumulator["confident_forward"]
             ),
         },
-        "per_prompt": per_prompt,
+        "per_prompt": accumulator["per_prompt"],
         "kl_mode": kl_mode,
         "kl_convention": _kl_convention(kl_mode),
     }
+
+
+def _quality_summary(
+    pairs: Sequence[Mapping[str, Any]], *, kl_mode: str = KL_COARSE_TOPK
+) -> dict[str, Any]:
+    accumulator = _new_quality_accumulator(kl_mode=kl_mode)
+    for pair in pairs:
+        _accumulate_quality_pair(accumulator, pair)
+    return _finish_quality_accumulator(accumulator)
 
 
 def _pairwise_score_summary(

--- a/scripts/validate_moe_gemv_v2_ab.py
+++ b/scripts/validate_moe_gemv_v2_ab.py
@@ -1,0 +1,1409 @@
+#!/usr/bin/env python3
+"""Same-engine DSV4 quality A/B for the alternate FP4-CB decode GEMV.
+
+This is the promotion-quality gate for ``PRISMAQUANT_CB_GEMV=v2`` on the
+exact dsv4flash0731 target artifact.  A fresh eager vLLM process loads the
+candidate once with both the inherited and v2 CUDA modules resident.  The two
+arms then toggle only the load-resolved Python booleans on the 35 target
+FP4-CB MoE layers:
+
+* ``baseline`` dispatches ``cb_moe_gemv_fp4_v2`` (the shipping inherited
+  schedule); and
+* ``fused`` dispatches ``cb_moe_gemv_v2`` (the smem-resident dictionary
+  schedule).
+
+The process-wide environment selector remains pinned to ``v2``.  Changing it
+after load is both unsupported by Gridbook and an invalid A/B: the selector is
+resolved once per process.  The harness instead switches the already-attested
+``layer._cb_use_v2_w13`` and ``layer._cb_use_v2_w2`` booleans, restoring them
+after every request and at shutdown.  Eager execution is mandatory because
+those Python booleans are trace-time constants under graph capture.
+
+The workload is value-closed: the first 16 tokens of every one of the eight
+producer-sealed DSV4 WikiText windows.  Every request therefore reaches the
+grouped decode branch at exactly M=16.  Full-vocabulary prompt logprobs are
+streamed through the established v5 scalar scorer one pair at a time; raw rows
+are released before the next pair.  Two counterbalanced repeats are fixed by
+the script and exact score/row digest repeatability is a core gate.
+
+Example::
+
+    python3 scripts/validate_moe_gemv_v2_ab.py \
+      --model /models/dsv4flash0731 \
+      --prompt-token-ids-json /evidence/dsv4-wikitext-inputs-v1.json \
+      --output /evidence/dsv4-gemv-v2-ab.json \
+      --max-mean-kl 1e-4 \
+      --max-mean-nll-regression 0.00498754 \
+      --max-ppl-relative-regression 0.005
+
+A pass qualifies model-level quality for this teacher-forced decode profile.
+The separate operator gate requires exact BF16 equality on the DSV4 release
+widths; the numeric thresholds here remain fail-closed corruption backstops.
+Served graph throughput, concurrency, long prefill, soak, and memory remain
+separate release gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import re
+import struct
+import sys
+import time
+import traceback
+from collections import Counter
+from collections.abc import Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+
+def _load_persistent_b_helpers() -> Any:
+    path = Path(__file__).with_name("validate_moe_persistent_b_ab.py")
+    module_name = "_gridbook_validate_moe_persistent_b_for_gemv_v2"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"could not load persistent-B validation helpers from {path}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pb = _load_persistent_b_helpers()
+v5 = pb.v5
+validation_common = pb.validation_common
+
+SCHEMA = "gridbook.moe-gemv-v2-ab.v1"
+DSV4_KV_CACHE_DTYPE = "fp8"
+ARMS = v5.ARMS
+ARM_LABELS = {
+    "baseline": "inherited_default_grouped_fp4_v2",
+    "fused": "smem_resident_dictionary_v2",
+}
+
+GEMV_ENV = "PRISMAQUANT_CB_GEMV"
+DECODE_CONTRACT_ENV = "PRISMAQUANT_CB_DECODE_CONTRACT"
+W2_SCHEDULE_ENVS = (
+    "PRISMAQUANT_CB_W2_SCHED",
+    "PRISMAQUANT_CB_W2_ROWS",
+    "PRISMAQUANT_CB_W2_WARPS",
+)
+
+_PROFILE_SAMPLES = 8
+_PROFILE_SEQLEN = 16
+_QUALITY_REPEATS = 2
+_EXPECTED_TOPK = 6
+_EXPECTED_FP4_LAYER_IDS = frozenset({
+    *range(0, 18), 20, 21, *range(23, 33), 37, 38, 40, 41, 42,
+})
+_EXPECTED_FP8_LAYER_IDS = frozenset({18, 19, 22, 33, 34, 35, 36, 39})
+_EXPECTED_K16_LAYER_IDS = frozenset({0, 2})
+_EXPECTED_PREFIX_TENSOR_SHA256 = (
+    "11c40cbfd3819f72f18507f359787f479ff06d30fd6e30f697c3bc4e0b4b99f7"
+)
+_EXPECTED_PREFIX_JSON_SHA256 = (
+    "9ed265d2e7202f2282a225929e55faef2a0f87b4508fe8fca10378de500b8c85"
+)
+
+# Exact dsv4flash0731 target artifact identity.  The shared provenance reader
+# independently hashes every file, including the 112 GB safetensors payload;
+# these constants make the gate compare those observations rather than merely
+# record them.
+_EXPECTED_ARTIFACT = {
+    "config_sha256": (
+        "cf07dd1184989ce21a3aa8a21815feb234bcec6385763ae2fcb2781bde015a89"
+    ),
+    "quant_config_sha256": (
+        "6ecb5ffaca90a9ca3f5095df0d788381f9d3451dcb2c0ec5426ec736b26844ef"
+    ),
+    "codebook_sha256": (
+        "ec893b2e56354d1ce8f8a5f613937a8b60b7cf7d2e08e590e114376cbabecc0c"
+    ),
+    "weight_sha256": (
+        "d347c32304e50aa2e8904593744f1e38f7fa1a4a54aece47ae9b3b3e6c8b5334"
+    ),
+    "weight_bytes": 112_349_037_959,
+    "codebook_relative_path": "cb_codebooks.pqcb",
+}
+_PAIRWISE_QUALITY_GATES = (
+    "max_mean_kl",
+    "max_mean_nll_regression",
+    "max_ppl_relative_regression",
+)
+_LAYER_PREFIX_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.ffn\.experts$")
+
+
+def _decode_profile(
+    windows: Sequence[Sequence[int]],
+) -> tuple[list[list[int]], dict[str, Any]]:
+    if len(windows) != _PROFILE_SAMPLES:
+        raise RuntimeError(
+            f"decode profile requires {_PROFILE_SAMPLES} sealed windows"
+        )
+    prompts = [list(map(int, window[:_PROFILE_SEQLEN])) for window in windows]
+    if any(len(prompt) != _PROFILE_SEQLEN for prompt in prompts):
+        raise RuntimeError("a sealed window is shorter than the decode profile")
+    if len({tuple(prompt) for prompt in prompts}) != len(prompts):
+        raise RuntimeError("decode profile prompts are not content-distinct")
+    flattened = [token for prompt in prompts for token in prompt]
+    tensor_digest = hashlib.sha256(
+        struct.pack(f"<{len(flattened)}q", *flattened)
+    ).hexdigest()
+    json_digest = pb._canonical_sha256(prompts)
+    if tensor_digest != _EXPECTED_PREFIX_TENSOR_SHA256:
+        raise RuntimeError(
+            "derived 8x16 token tensor is not the canonical DSV4 decode profile"
+        )
+    if json_digest != _EXPECTED_PREFIX_JSON_SHA256:
+        raise RuntimeError(
+            "derived 8x16 JSON value digest is not the canonical DSV4 profile"
+        )
+    return prompts, {
+        "schema": "gridbook.dsv4-gemv-v2-prefix-profile.v1",
+        "selection": "first_16_tokens_of_every_sealed_full_kl_window",
+        "n_samples": _PROFILE_SAMPLES,
+        "seqlen": _PROFILE_SEQLEN,
+        "quality_repeats": _QUALITY_REPEATS,
+        "positions_per_repeat": _PROFILE_SAMPLES * (_PROFILE_SEQLEN - 1),
+        "total_scored_positions": (
+            _PROFILE_SAMPLES * (_PROFILE_SEQLEN - 1) * _QUALITY_REPEATS
+        ),
+        "token_ids_tensor_sha256": tensor_digest,
+        "token_ids_json_sha256": json_digest,
+        "prompt_sha256": [
+            hashlib.sha256(
+                struct.pack(f"<{len(prompt)}q", *prompt)
+            ).hexdigest()
+            for prompt in prompts
+        ],
+    }
+
+
+def _fixed_decode_prompt_loader(
+    args: argparse.Namespace, tokenizer: Any
+) -> tuple[list[list[int]], dict[str, Any]]:
+    # The producer-owned loader intentionally requires the complete sealed
+    # 8x512 payload.  Give it that immutable source contract, then derive the
+    # independently digest-pinned 8x16 decode view used by this harness.
+    source_args = SimpleNamespace(**vars(args))
+    source_args.n_samples = pb._CANONICAL_FULL_KL_SELECTION["n_samples"]
+    source_args.seqlen = pb._CANONICAL_FULL_KL_SELECTION["seqlen"]
+    windows, source_record = pb._fixed_prompt_loader(source_args, tokenizer)
+    prompts, profile = _decode_profile(windows)
+    return prompts, {
+        "name": "wikitext",
+        "source": "producer_sealed_token_ids_derived_decode_prefix",
+        "sealed_source": source_record,
+        "decode_profile": profile,
+    }
+
+
+def _artifact_gate(provenance: Mapping[str, Any] | None) -> dict[str, Any]:
+    observed: dict[str, Any] = {}
+    if isinstance(provenance, Mapping):
+        config = provenance.get("config")
+        quant = provenance.get("quant_config")
+        codebook = provenance.get("codebook_file")
+        weights = provenance.get("weight_files")
+        weight = (
+            weights.get("model.safetensors")
+            if isinstance(weights, Mapping)
+            else None
+        )
+        observed = {
+            "config_sha256": (
+                config.get("sha256") if isinstance(config, Mapping) else None
+            ),
+            "quant_config_sha256": (
+                quant.get("sha256") if isinstance(quant, Mapping) else None
+            ),
+            "codebook_sha256": (
+                codebook.get("sha256")
+                if isinstance(codebook, Mapping) else None
+            ),
+            "weight_sha256": (
+                weight.get("sha256") if isinstance(weight, Mapping) else None
+            ),
+            "weight_bytes": (
+                weight.get("bytes") if isinstance(weight, Mapping) else None
+            ),
+            "codebook_relative_path": (
+                codebook.get("relative_path")
+                if isinstance(codebook, Mapping) else None
+            ),
+        }
+    checks = {
+        key: observed.get(key) == expected
+        for key, expected in _EXPECTED_ARTIFACT.items()
+    }
+    return {
+        "expected": dict(_EXPECTED_ARTIFACT),
+        "observed": observed,
+        "checks": checks,
+        "pass": bool(checks) and all(checks.values()),
+    }
+
+
+def _moe_skip_padding_gate(observed: Any) -> dict[str, Any]:
+    """Attest the static routed-token contract of the qualified DSV4 image."""
+
+    return {
+        "expected": True,
+        "observed": observed,
+        "pass": observed is True,
+    }
+
+
+@dataclass(frozen=True)
+class _LayerBinding:
+    layer_id: int
+    layer_index: int
+    prefix: str
+    method: Any
+    layer: Any
+    original_w13: bool
+    original_w2: bool
+    k_bits: int
+    n_sub: int
+    type_size: int
+    hidden_size: int
+    intermediate_size: int
+    role_split: bool
+
+
+class GemvV2ArmController:
+    """Exception-safe switch over the exact loaded target-layer booleans."""
+
+    def __init__(self, *, ops: Any, moe: Any) -> None:
+        bindings: list[_LayerBinding] = []
+        malformed_prefixes: list[str] = []
+        for layer_id in sorted(ops._LAYER_REGISTRY):
+            try:
+                method, layer = ops._lookup_cb_layer(layer_id)
+            except RuntimeError:
+                continue
+            if not isinstance(method, moe.PrismaQuantCBMoEMethod):
+                continue
+            prefix = str(method.prefix)
+            match = _LAYER_PREFIX_RE.search(prefix)
+            if match is None:
+                malformed_prefixes.append(prefix)
+                continue
+            original_w13 = getattr(layer, "_cb_use_v2_w13", None)
+            original_w2 = getattr(layer, "_cb_use_v2_w2", None)
+            if not isinstance(original_w13, bool) or not isinstance(
+                original_w2, bool
+            ):
+                raise RuntimeError(
+                    f"{prefix}: load did not resolve both CB-GEMV booleans"
+                )
+            bindings.append(_LayerBinding(
+                layer_id=int(layer_id),
+                layer_index=int(match.group(1)),
+                prefix=prefix,
+                method=method,
+                layer=layer,
+                original_w13=original_w13,
+                original_w2=original_w2,
+                k_bits=int(method.k),
+                n_sub=int(method.n_sub),
+                type_size=int(method.type_size),
+                hidden_size=int(getattr(layer, "_cb_hidden", -1)),
+                intermediate_size=int(getattr(layer, "_cb_inter", -1)),
+                role_split=bool(getattr(layer, "_cb_role_split", False)),
+            ))
+        prefixes = [binding.prefix for binding in bindings]
+        fp4 = tuple(binding for binding in bindings if bool(binding.method.is_fp4))
+        fp8 = tuple(binding for binding in bindings if not bool(binding.method.is_fp4))
+        self.fp4 = fp4
+        self.fp8 = fp8
+        self._all = (*fp4, *fp8)
+
+        fp4_ids = {binding.layer_index for binding in fp4}
+        fp8_ids = {binding.layer_index for binding in fp8}
+        fp4_records = [self._binding_record(binding) for binding in fp4]
+        fp8_records = [self._binding_record(binding) for binding in fp8]
+        checks = {
+            "no_malformed_moe_prefix": not malformed_prefixes,
+            "unique_prefixes": len(prefixes) == len(set(prefixes)),
+            "unique_layer_indices": len(bindings) == len({
+                binding.layer_index for binding in bindings
+            }),
+            "exact_fp4_layer_ids": fp4_ids == _EXPECTED_FP4_LAYER_IDS,
+            "exact_fp8_layer_ids": fp8_ids == _EXPECTED_FP8_LAYER_IDS,
+            "exact_total_moe_layers": len(bindings) == 43,
+            "all_fp4_two_tier_v2": all(
+                bool(binding.method.is_v2)
+                and binding.n_sub == 2
+                and binding.type_size == 4 * binding.k_bits + 9
+                for binding in fp4
+            ),
+            "exact_fp4_rungs": all(
+                binding.k_bits
+                == (16 if binding.layer_index in _EXPECTED_K16_LAYER_IDS else 18)
+                for binding in fp4
+            ),
+            "all_fp4_shapes": all(
+                binding.hidden_size == 4096
+                and binding.intermediate_size == 2048
+                for binding in fp4
+            ),
+            "all_fp4_v2_selected_at_load": all(
+                binding.original_w13 is True and binding.original_w2 is True
+                for binding in fp4
+            ),
+            "all_fp8_k28_product": all(
+                not bool(binding.method.is_v2)
+                and binding.k_bits == 28
+                and binding.n_sub == 4
+                and binding.type_size == 112
+                for binding in fp8
+            ),
+            "all_fp8_role_split": all(binding.role_split for binding in fp8),
+            "all_fp8_excluded_from_v2": all(
+                binding.original_w13 is False and binding.original_w2 is False
+                for binding in fp8
+            ),
+        }
+        self.inventory_gate = {
+            "expected_fp4_layer_ids": sorted(_EXPECTED_FP4_LAYER_IDS),
+            "observed_fp4_layer_ids": sorted(fp4_ids),
+            "expected_fp8_layer_ids": sorted(_EXPECTED_FP8_LAYER_IDS),
+            "observed_fp8_layer_ids": sorted(fp8_ids),
+            "expected_fp4_stack_booleans": 70,
+            "observed_fp4_stack_booleans": len(fp4) * 2,
+            "expected_fp8_stack_booleans": 16,
+            "observed_fp8_stack_booleans": len(fp8) * 2,
+            "malformed_prefixes": malformed_prefixes,
+            "fp4": fp4_records,
+            "fp8": fp8_records,
+            "checks": checks,
+            "pass": all(checks.values()),
+        }
+        if not self.inventory_gate["pass"]:
+            raise RuntimeError(
+                "loaded DSV4 target CB MoE inventory is not exact: "
+                f"{self.inventory_gate}"
+            )
+
+    @staticmethod
+    def _binding_record(binding: _LayerBinding) -> dict[str, Any]:
+        return {
+            "layer_id": binding.layer_id,
+            "layer_index": binding.layer_index,
+            "prefix": binding.prefix,
+            "is_fp4": bool(binding.method.is_fp4),
+            "is_v2_format": bool(binding.method.is_v2),
+            "k_bits": binding.k_bits,
+            "n_sub": binding.n_sub,
+            "type_size": binding.type_size,
+            "hidden_size": binding.hidden_size,
+            "intermediate_size": binding.intermediate_size,
+            "role_split": binding.role_split,
+            "resolved_w13_v2": binding.original_w13,
+            "resolved_w2_v2": binding.original_w2,
+        }
+
+    @property
+    def fp4_prefixes(self) -> frozenset[str]:
+        return frozenset(binding.prefix for binding in self.fp4)
+
+    @property
+    def fp8_prefixes(self) -> frozenset[str]:
+        return frozenset(binding.prefix for binding in self.fp8)
+
+    @contextmanager
+    def arm(self, arm: str, *, label: str) -> Iterator[dict[str, Any]]:
+        if arm not in ARMS:
+            raise ValueError(f"unknown arm {arm!r}")
+        drift = [
+            binding.prefix
+            for binding in self.fp4
+            if (
+                getattr(binding.layer, "_cb_use_v2_w13", None)
+                is not binding.original_w13
+                or getattr(binding.layer, "_cb_use_v2_w2", None)
+                is not binding.original_w2
+            )
+        ]
+        if drift:
+            raise RuntimeError(
+                f"CB-GEMV selector booleans were not restored before {label}: "
+                f"{drift}"
+            )
+        requested = arm == "fused"
+        for binding in self.fp4:
+            binding.layer._cb_use_v2_w13 = requested
+            binding.layer._cb_use_v2_w2 = requested
+        record = {
+            "label": label,
+            "arm": arm,
+            "arm_label": ARM_LABELS[arm],
+            "expected_v2_stack_booleans": 70 if requested else 0,
+            "observed_v2_stack_booleans": sum(
+                int(getattr(binding.layer, "_cb_use_v2_w13", False))
+                + int(getattr(binding.layer, "_cb_use_v2_w2", False))
+                for binding in self.fp4
+            ),
+            "fp8_stack_booleans_true": sum(
+                int(getattr(binding.layer, "_cb_use_v2_w13", False))
+                + int(getattr(binding.layer, "_cb_use_v2_w2", False))
+                for binding in self.fp8
+            ),
+            "restored_after_request": False,
+        }
+        record["selection_pass"] = bool(
+            record["observed_v2_stack_booleans"]
+            == record["expected_v2_stack_booleans"]
+            and record["fp8_stack_booleans_true"] == 0
+        )
+        if not record["selection_pass"]:
+            self.restore_all()
+            raise RuntimeError(f"CB-GEMV arm switch failed: {record}")
+        try:
+            yield record
+        finally:
+            self.restore_all()
+            record["restored_after_request"] = self.restoration_gate()["pass"]
+            record["pass"] = bool(
+                record["selection_pass"] and record["restored_after_request"]
+            )
+
+    def restore_all(self) -> None:
+        for binding in self.fp4:
+            binding.layer._cb_use_v2_w13 = binding.original_w13
+            binding.layer._cb_use_v2_w2 = binding.original_w2
+
+    def restoration_gate(self) -> dict[str, Any]:
+        violations = []
+        for binding in self._all:
+            for stack, expected in (
+                ("w13", binding.original_w13), ("w2", binding.original_w2)
+            ):
+                observed = getattr(binding.layer, f"_cb_use_v2_{stack}", None)
+                if observed is not expected:
+                    violations.append({
+                        "prefix": binding.prefix,
+                        "stack": stack,
+                        "expected": expected,
+                        "observed": observed,
+                    })
+        return {"violations": violations, "pass": not violations}
+
+
+class GemvDispatchProbe:
+    """Eager-only, request-scoped proof of every layer and CUDA-op route."""
+
+    _OP_ATTRS = {
+        "inherited": "cb_moe_gemv_fp4_v2",
+        "v2": "cb_moe_gemv_v2",
+        "fp8": "cb_moe_gemv_fp8",
+    }
+
+    def __init__(self, *, ops: Any, moe: Any, controller: GemvV2ArmController):
+        self.ops = ops
+        self.moe = moe
+        self.controller = controller
+        self.records: list[dict[str, Any]] = []
+        self.unscoped_calls: list[dict[str, Any]] = []
+        self._active: dict[str, Any] | None = None
+        self._current_layer: dict[str, Any] | None = None
+        self._original_ops = {
+            name: getattr(ops, attr) for name, attr in self._OP_ATTRS.items()
+        }
+        self._original_grouped = moe.PrismaQuantCBMoEMethod._apply_grouped_decode
+        self._installed = False
+
+    def install(self) -> None:
+        if self._installed:
+            raise RuntimeError("GEMV dispatch probe is already installed")
+        for name, attr in self._OP_ATTRS.items():
+            original = self._original_ops[name]
+
+            def wrapper(*args: Any, _name=name, _original=original, **kwargs: Any):
+                self._record_op(_name, args)
+                return _original(*args, **kwargs)
+
+            wrapper.__name__ = f"gridbook_ab_probe_{attr}"
+            setattr(self.ops, attr, wrapper)
+        original_grouped = self._original_grouped
+
+        def grouped_wrapper(
+            method: Any,
+            layer: Any,
+            x: Any,
+            topk_weights: Any,
+            topk_ids: Any,
+            act: Any,
+        ) -> Any:
+            self._record_layer(method, layer, x)
+            if self._current_layer is not None:
+                raise RuntimeError("nested grouped-decode layer probes are forbidden")
+            self._current_layer = {
+                "prefix": str(method.prefix),
+                "is_fp4": bool(method.is_fp4),
+            }
+            try:
+                return original_grouped(
+                    method, layer, x, topk_weights, topk_ids, act
+                )
+            finally:
+                self._current_layer = None
+
+        grouped_wrapper.__name__ = "gridbook_ab_probe_apply_grouped_decode"
+        self.moe.PrismaQuantCBMoEMethod._apply_grouped_decode = grouped_wrapper
+        self._installed = True
+
+    @contextmanager
+    def request(
+        self, *, label: str, arm: str, expected_tokens: int
+    ) -> Iterator[dict[str, Any]]:
+        if not self._installed:
+            raise RuntimeError("GEMV dispatch probe is not installed")
+        if self._active is not None:
+            raise RuntimeError("nested GEMV dispatch probe scopes are forbidden")
+        record = {
+            "label": label,
+            "arm": arm,
+            "arm_label": ARM_LABELS[arm],
+            "expected_tokens": int(expected_tokens),
+            "layer_calls": [],
+            "op_calls": [],
+        }
+        self._active = record
+        try:
+            yield record
+        finally:
+            self._active = None
+            self._finalize_record(record)
+            self.records.append(record)
+
+    def _require_active(self, kind: str) -> dict[str, Any]:
+        if self._active is None:
+            event = {"kind": kind, "reason": "call outside request scope"}
+            self.unscoped_calls.append(event)
+            raise RuntimeError(
+                f"GEMV dispatch probe observed {kind} outside a request scope"
+            )
+        return self._active
+
+    def _record_layer(self, method: Any, layer: Any, x: Any) -> None:
+        record = self._require_active("grouped_decode")
+        record["layer_calls"].append({
+            "prefix": str(method.prefix),
+            "tokens": int(x.shape[0]),
+            "is_fp4": bool(method.is_fp4),
+            "w13_v2": bool(getattr(layer, "_cb_use_v2_w13", False)),
+            "w2_v2": bool(getattr(layer, "_cb_use_v2_w2", False)),
+        })
+
+    def _record_op(self, op: str, args: Sequence[Any]) -> None:
+        record = self._require_active(op)
+        if self._current_layer is None:
+            event = {
+                "kind": op,
+                "reason": "CUDA op outside a grouped-decode layer scope",
+            }
+            self.unscoped_calls.append(event)
+            raise RuntimeError(
+                f"GEMV dispatch probe observed {op} outside a layer scope"
+            )
+        if len(args) < 6:
+            raise RuntimeError(f"{op} probe received a truncated call signature")
+        xq, qw, _cb, _compose_or_scale, pair_expert, _pair_xrow = args[:6]
+        pair_count = int(pair_expert.shape[0])
+        input_rows = int(xq.shape[0])
+        tokens = (
+            pair_count // _EXPECTED_TOPK
+            if pair_count % _EXPECTED_TOPK == 0 else -1
+        )
+        stage = (
+            "w13" if input_rows == tokens
+            else "w2" if input_rows == pair_count
+            else "unknown"
+        )
+        record["op_calls"].append({
+            "op": op,
+            "prefix": self._current_layer["prefix"],
+            "is_fp4": self._current_layer["is_fp4"],
+            "stage": stage,
+            "pair_count": pair_count,
+            "input_rows": input_rows,
+            "tokens": tokens,
+            "output_columns": int(qw.shape[1]),
+        })
+
+    def _finalize_record(self, record: MutableMapping[str, Any]) -> None:
+        violations: list[str] = []
+        expected_tokens = int(record["expected_tokens"])
+        layer_calls = list(record["layer_calls"])
+        op_calls = list(record["op_calls"])
+        prefix_counts = Counter(call["prefix"] for call in layer_calls)
+        expected_prefixes = (
+            self.controller.fp4_prefixes | self.controller.fp8_prefixes
+        )
+        if set(prefix_counts) != expected_prefixes:
+            violations.append("grouped-decode layer prefix set differs")
+        if any(count != 1 for count in prefix_counts.values()):
+            violations.append("a grouped-decode layer ran other than once")
+        if any(call["tokens"] != expected_tokens for call in layer_calls):
+            violations.append("a grouped-decode layer did not receive exact M=16")
+
+        fp4_calls = [call for call in layer_calls if call["is_fp4"]]
+        fp8_calls = [call for call in layer_calls if not call["is_fp4"]]
+        requested = record["arm"] == "fused"
+        if len(fp4_calls) != 35 or len(fp8_calls) != 8:
+            violations.append("request did not traverse exact 35 FP4 + 8 FP8 layers")
+        if any(
+            call["w13_v2"] is not requested or call["w2_v2"] is not requested
+            for call in fp4_calls
+        ):
+            violations.append("an FP4 layer exposed the wrong per-stack selector")
+        if any(call["w13_v2"] or call["w2_v2"] for call in fp8_calls):
+            violations.append("an FP8 layer entered the FP4 v2 selector")
+
+        counts = Counter(call["op"] for call in op_calls)
+        expected_counts = {
+            "inherited": 0 if requested else 70,
+            "v2": 70 if requested else 0,
+            # Exact artifact has per-role FP8 books: gate/up plus w2 per layer.
+            "fp8": 24,
+        }
+        if dict(counts) != {k: v for k, v in expected_counts.items() if v}:
+            violations.append(
+                f"CUDA op counts {dict(counts)} != expected {expected_counts}"
+            )
+        if any(call["tokens"] != expected_tokens for call in op_calls):
+            violations.append("a CUDA op call did not represent exact M=16")
+        if any(call["stage"] == "unknown" for call in op_calls):
+            violations.append("a CUDA op call had an unknown projection stage")
+        fp4_ops = [call for call in op_calls if call["op"] != "fp8"]
+        fp8_ops = [call for call in op_calls if call["op"] == "fp8"]
+        if Counter(call["stage"] for call in fp4_ops) != {"w13": 35, "w2": 35}:
+            violations.append("FP4 dispatch did not contain exact 35 w13 + 35 w2")
+        if Counter(call["stage"] for call in fp8_ops) != {"w13": 16, "w2": 8}:
+            violations.append("FP8 dispatch did not contain exact 16 w13 + 8 w2")
+        for prefix in self.controller.fp4_prefixes:
+            observed = Counter(
+                (call["op"], call["stage"])
+                for call in fp4_ops if call["prefix"] == prefix
+            )
+            selected = "v2" if requested else "inherited"
+            if observed != {(selected, "w13"): 1, (selected, "w2"): 1}:
+                violations.append(
+                    f"{prefix}: per-layer FP4 dispatch {dict(observed)} differs"
+                )
+        for prefix in self.controller.fp8_prefixes:
+            observed = Counter(
+                call["stage"] for call in fp8_ops if call["prefix"] == prefix
+            )
+            if observed != {"w13": 2, "w2": 1}:
+                violations.append(
+                    f"{prefix}: per-layer FP8 dispatch {dict(observed)} differs"
+                )
+
+        record["observed_op_counts"] = dict(counts)
+        record["expected_op_counts"] = expected_counts
+        record["observed_layer_count"] = len(layer_calls)
+        record["expected_layer_count"] = 43
+        record["fp8_signature"] = [
+            {key: call[key] for key in (
+                "prefix", "stage", "pair_count", "input_rows", "tokens",
+                "output_columns",
+            )}
+            for call in fp8_ops
+        ]
+        record["violations"] = violations
+        record["pass"] = not violations
+
+    def restore(self) -> None:
+        if not self._installed:
+            return
+        for name, attr in self._OP_ATTRS.items():
+            setattr(self.ops, attr, self._original_ops[name])
+        self.moe.PrismaQuantCBMoEMethod._apply_grouped_decode = (
+            self._original_grouped
+        )
+        self._installed = False
+
+    def restoration_gate(self) -> dict[str, Any]:
+        checks = {
+            attr: getattr(self.ops, attr) is self._original_ops[name]
+            for name, attr in self._OP_ATTRS.items()
+        }
+        checks["_apply_grouped_decode"] = (
+            self.moe.PrismaQuantCBMoEMethod._apply_grouped_decode
+            is self._original_grouped
+        )
+        return {
+            "checks": checks,
+            "unscoped_calls": list(self.unscoped_calls),
+            "pass": all(checks.values()) and not self.unscoped_calls,
+        }
+
+
+def _assert_measurement_environment() -> None:
+    expected = {
+        GEMV_ENV: "v2",
+        DECODE_CONTRACT_ENV: "v1",
+        **{name: None for name in W2_SCHEDULE_ENVS},
+    }
+    observed = {name: os.environ.get(name) for name in expected}
+    if observed != expected:
+        raise RuntimeError(
+            f"decode measurement environment changed mid-run: {observed}"
+        )
+
+
+def _run_generate(
+    *,
+    llm: Any,
+    sampling: Any,
+    prompt_ids: list[int],
+    arm: str,
+    label: str,
+    controller: GemvV2ArmController,
+    probe: GemvDispatchProbe,
+    synchronize: Any,
+) -> tuple[Any, float, dict[str, Any], dict[str, Any]]:
+    _assert_measurement_environment()
+    with controller.arm(arm, label=label) as selector:
+        with probe.request(
+            label=label, arm=arm, expected_tokens=len(prompt_ids)
+        ) as dispatch:
+            synchronize()
+            started = time.perf_counter()
+            output = llm.generate(
+                [{"prompt_token_ids": prompt_ids}], sampling, use_tqdm=False
+            )[0]
+            synchronize()
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+    if not selector["pass"]:
+        raise RuntimeError(f"selector restore gate failed: {selector}")
+    if not dispatch["pass"]:
+        raise RuntimeError(f"request dispatch gate failed: {dispatch}")
+    return output, elapsed_ms, selector, dispatch
+
+
+def _dispatch_gate(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    failed = [
+        {
+            "label": record["label"],
+            "arm": record["arm"],
+            "violations": list(record.get("violations", ())),
+        }
+        for record in records if not record.get("pass")
+    ]
+    return {
+        "requests": len(records),
+        "failed_requests": failed,
+        "pass": bool(records) and not failed,
+    }
+
+
+def _selector_gate(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    failed = [dict(record) for record in records if not record.get("pass")]
+    return {
+        "measurements": len(records),
+        "failed": failed,
+        "pass": bool(records) and not failed,
+    }
+
+
+def _fp8_dispatch_invariance_gate(
+    pairs: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    mismatches: list[dict[str, Any]] = []
+    for pair in pairs:
+        baseline = pair["dispatch"]["baseline"]["fp8_signature"]
+        fused = pair["dispatch"]["fused"]["fp8_signature"]
+        if baseline != fused:
+            mismatches.append({
+                "source_prompt_index": pair["source_prompt_index"],
+                "repeat_index": pair["repeat_index"],
+                "baseline": baseline,
+                "fused": fused,
+            })
+    return {
+        "paired_requests": len(pairs),
+        "mismatches": mismatches,
+        "pass": bool(pairs) and not mismatches,
+    }
+
+
+def _score_cardinality_gate(
+    pairs: Sequence[Mapping[str, Any]], *, vocab_size: int
+) -> dict[str, Any]:
+    expected_positions = _PROFILE_SEQLEN - 1
+    failures: list[dict[str, Any]] = []
+    observations = 0
+    for pair in pairs:
+        for arm in ARMS:
+            observations += 1
+            score = pair["score_digests"][arm]
+            if (
+                score.get("positions") != expected_positions
+                or score.get("vocab_size") != vocab_size
+                or len(score.get("row_sha256", ())) != expected_positions
+                or not math.isfinite(float(score.get("mean_nll", math.nan)))
+                or not math.isfinite(float(score.get("ppl", math.nan)))
+            ):
+                failures.append({
+                    "source_prompt_index": pair["source_prompt_index"],
+                    "repeat_index": pair["repeat_index"],
+                    "arm": arm,
+                    "score": score,
+                })
+    expected_observations = _PROFILE_SAMPLES * _QUALITY_REPEATS * len(ARMS)
+    return {
+        "expected_positions_per_score": expected_positions,
+        "expected_vocab_size": vocab_size,
+        "expected_score_observations": expected_observations,
+        "observed_score_observations": observations,
+        "failures": failures,
+        "pass": observations == expected_observations and not failures,
+    }
+
+
+def _extension_residency_gate(
+    cuda_ext: Any, bootstrap_extension: Mapping[str, Any]
+) -> dict[str, Any]:
+    main = cuda_ext.get_ext()
+    v2_ext = cuda_ext.get_ext_v2()
+    checks = {
+        "main_extension_resident": main is not None,
+        "v2_extension_resident": v2_ext is not None,
+        "main_inherited_symbol": (
+            main is not None and hasattr(main, "cb_moe_gemv_fp4_v2")
+        ),
+        "main_fp8_symbol": (
+            main is not None and hasattr(main, "cb_moe_gemv_fp8")
+        ),
+        "v2_symbol": v2_ext is not None and hasattr(v2_ext, "cb_gemv_v2"),
+        "v2_preloaded_before_model": bool(
+            bootstrap_extension.get("preloaded_before_model")
+        ),
+    }
+    records: dict[str, Any] = {}
+    for label, module in (("main", main), ("v2", v2_ext)):
+        path_raw = getattr(module, "__file__", None) if module is not None else None
+        if path_raw is not None:
+            path = Path(path_raw).resolve()
+            records[label] = {
+                "path": str(path), **v5._required_file_record(path)
+            }
+    return {"modules": records, "checks": checks, "pass": all(checks.values())}
+
+
+def _augment_provenance(runtime: MutableMapping[str, Any]) -> None:
+    package_root = Path(runtime["gridbook"]["package_root"])
+    additions = {
+        "moe_gemv_select.py": package_root / "moe_gemv_select.py",
+        "cb_gemv.cu": package_root / "csrc" / "cb_gemv.cu",
+        "cb_gemv_v2.cu": package_root / "csrc" / "cb_gemv_v2.cu",
+    }
+    for label, path in additions.items():
+        record = {"path": str(path.resolve()), **v5._required_file_record(path)}
+        runtime["source_files"][label] = record
+        runtime["source_sha256"][label] = record["sha256"]
+    helper_path = Path(pb.__file__).resolve()
+    runtime["harness"]["shared_helpers"]["persistent_b_validation_api"] = {
+        "path": str(helper_path), **v5._required_file_record(helper_path)
+    }
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    if args.kv_cache_dtype != DSV4_KV_CACHE_DTYPE:
+        raise RuntimeError(
+            "CB-GEMV-v2 DSV4 validation requires "
+            f"kv_cache_dtype={DSV4_KV_CACHE_DTYPE!r}, got "
+            f"{args.kv_cache_dtype!r}"
+        )
+    if "vllm" in sys.modules or "gridbook.moe_gemv_select" in sys.modules:
+        raise RuntimeError(
+            "vLLM/Gridbook selector was imported before the harness could pin "
+            f"the same-process contract; launch {Path(__file__).name} fresh"
+        )
+    measured_envs = (GEMV_ENV, DECODE_CONTRACT_ENV, *W2_SCHEDULE_ENVS)
+    inherited = {name: os.environ.get(name) for name in measured_envs}
+    os.environ[v5.VLLM_MP_ENV] = "0"
+    os.environ[GEMV_ENV] = "v2"
+    os.environ[DECODE_CONTRACT_ENV] = "v1"
+    for name in W2_SCHEDULE_ENVS:
+        os.environ.pop(name, None)
+    # These prefill selectors are out of scope and must not allocate an
+    # unrelated experimental route while this decode-only gate loads.
+    os.environ[pb.PERSISTENT_B_ENV] = "0"
+    os.environ[pb.BF16_SM120_ENV] = "0"
+    os.environ[v5.FUSED_MOE_ENV] = ""
+    os.environ.pop(v5.PREFILL_ENV, None)
+    started = time.monotonic()
+
+    bootstrap = validation_common.prepare_validation(
+        args,
+        harness_path=Path(__file__),
+        helpers=v5,
+        extension_none_message=(
+            "CB-GEMV-v2 extension did not build/load; refusing a fallback A/B"
+        ),
+        extension_loader="get_ext_v2",
+        required_symbol="cb_gemv_v2",
+        validation_name="CB-GEMV-v2",
+        prompt_loader=_fixed_decode_prompt_loader,
+    )
+    torch = bootstrap.torch
+    moe = bootstrap.moe
+    runtime = bootstrap.runtime
+    _augment_provenance(runtime)
+    from gridbook import moe_gemv_select, ops
+    from vllm import envs as vllm_envs
+
+    skip_padding_gate = _moe_skip_padding_gate(
+        vllm_envs.VLLM_MOE_SKIP_PADDING
+    )
+    if not skip_padding_gate["pass"]:
+        raise RuntimeError(
+            "exact DSV4 CB-GEMV-v2 validation requires "
+            f"VLLM_MOE_SKIP_PADDING=True: {skip_padding_gate}"
+        )
+
+    model_gate = pb._model_contract_gate(bootstrap.candidate_config, args)
+    raw_config = v5._config_dict(bootstrap.candidate_config)
+    model_gate["checks"]["num_experts_per_tok"] = (
+        raw_config.get("num_experts_per_tok") == _EXPECTED_TOPK
+    )
+    model_gate["expected"]["num_experts_per_tok"] = _EXPECTED_TOPK
+    model_gate["observed"]["num_experts_per_tok"] = raw_config.get(
+        "num_experts_per_tok"
+    )
+    model_gate["pass"] = all(model_gate["checks"].values())
+    if not model_gate["pass"]:
+        raise RuntimeError(f"loaded model is not exact DSV4: {model_gate}")
+    artifact_gate = _artifact_gate(bootstrap.candidate_artifact_provenance)
+    if not artifact_gate["pass"]:
+        raise RuntimeError(
+            f"candidate is not the exact dsv4flash0731 artifact: {artifact_gate}"
+        )
+    if moe_gemv_select.cb_gemv_mode() != "v2":
+        raise RuntimeError("CB-GEMV process selector did not resolve to v2")
+
+    class _LoadProbe:
+        @staticmethod
+        def restore() -> None:
+            return None
+
+    engine = validation_common.load_candidate_engine(
+        bootstrap, args, probe=_LoadProbe(), attest_chunked_prefill=True
+    )
+    chunked_contract = engine.chunked_prefill_contract
+    if chunked_contract is None:
+        raise RuntimeError("chunked-prefill contract attestation did not run")
+    extension_gate = _extension_residency_gate(
+        bootstrap.cuda_ext, bootstrap.extension
+    )
+    if not extension_gate["pass"]:
+        raise RuntimeError(
+            f"matched extension residency could not be proven: {extension_gate}"
+        )
+
+    controller = GemvV2ArmController(ops=ops, moe=moe)
+    probe = GemvDispatchProbe(ops=ops, moe=moe, controller=controller)
+    probe.install()
+    llm = engine.llm
+    synchronize = torch.cuda.synchronize
+    warmup_records: list[dict[str, Any]] = []
+    selectors: list[dict[str, Any]] = []
+    quality_pairs: list[dict[str, Any]] = []
+    accumulator = v5._new_quality_accumulator(kl_mode=v5.KL_FULL_VOCAB)
+
+    try:
+        for warmup_index in range(args.warmup_pairs):
+            prompt_index = warmup_index % len(bootstrap.prompts)
+            for arm in v5.paired_arm_order(warmup_index):
+                output, wall_ms, selector, dispatch = _run_generate(
+                    llm=llm,
+                    sampling=engine.timing_sampling,
+                    prompt_ids=bootstrap.prompts[prompt_index],
+                    arm=arm,
+                    label=f"warmup:{warmup_index}:{prompt_index}:{arm}",
+                    controller=controller,
+                    probe=probe,
+                    synchronize=synchronize,
+                )
+                selectors.append(selector)
+                warmup_records.append({
+                    "warmup_index": warmup_index,
+                    "source_prompt_index": prompt_index,
+                    "arm": arm,
+                    "wall_ms": wall_ms,
+                    "selector": selector,
+                    "dispatch": dispatch,
+                })
+                del output
+
+        for repeat in range(_QUALITY_REPEATS):
+            for prompt_index, prompt_ids in enumerate(bootstrap.prompts):
+                block_index = repeat * len(bootstrap.prompts) + prompt_index
+                order = v5.paired_arm_order(repeat + prompt_index)
+                compact_scores: dict[str, Any] = {}
+                score_digests: dict[str, dict[str, Any]] = {}
+                dispatches: dict[str, dict[str, Any]] = {}
+                selector_pair: dict[str, dict[str, Any]] = {}
+                walls: dict[str, float] = {}
+                for arm in order:
+                    output, wall_ms, selector, dispatch = _run_generate(
+                        llm=llm,
+                        sampling=engine.quality_sampling,
+                        prompt_ids=prompt_ids,
+                        arm=arm,
+                        label=f"quality:{repeat}:{prompt_index}:{arm}",
+                        controller=controller,
+                        probe=probe,
+                        synchronize=synchronize,
+                    )
+                    selectors.append(selector)
+                    selector_pair[arm] = selector
+                    dispatches[arm] = dispatch
+                    walls[arm] = wall_ms
+                    score = pb._compact_full_vocab_score(
+                        output,
+                        prompt_ids,
+                        expected_vocab_size=bootstrap.candidate_vocab_size,
+                    )
+                    compact_scores[arm] = score
+                    score_digests[arm] = score.digest_record()
+                    del output
+                scoring_pair = {
+                    "prompt_index": block_index,
+                    "pair_order": list(order),
+                    "scores": compact_scores,
+                }
+                v5._accumulate_quality_pair(accumulator, scoring_pair)
+                quality_pairs.append({
+                    "prompt_index": block_index,
+                    "block_index": block_index,
+                    "repeat_index": repeat,
+                    "source_prompt_index": prompt_index,
+                    "pair_order": list(order),
+                    "score_digests": score_digests,
+                    "wall_ms": walls,
+                    "selectors": selector_pair,
+                    "dispatch": dispatches,
+                })
+                del scoring_pair, compact_scores, score
+    finally:
+        probe.restore()
+        controller.restore_all()
+
+    quality = v5._finish_quality_accumulator(accumulator)
+    quality["arm_labels"] = dict(ARM_LABELS)
+    all_dispatch = list(probe.records)
+    profile = bootstrap.dataset["decode_profile"]
+    core_gates = {
+        "model_contract": model_gate,
+        "exact_artifact": artifact_gate,
+        "canonical_8x16_workload": {
+            "expected_tensor_sha256": _EXPECTED_PREFIX_TENSOR_SHA256,
+            "observed_tensor_sha256": profile["token_ids_tensor_sha256"],
+            "expected_json_sha256": _EXPECTED_PREFIX_JSON_SHA256,
+            "observed_json_sha256": profile["token_ids_json_sha256"],
+            "pass": (
+                profile["token_ids_tensor_sha256"]
+                == _EXPECTED_PREFIX_TENSOR_SHA256
+                and profile["token_ids_json_sha256"]
+                == _EXPECTED_PREFIX_JSON_SHA256
+                and profile["n_samples"] == _PROFILE_SAMPLES
+                and profile["seqlen"] == _PROFILE_SEQLEN
+            ),
+        },
+        "loaded_layer_inventory": controller.inventory_gate,
+        "vllm_moe_skip_padding_contract": skip_padding_gate,
+        "matched_extension_residency": extension_gate,
+        "same_process_one_engine": {
+            "expected_pid": os.getpid(),
+            "runtime_pid": runtime["pid"],
+            "engine_object_id": id(llm),
+            "model_load_count": 1,
+            "pass": runtime["pid"] == os.getpid(),
+        },
+        "eager_toggle_contract": {
+            "enforce_eager": True,
+            "toggle_attributes": ["_cb_use_v2_w13", "_cb_use_v2_w2"],
+            "environment_selector_remained": os.environ.get(GEMV_ENV),
+            "pass": os.environ.get(GEMV_ENV) == "v2",
+        },
+        "chunked_prefill_execution_contract": (
+            validation_common.chunked_prefill_integrity_gate(chunked_contract)
+        ),
+        "selector_switch_and_per_request_restore": _selector_gate(selectors),
+        "exact_dispatch_and_no_fallback": _dispatch_gate(all_dispatch),
+        "quality_arm_order_counterbalanced": pb._pair_order_gate(quality_pairs),
+        "quality_repeat_digest_determinism": (
+            pb._full_vocab_repeat_determinism_gate(
+                quality_pairs,
+                n_prompts=_PROFILE_SAMPLES,
+                repeats=_QUALITY_REPEATS,
+            )
+        ),
+        "full_vocab_cardinality_and_finiteness": _score_cardinality_gate(
+            quality_pairs, vocab_size=bootstrap.candidate_vocab_size
+        ),
+        "fp8_dispatch_unchanged_between_arms": (
+            _fp8_dispatch_invariance_gate(quality_pairs)
+        ),
+        "controller_final_restore": controller.restoration_gate(),
+        "probe_final_restore_and_scope": probe.restoration_gate(),
+    }
+
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "created_at": v5._utc_now(),
+        "scope": (
+            "exact dsv4flash0731 target decode at M=16; TP=1; one eager "
+            "in-process vLLM engine; inherited vs CB-GEMV-v2 boolean A/B"
+        ),
+        "arm_labels": dict(ARM_LABELS),
+        "comparison_contract": {
+            "weights": "identical packed FP4-CB bytes and resident codebooks",
+            "activations": "identical native group-16 FP4 activation QDQ",
+            "router_and_fp8_layers": "identical and dispatch-attested",
+            "permitted_difference": (
+                "none expected on the exact DSV4 K=2048/4096 "
+                "default-schedule specializations; numeric gates are "
+                "fail-closed corruption backstops"
+            ),
+            "same_contract": True,
+        },
+        "settings": {
+            "model": args.model,
+            "model_resolved": str(bootstrap.candidate_path.resolve()),
+            "quantization": args.quantization,
+            "dtype": args.dtype,
+            "tokenizer_mode": args.tokenizer_mode,
+            "tensor_parallel_size": 1,
+            "enforce_eager": True,
+            "v1_multiprocessing": False,
+            "prefix_caching": False,
+            "vllm_moe_skip_padding": skip_padding_gate["observed"],
+            "max_model_len": args.seqlen + 16,
+            "kv_cache_memory_bytes": args.kv_cache_memory_bytes,
+            "kv_cache_dtype": args.kv_cache_dtype,
+            "gpu_memory_utilization": args.gpu_memory_utilization,
+            "warmup_pairs": args.warmup_pairs,
+            "quality_repeats": _QUALITY_REPEATS,
+            "quality_kl_mode": v5.KL_FULL_VOCAB,
+            "quality_prompt_logprobs_request": -1,
+            "candidate_vocab_size": bootstrap.candidate_vocab_size,
+            "decode_profile": profile,
+            "chunked_prefill_contract": chunked_contract,
+            "seed": args.seed,
+        },
+        "environment_contract": {
+            "inherited_before_sanitization": inherited,
+            "during_model_load_and_measurement": {
+                name: os.environ.get(name) for name in measured_envs
+            },
+            "inherited_w2_schedule_is_unset_default": True,
+            "decode_contract": "v1",
+            "selector": "v2",
+            "measurement_exception": (
+                "only the 70 captured target FP4 stack booleans are scoped; "
+                "the process selector and extension residency never change"
+            ),
+        },
+        "runtime": runtime,
+        "extension": bootstrap.extension,
+        "candidate_artifact_provenance": (
+            bootstrap.candidate_artifact_provenance
+        ),
+        "dataset": bootstrap.dataset,
+        "model_load_seconds": engine.model_load_seconds,
+        "warmup": warmup_records,
+        "quality": quality,
+        "full_vocab_streaming_evidence": {
+            "profile": profile,
+            "pairs": quality_pairs,
+            "storage_contract": (
+                "vLLM FlatLogprobs -> paired float32 rows -> shared v5 "
+                "incremental scorer -> scalar/digest evidence; raw rows "
+                "released before the next pair"
+            ),
+        },
+        "dispatch": {
+            "layer_inventory": controller.inventory_gate,
+            "request_attestations": all_dispatch,
+            "selector_attestations": selectors,
+        },
+        "core_integrity_gates": core_gates,
+        "limitations": [
+            "This gate exercises grouped decode at exactly M=16, not prefill.",
+            "Eager quality evidence does not prove CUDA-graph replay.",
+            "Served speed, concurrency, long prefill, soak, and memory gates remain.",
+        ],
+        "elapsed_seconds": time.monotonic() - started,
+    }
+    configured = v5._configured_gates(args, report)
+    report["configured_promotion_gates"] = configured
+    report["measurement_only"] = bool(args.measurement_only)
+    report["measurement_valid"] = all(
+        bool(gate.get("pass")) for gate in core_gates.values()
+    )
+    report["configured_gates_pass"] = (
+        None
+        if args.measurement_only
+        else all(bool(gate.get("pass")) for gate in configured.values())
+    )
+    present = [
+        name for name in _PAIRWISE_QUALITY_GATES
+        if getattr(args, name) is not None
+    ]
+    missing = [name for name in _PAIRWISE_QUALITY_GATES if name not in present]
+    report["promotion_contract"] = {
+        "exact_full_vocab_pairwise_quality": True,
+        "same_process_without_reload": True,
+        "exact_8x16_two_repeat_profile": True,
+        "required_pairwise_quality_thresholds": list(_PAIRWISE_QUALITY_GATES),
+        "present_pairwise_quality_thresholds": present,
+        "missing_pairwise_quality_thresholds": missing,
+        "served_graph_performance_concurrency_soak_still_required": True,
+        "complete": not missing,
+    }
+    report["promotion_recommendation"] = (
+        "measurement_failed"
+        if not report["measurement_valid"]
+        else "measurement_only_no_promotion_thresholds_configured"
+        if args.measurement_only
+        else "configured_gates_failed"
+        if report["configured_gates_pass"] is False
+        else "screening_only_all_pairwise_thresholds_required"
+        if missing
+        else "quality_candidate_only_requires_served_release_gates"
+    )
+    return report
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prompt-token-ids-json", type=Path, required=True)
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument(
+        "--kv-cache-memory-bytes", type=v5._positive_int, default=268_435_456
+    )
+    parser.add_argument(
+        "--kv-cache-dtype",
+        choices=(DSV4_KV_CACHE_DTYPE,),
+        default=DSV4_KV_CACHE_DTYPE,
+        help="fixed DSV4 sparse-MLA KV-cache dtype",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization", type=v5._unit_interval, default=0.90
+    )
+    parser.add_argument("--warmup-pairs", type=v5._positive_int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--measurement-only", action="store_true")
+    parser.add_argument("--max-mean-kl", type=v5._nonnegative_float)
+    parser.add_argument(
+        "--max-mean-nll-regression", type=v5._nonnegative_float
+    )
+    parser.add_argument(
+        "--max-ppl-relative-regression", type=v5._nonnegative_float
+    )
+    args = parser.parse_args(argv)
+
+    model = Path(args.model).expanduser()
+    if not model.is_dir():
+        parser.error("CB-GEMV-v2 DSV4 validation requires a local --model")
+    # Fixed fields consumed by the shared bootstrap/engine and threshold API.
+    args.revision = None
+    args.allow_downloads = False
+    args.teacher_model = None
+    args.teacher_revision = None
+    args.teacher_dtype = "bfloat16"
+    args.teacher_full_vocab_kl = True
+    args.mode = "moe256"
+    args.n_samples = _PROFILE_SAMPLES
+    args.seqlen = _PROFILE_SEQLEN
+    args.top_k = 129_280
+    args.dtype = "bfloat16"
+    args.quantization = "gridbook"
+    args.tokenizer_mode = "deepseek_v4"
+    args.max_num_batched_tokens = None
+    args.enable_chunked_prefill = None
+    args.dataset_cache_dir = None
+    args.dataset_split = "train"
+    args.wikitext_text = None
+    args.expected_architecture = "DeepseekV4ForCausalLM"
+    args.expected_model_type = "deepseek_v4"
+    args.expected_hidden_layers = 43
+    args.expected_hidden_size = 4096
+    args.expected_moe_intermediate_size = 2048
+    args.expected_routed_experts = 256
+    args.expected_vocab_size = 129_280
+    args.max_teacher_fused_mean_kl = None
+    args.max_teacher_fused_kl_regression = None
+    args.min_timing_speedup = None
+
+    thresholds = [getattr(args, name) for name in _PAIRWISE_QUALITY_GATES]
+    if not any(value is not None for value in thresholds) and not args.measurement_only:
+        parser.error(
+            "no thresholds configured; pass --measurement-only for evidence-only use"
+        )
+    if any(value is not None for value in thresholds) and args.measurement_only:
+        parser.error("--measurement-only cannot be combined with thresholds")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run(args)
+    except Exception as exc:  # noqa: BLE001 - preserve machine-readable failure
+        failure = {
+            "schema": SCHEMA,
+            "created_at": v5._utc_now(),
+            "status": "error",
+            "error": {"type": type(exc).__name__, "message": str(exc)},
+            "traceback": traceback.format_exc(),
+        }
+        v5._atomic_json(args.output, failure)
+        print(json.dumps(failure, indent=2), file=sys.stderr, flush=True)
+        return 1
+    if not report["measurement_valid"] or report["configured_gates_pass"] is False:
+        report["status"] = "gate_failed"
+    elif report["measurement_only"]:
+        report["status"] = "measurement_only"
+    elif not report["promotion_contract"]["complete"]:
+        report["status"] = "screening_only"
+    else:
+        report["status"] = "ok"
+    v5._atomic_json(args.output, report)
+    print(json.dumps({
+        "status": report["status"],
+        "output": str(args.output),
+        "measurement_valid": report["measurement_valid"],
+        "configured_gates_pass": report["configured_gates_pass"],
+        "promotion_contract": report["promotion_contract"],
+        "promotion_recommendation": report["promotion_recommendation"],
+        "quality_delta": report["quality"]["delta"],
+        "layer_inventory": report["dispatch"]["layer_inventory"],
+    }, indent=2), flush=True)
+    return 0 if report["status"] in ("ok", "measurement_only") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_moe_persistent_b_ab.py
+++ b/scripts/validate_moe_persistent_b_ab.py
@@ -1,0 +1,1961 @@
+#!/usr/bin/env python3
+"""Same-engine quality A/B for the persistent-B routed FP4-CB lane.
+
+This is the whole-model quality gate for the opt-in
+``PRISMAQUANT_CB_MOE_PERSISTENT_B`` schedule.  It loads the extension and the
+candidate exactly once with persistent-B resolved for every compatible FP4-CB
+MoE layer, then interleaves two arms over fixed, pre-tokenized WikiText windows:
+
+* ``baseline`` is Gridbook's default exact CB-to-BF16 expansion plus owned
+  grouped-BF16 bridge; and
+* ``fused`` is persistent-B's decode-in-mainloop schedule.
+
+Those report arm names intentionally match ``validate_fused_nvfp4_ab.py`` so
+its established scoring and threshold machinery can be reused without a
+second numerical implementation.  ``arm_labels`` always makes their concrete
+meaning explicit.  Both arms consume the same packed weights and exact native
+group-16 activation QDQ; only the FP32 GEMM reduction order changes.
+
+The model is never reloaded.  The harness keeps the production selector at
+``1`` and temporarily swaps only the already-attested per-layer extension
+handle.  Before every request it clears latest-route telemetry, then requires
+all loaded FP4-CB MoE layers to report the requested symbol and every loaded
+FP8-CB MoE layer to report a served route.  FP8 routes must be byte-for-byte
+identical between each paired request.  Layer counts and the DeepSeek-V4
+architecture contract are machine gates, not log-inspection suggestions.
+
+Target-token NLL/PPL are always exact.  Paired KL is top-K/coarse by default;
+``--full-vocab-kl`` retains the complete sealed 8x512 coarse/NLL stage and
+adds an exact-vocabulary stage over a digest-attested prefix of every window
+(64 tokens by default).  vLLM's flat representation is compacted one arm at a
+time; each pair is scored immediately through the shared v5 accumulator and
+only scalar metrics plus row/score digests survive.  A coarse-only run can
+reject a lane but cannot promote it.  Repeated arms are required and exact
+repeat digests are a core gate.  An optional identity-matched BF16 teacher uses
+the same shared teacher scorer in coarse mode, but is not required for a
+transparent same-contract schedule A/B.
+
+Run this script in a fresh Python process inside the pinned Gridbook/vLLM CUDA
+image.  Example for the exact dsv4flash artifact::
+
+    python3 scripts/validate_moe_persistent_b_ab.py \
+      --model /models/dsv4flash0731 \
+      --prompt-token-ids-json /evidence/dsv4-wikitext-inputs-v1.json \
+      --output /evidence/dsv4-persistent-b-ab.json \
+      --enable-chunked-prefill --max-num-batched-tokens 256 \
+      --top-k 256 --full-vocab-kl \
+      --quality-repeats 2 --timing-repeats 2 \
+      --max-mean-kl 1e-4 --max-mean-nll-regression 0.00498754 \
+      --max-ppl-relative-regression 0.005
+
+A passing report remains candidate evidence; served TTFT/ITL/TPS and memory
+headroom are separate NATIVE-PARITY gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import array
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import struct
+import sys
+import time
+import traceback
+from collections.abc import Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+
+def _load_v5_helpers() -> Any:
+    path = Path(__file__).with_name("validate_fused_nvfp4_ab.py")
+    module_name = "_gridbook_validate_fused_nvfp4_ab_for_persistent_b"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load v5 validation helpers from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+v5 = _load_v5_helpers()
+validation_common = v5.validation_common
+
+SCHEMA = "gridbook.moe-persistent-b-ab.v1"
+ARMS = v5.ARMS
+DSV4_KV_CACHE_DTYPE = "fp8"
+ARM_LABELS = {
+    "baseline": "expand_plus_grouped_bf16_bridge",
+    "fused": "persistent_b_decode_in_mainloop",
+}
+PERSISTENT_B_ENV = "PRISMAQUANT_CB_MOE_PERSISTENT_B"
+PERSISTENT_B_CFG_ENV = "PRISMAQUANT_CB_MOE_PERSISTENT_B_CFG"
+BF16_SM120_ENV = "PRISMAQUANT_CB_BF16_SM120"
+_FULL_KL_SCHEMA = "prismaquant.dsv4_wikitext_inputs/1"
+_MAX_INPUT_BYTES = 1_048_576
+_SHA256_CHARS = frozenset("0123456789abcdef")
+# Closed release workload copied from PrismaQuant's producer-owned
+# ``tools/dsv4_wikitext_inputs.py``. The self-digest in the JSON protects a
+# payload against accidental damage; these constants protect the gate against
+# an operator re-sealing a different, easier corpus under the same schema.
+_CANONICAL_INPUT_SEMANTIC_SHA256 = (
+    "3eedb1a879e8e9cf13a2a0f16d3fd01a0817d18de60a2dd743c9c4fc44a34680"
+)
+_CANONICAL_DATASETS_DISTRIBUTION = {
+    "name": "datasets",
+    "version": "4.6.0",
+}
+_CANONICAL_CORPUS_CONSTRUCTION = {
+    "row_filter": "include iff bool(text.strip()); preserve text verbatim",
+    "join_separator": "\n\n",
+    "normalization": "none",
+}
+_CANONICAL_TOKENIZER_CONTENT_SHA256 = (
+    "9f7ee7cb93b58bf30f278965547e7584b89c848e76c3adfeb92c070a88492de0"
+)
+_CANONICAL_TOKENIZER_VOCAB_SIZE = 129_280
+_CANONICAL_WIKITEXT_REVISION = "b08601e04326c79dfdd32d625aee71d232d685c3"
+_CANONICAL_FULL_KL_DATASET = {
+    "name": "wikitext",
+    "config": "wikitext-2-raw-v1",
+    "split": "train",
+    "revision": _CANONICAL_WIKITEXT_REVISION,
+    "fingerprint": "7c4dea6941cc4a0a",
+    "corpus_sha256": (
+        "fb23ad9643a34514eec5cb85ec2a6f49d1a33e6a3d5077dff5a403e1d18f5047"
+    ),
+    "total_tokens": 2_423_186,
+}
+_CANONICAL_FULL_KL_SELECTION = {
+    "sampler": (
+        "python.random.Random(seed).sample(range(max_start), n_samples)/v1"
+    ),
+    "window_seed": 42,
+    "n_samples": 8,
+    "seqlen": 512,
+    "starts": [
+        466_956,
+        104_902,
+        1_153_556,
+        1_027_150,
+        936_213,
+        585_264,
+        429_895,
+        2_287_433,
+    ],
+}
+_CANONICAL_FULL_KL_TOKEN_IDS_TENSOR_SHA256 = (
+    "b3426e9bab87a1c444b04d0ce01fa9cba5ace313b91db2c3f77fc3525e732b22"
+)
+_CANONICAL_PPL_DATASET = {
+    "name": "wikitext",
+    "config": "wikitext-2-raw-v1",
+    "split": "test",
+    "revision": _CANONICAL_WIKITEXT_REVISION,
+    "fingerprint": "7ccd6deaa4fc56e5",
+    "corpus_sha256": (
+        "c5b5caea5bd655cb221545a484f2f0f59d35092a17a66840d7b9513d0b99687d"
+    ),
+    "total_tokens": 287_597,
+}
+_CANONICAL_PPL_SELECTION = {
+    "strategy": "contiguous_prefix_after_full_corpus_tokenization/v1",
+    "n_tokens": 8_192,
+}
+_CANONICAL_PPL_TOKEN_IDS_SHA256 = (
+    "6c23cefbd78c327d6edac566a5c6b419871021b6cf9890ec830713c1de704961"
+)
+_PAIRWISE_QUALITY_GATES = (
+    "max_mean_kl",
+    "max_mean_nll_regression",
+    "max_ppl_relative_regression",
+)
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _strict_json(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    source = path.expanduser().resolve(strict=True)
+    size = source.stat().st_size
+    if not 0 < size <= _MAX_INPUT_BYTES:
+        raise RuntimeError(
+            f"fixed prompt payload must be 1..{_MAX_INPUT_BYTES} bytes, got {size}"
+        )
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-JSON constant {value}")
+
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON member {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        payload = json.loads(
+            source.read_text(encoding="utf-8"),
+            parse_constant=reject_constant,
+            object_pairs_hook=reject_duplicates,
+        )
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"invalid fixed prompt payload {source}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("fixed prompt payload must contain a JSON object")
+    return payload, {
+        "path": str(source),
+        "bytes": size,
+        "sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+    }
+
+
+def _valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and set(value).issubset(_SHA256_CHARS)
+    )
+
+
+def _fixed_prompt_loader(
+    args: argparse.Namespace, tokenizer: Any
+) -> tuple[list[list[int]], dict[str, Any]]:
+    """Read and attest the producer-sealed DSV4 full-KL token windows."""
+
+    payload, file_record = _strict_json(args.prompt_token_ids_json)
+    expected_top = {
+        "schema", "datasets_distribution", "corpus_construction",
+        "tokenizer", "full_kl", "ppl", "semantic_sha256",
+    }
+    if set(payload) != expected_top or payload.get("schema") != _FULL_KL_SCHEMA:
+        raise RuntimeError(
+            f"fixed prompt payload must be closed schema {_FULL_KL_SCHEMA!r}"
+        )
+    unsigned = {key: value for key, value in payload.items()
+                if key != "semantic_sha256"}
+    if (
+        not _valid_sha256(payload.get("semantic_sha256"))
+        or payload["semantic_sha256"] != _canonical_sha256(unsigned)
+    ):
+        raise RuntimeError("fixed prompt payload semantic digest differs")
+    if payload["semantic_sha256"] != _CANONICAL_INPUT_SEMANTIC_SHA256:
+        raise RuntimeError(
+            "fixed prompt payload is not the canonical DSV4 WikiText release "
+            "workload"
+        )
+    if payload.get("datasets_distribution") != _CANONICAL_DATASETS_DISTRIBUTION:
+        raise RuntimeError("fixed prompt datasets producer identity differs")
+    if payload.get("corpus_construction") != _CANONICAL_CORPUS_CONSTRUCTION:
+        raise RuntimeError("fixed prompt corpus construction differs")
+
+    tokenizer_record = payload.get("tokenizer")
+    if (
+        not isinstance(tokenizer_record, Mapping)
+        or set(tokenizer_record) != {"schema", "content_sha256", "files"}
+        or tokenizer_record.get("schema") != "prismaquant.tokenizer_identity/1"
+        or not isinstance(tokenizer_record.get("files"), Mapping)
+        or not tokenizer_record["files"]
+    ):
+        raise RuntimeError("fixed prompt tokenizer identity is malformed")
+    files = dict(tokenizer_record["files"])
+    if tokenizer_record.get("content_sha256") != _canonical_sha256({"files": files}):
+        raise RuntimeError("fixed prompt tokenizer content digest differs")
+    if (
+        tokenizer_record.get("content_sha256")
+        != _CANONICAL_TOKENIZER_CONTENT_SHA256
+    ):
+        raise RuntimeError("fixed prompt tokenizer value identity differs")
+    model_root = Path(args.model).expanduser()
+    if not model_root.is_dir():
+        raise RuntimeError(
+            "fixed DSV4 token inputs require a local --model so tokenizer "
+            "files can be content-attested"
+        )
+    observed_files: dict[str, dict[str, Any]] = {}
+    for name, descriptor in files.items():
+        if (
+            not isinstance(name, str)
+            or not name
+            or Path(name).name != name
+            or not isinstance(descriptor, Mapping)
+            or set(descriptor) != {"bytes", "sha256"}
+            or isinstance(descriptor.get("bytes"), bool)
+            or not isinstance(descriptor.get("bytes"), int)
+            or int(descriptor["bytes"]) <= 0
+            or not _valid_sha256(descriptor.get("sha256"))
+        ):
+            raise RuntimeError(f"malformed tokenizer descriptor {name!r}")
+        candidate = model_root / name
+        if not candidate.is_file():
+            raise RuntimeError(f"candidate tokenizer file is missing: {candidate}")
+        record = v5._required_file_record(candidate)
+        observed_files[name] = record
+        if record != dict(descriptor):
+            raise RuntimeError(
+                f"candidate tokenizer file differs from fixed inputs: {name}"
+            )
+
+    full_kl = payload.get("full_kl")
+    if (
+        not isinstance(full_kl, Mapping)
+        or set(full_kl) != {
+            "dataset", "selection", "token_ids", "token_ids_tensor_sha256"
+        }
+        or not isinstance(full_kl.get("selection"), Mapping)
+        or not isinstance(full_kl.get("token_ids"), list)
+    ):
+        raise RuntimeError("fixed full-KL prompt section is malformed")
+    selection = dict(full_kl["selection"])
+    if full_kl.get("dataset") != _CANONICAL_FULL_KL_DATASET:
+        raise RuntimeError("fixed full-KL dataset identity differs")
+    if selection != _CANONICAL_FULL_KL_SELECTION:
+        raise RuntimeError("fixed full-KL window selection differs")
+    raw_windows = full_kl["token_ids"]
+    source_samples = selection.get("n_samples")
+    source_seqlen = selection.get("seqlen")
+    if (
+        isinstance(source_samples, bool)
+        or not isinstance(source_samples, int)
+        or isinstance(source_seqlen, bool)
+        or not isinstance(source_seqlen, int)
+        or source_samples <= 0
+        or source_seqlen <= 1
+        or len(raw_windows) != source_samples
+    ):
+        raise RuntimeError("fixed full-KL selection dimensions are malformed")
+    if args.n_samples != source_samples or args.seqlen != source_seqlen:
+        raise RuntimeError(
+            "quality gate requires the complete sealed prompt selection: "
+            f"--n-samples={source_samples} --seqlen={source_seqlen}"
+        )
+    vocab_size = int(len(tokenizer))
+    if vocab_size != _CANONICAL_TOKENIZER_VOCAB_SIZE:
+        raise RuntimeError(
+            "fixed prompt tokenizer vocabulary differs from the canonical "
+            f"DSV4 size {_CANONICAL_TOKENIZER_VOCAB_SIZE}: got {vocab_size}"
+        )
+    windows: list[list[int]] = []
+    flattened: list[int] = []
+    for index, raw in enumerate(raw_windows):
+        if not isinstance(raw, list) or len(raw) != source_seqlen:
+            raise RuntimeError(f"fixed prompt window {index} has wrong length")
+        window: list[int] = []
+        for value in raw:
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or value < 0
+                or value >= vocab_size
+            ):
+                raise RuntimeError(
+                    f"fixed prompt window {index} contains invalid token id"
+                )
+            window.append(int(value))
+        windows.append(window)
+        flattened.extend(window)
+    tensor_bytes = struct.pack(f"<{len(flattened)}q", *flattened)
+    tensor_digest = hashlib.sha256(tensor_bytes).hexdigest()
+    if (
+        not _valid_sha256(full_kl.get("token_ids_tensor_sha256"))
+        or full_kl["token_ids_tensor_sha256"] != tensor_digest
+    ):
+        raise RuntimeError("fixed full-KL token tensor digest differs")
+    if tensor_digest != _CANONICAL_FULL_KL_TOKEN_IDS_TENSOR_SHA256:
+        raise RuntimeError("fixed full-KL token values are not canonical")
+    if len({tuple(window) for window in windows}) != len(windows):
+        raise RuntimeError("fixed prompt windows are not content-distinct")
+
+    # The harness scores the full-KL windows, not the PPL prefix, but the one
+    # canonical payload binds both release workloads. Validate the unused half
+    # too so a report cannot cite the canonical semantic identity while carrying
+    # substituted corpus metadata or token values elsewhere in the record.
+    ppl = payload.get("ppl")
+    if (
+        not isinstance(ppl, Mapping)
+        or set(ppl) != {"dataset", "selection", "token_ids", "token_ids_sha256"}
+        or ppl.get("dataset") != _CANONICAL_PPL_DATASET
+        or ppl.get("selection") != _CANONICAL_PPL_SELECTION
+        or not isinstance(ppl.get("token_ids"), list)
+        or len(ppl["token_ids"]) != _CANONICAL_PPL_SELECTION["n_tokens"]
+    ):
+        raise RuntimeError("fixed PPL corpus selection identity differs")
+    ppl_ids: list[int] = []
+    for value in ppl["token_ids"]:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < 0
+            or value >= vocab_size
+        ):
+            raise RuntimeError("fixed PPL token prefix contains invalid token id")
+        ppl_ids.append(int(value))
+    ppl_digest = _canonical_sha256(ppl_ids)
+    if (
+        not _valid_sha256(ppl.get("token_ids_sha256"))
+        or ppl["token_ids_sha256"] != ppl_digest
+        or ppl_digest != _CANONICAL_PPL_TOKEN_IDS_SHA256
+    ):
+        raise RuntimeError("fixed PPL token values are not canonical")
+    return windows, {
+        "name": "wikitext",
+        "source": "producer_sealed_token_ids",
+        "input_file": file_record,
+        "semantic_sha256": payload["semantic_sha256"],
+        "datasets_distribution": payload["datasets_distribution"],
+        "corpus_construction": payload["corpus_construction"],
+        "dataset": full_kl["dataset"],
+        "selection": selection,
+        "tokenizer": {
+            "content_sha256": tokenizer_record["content_sha256"],
+            "files": observed_files,
+            "runtime_vocab_size": vocab_size,
+        },
+        "prompt_token_ids_tensor_sha256": tensor_digest,
+        "prompt_window_sha256": [
+            hashlib.sha256(_canonical_json_bytes(window)).hexdigest()
+            for window in windows
+        ],
+    }
+
+
+@dataclass(frozen=True)
+class _LayerBinding:
+    layer_id: int
+    prefix: str
+    method: Any
+    layer: Any
+    persistent_handle: Any | None
+    persistent_cfg: int | None
+
+
+_FULL_VOCAB_TOKEN_IDS: dict[int, tuple[int, ...]] = {}
+
+
+def _full_vocab_token_ids(vocab_size: int) -> tuple[int, ...]:
+    token_ids = _FULL_VOCAB_TOKEN_IDS.get(vocab_size)
+    if token_ids is None:
+        token_ids = tuple(range(vocab_size))
+        _FULL_VOCAB_TOKEN_IDS[vocab_size] = token_ids
+    return token_ids
+
+
+class _CompactFullVocabRows(Sequence[Any]):
+    """Lazy ``TopKRow`` view over packed float32 full-vocabulary rows."""
+
+    def __init__(self, values: array.array, *, rows: int, vocab_size: int):
+        if values.typecode != "f":
+            raise TypeError("compact full-vocabulary values must be float32")
+        if len(values) != rows * vocab_size:
+            raise ValueError("compact full-vocabulary row storage is truncated")
+        self._values = values
+        self._rows = int(rows)
+        self._vocab_size = int(vocab_size)
+        self._token_ids = _full_vocab_token_ids(vocab_size)
+
+    def __len__(self) -> int:
+        return self._rows
+
+    def __getitem__(self, index: int | slice) -> Any:
+        if isinstance(index, slice):
+            return tuple(self[position] for position in range(*index.indices(
+                self._rows
+            )))
+        if index < 0:
+            index += self._rows
+        if not 0 <= index < self._rows:
+            raise IndexError(index)
+        start = index * self._vocab_size
+        end = start + self._vocab_size
+        return v5.TopKRow(
+            token_ids=self._token_ids,
+            logprobs=tuple(self._values[start:end]),
+        )
+
+    def __iter__(self) -> Iterator[Any]:
+        for index in range(self._rows):
+            yield self[index]
+
+
+@dataclass(frozen=True)
+class _CompactFullVocabScore:
+    """One exact score in float32 rows plus stable evidence digests."""
+
+    target_logprobs: tuple[float, ...]
+    _row_values: array.array
+    vocab_size: int
+    prompt_token_ids_sha256: str
+    row_sha256: tuple[str, ...]
+    score_sha256: str
+
+    @property
+    def rows(self) -> _CompactFullVocabRows:
+        return _CompactFullVocabRows(
+            self._row_values,
+            rows=len(self.target_logprobs),
+            vocab_size=self.vocab_size,
+        )
+
+    @property
+    def mean_nll(self) -> float:
+        return -v5.statistics.fmean(self.target_logprobs)
+
+    @property
+    def ppl(self) -> float:
+        return math.exp(self.mean_nll)
+
+    def digest_record(self) -> dict[str, Any]:
+        return {
+            "schema": "gridbook.compact-full-vocab-score.v1",
+            "positions": len(self.target_logprobs),
+            "vocab_size": self.vocab_size,
+            "float_storage": "little_endian_ieee754_float32",
+            "row_storage_bytes": len(self._row_values) * self._row_values.itemsize,
+            "prompt_token_ids_sha256": self.prompt_token_ids_sha256,
+            "row_sha256": list(self.row_sha256),
+            "score_sha256": self.score_sha256,
+            "mean_nll": self.mean_nll,
+            "ppl": self.ppl,
+        }
+
+
+def _compact_full_vocab_score(
+    output: Any,
+    prompt_ids: Sequence[int],
+    *,
+    expected_vocab_size: int,
+) -> _CompactFullVocabScore:
+    """Cardinality-check one flat vLLM result into compact row storage.
+
+    A single full-vocabulary request is already large.  Requiring vLLM's
+    primitive ``FlatLogprobs`` representation prevents the much larger
+    list-of-dictionaries object graph.  Read its primitive lists directly:
+    integer ``__getitem__`` on vLLM's compatibility Sequence would otherwise
+    recreate one ``Logprob`` plus one dictionary entry for every vocabulary
+    cell.  The direct path deliberately preserves that mapping view's
+    last-value-wins duplicate semantics before applying the established v5
+    cardinality and finite-value rules.
+    """
+
+    if sys.byteorder != "little":
+        raise RuntimeError("compact full-vocabulary evidence requires little endian")
+    returned = getattr(output, "prompt_token_ids", None)
+    try:
+        returned_ids = [int(token) for token in returned]
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("vLLM returned invalid prompt_token_ids") from exc
+    expected_ids = [int(token) for token in prompt_ids]
+    if returned_ids != expected_ids:
+        raise RuntimeError("vLLM returned different prompt_token_ids")
+    prompt_logprobs = getattr(output, "prompt_logprobs", None)
+    if prompt_logprobs is None or len(prompt_logprobs) != len(expected_ids):
+        raise RuntimeError("vLLM returned the wrong prompt_logprobs length")
+    flat_fields = (
+        "start_indices", "end_indices", "token_ids", "logprobs", "ranks",
+        "decoded_tokens",
+    )
+    if not all(hasattr(prompt_logprobs, name) for name in flat_fields):
+        raise RuntimeError(
+            "full-vocabulary scoring requires vLLM FlatLogprobs; refusing "
+            "the cardinality-sized list[dict] representation"
+        )
+
+    flat = {name: getattr(prompt_logprobs, name) for name in flat_fields}
+    if not all(isinstance(flat[name], list) for name in flat_fields):
+        raise RuntimeError(
+            "vLLM FlatLogprobs fields must use the pinned primitive-list "
+            "layout"
+        )
+    starts = flat["start_indices"]
+    ends = flat["end_indices"]
+    token_ids = flat["token_ids"]
+    logprobs = flat["logprobs"]
+    if len(starts) != len(expected_ids) or len(ends) != len(expected_ids):
+        raise RuntimeError(
+            "vLLM FlatLogprobs span count does not match prompt length"
+        )
+    flat_length = len(token_ids)
+    for name in ("logprobs", "ranks", "decoded_tokens"):
+        if len(flat[name]) != flat_length:
+            raise RuntimeError(
+                "vLLM FlatLogprobs primitive fields have different lengths"
+            )
+    if starts and starts[0] != ends[0]:
+        raise RuntimeError(
+            "vLLM FlatLogprobs position zero must have an empty span"
+        )
+    previous_end = 0
+    for position, (start, end) in enumerate(zip(starts, ends)):
+        if type(start) is not int or type(end) is not int:
+            raise RuntimeError("vLLM FlatLogprobs spans must be Python ints")
+        if start != previous_end:
+            raise RuntimeError(
+                "vLLM FlatLogprobs spans are not contiguous at position "
+                f"{position}"
+            )
+        if not 0 <= start <= end <= flat_length:
+            raise RuntimeError(
+                "vLLM FlatLogprobs span is out of bounds at position "
+                f"{position}: [{start},{end}) for flat_length={flat_length}"
+            )
+        previous_end = end
+    if previous_end != flat_length:
+        raise RuntimeError("vLLM FlatLogprobs has unreferenced trailing cells")
+
+    prompt_bytes = struct.pack(f"<{len(expected_ids)}q", *expected_ids)
+    prompt_digest = hashlib.sha256(prompt_bytes).hexdigest()
+    score_digest = hashlib.sha256()
+    score_digest.update(b"gridbook.compact-full-vocab-score.v1\0")
+    score_digest.update(struct.pack("<II", len(expected_ids) - 1,
+                                    expected_vocab_size))
+    score_digest.update(bytes.fromhex(prompt_digest))
+    row_values = array.array("f")
+    targets: list[float] = []
+    row_digests: list[str] = []
+    for position in range(1, len(expected_ids)):
+        start = starts[position]
+        end = ends[position]
+        expected_target = expected_ids[position]
+
+        # FlatLogprobs.__getitem__ builds a dict comprehension.  A full-vocab
+        # row normally contains the requested target first and again inside
+        # topk(V), so the later value is authoritative.  Reverse lookup keeps
+        # that last-value-wins behavior and, like the legacy path, validates
+        # the target before any row-cardinality error.
+        target = None
+        for flat_index in range(end - 1, start - 1, -1):
+            raw_token = token_ids[flat_index]
+            if type(raw_token) is not int:
+                continue
+            if raw_token == expected_target:
+                target = v5._entry_logprob(logprobs[flat_index])
+                break
+        if target is None:
+            raise KeyError(expected_target)
+
+        # Retain only the final primitive value for each canonical token while
+        # remembering first-insertion order.  That order matters for the
+        # legacy helper's failure precedence (finite value vs out-of-range),
+        # even though successful rows are always packed in token-id order.
+        retained: list[Any | None] = [None] * expected_vocab_size
+        seen = bytearray(expected_vocab_size)
+        first_order: list[int] = []
+        observed = 0
+        for flat_index in range(start, end):
+            raw_token = token_ids[flat_index]
+            if type(raw_token) is not int:
+                raise RuntimeError(
+                    "vLLM FlatLogprobs token_ids must contain Python ints"
+                )
+            if raw_token < 0 or raw_token >= expected_vocab_size:
+                # Invalid ids have no destination slot.  Keeping them in the
+                # order stream preserves the legacy negative-skip / positive-
+                # out-of-range behavior without allocating a mapping.
+                first_order.append(raw_token)
+                continue
+            if not seen[raw_token]:
+                seen[raw_token] = 1
+                observed += 1
+                first_order.append(raw_token)
+            retained[raw_token] = logprobs[flat_index]
+
+        for token in first_order:
+            if token < 0:
+                continue
+            if token >= expected_vocab_size:
+                raise RuntimeError(
+                    "vLLM full-vocab row returned out-of-range token id "
+                    f"{token} for vocab_size={expected_vocab_size}"
+                )
+            retained[token] = v5._entry_logprob(retained[token])
+        if observed != expected_vocab_size or any(
+            value is None for value in retained
+        ):
+            raise RuntimeError(
+                "vLLM full-vocab row cardinality mismatch: expected exactly "
+                f"{expected_vocab_size} token ids "
+                f"[0,{expected_vocab_size - 1}], observed {observed}"
+            )
+        packed = array.array("f", retained)
+        if len(packed) != expected_vocab_size:
+            raise RuntimeError("packed full-vocabulary row has wrong cardinality")
+        raw = packed.tobytes()
+        row_digest = hashlib.sha256(raw).hexdigest()
+        row_values.extend(packed)
+        targets.append(target)
+        row_digests.append(row_digest)
+        score_digest.update(struct.pack("<d", target))
+        score_digest.update(bytes.fromhex(row_digest))
+        del retained, seen, first_order, packed, raw
+    if not targets:
+        raise RuntimeError("full-vocabulary quality prompt has no scored tokens")
+    return _CompactFullVocabScore(
+        target_logprobs=tuple(targets),
+        _row_values=row_values,
+        vocab_size=expected_vocab_size,
+        prompt_token_ids_sha256=prompt_digest,
+        row_sha256=tuple(row_digests),
+        score_sha256=score_digest.hexdigest(),
+    )
+
+
+def _full_vocab_profile(
+    prompts: Sequence[Sequence[int]], *, seqlen: int
+) -> tuple[list[list[int]], dict[str, Any]]:
+    if seqlen <= 16:
+        raise RuntimeError("full-vocabulary profile must cross prefill threshold 16")
+    selected = [list(map(int, prompt[:seqlen])) for prompt in prompts]
+    if any(len(prompt) != seqlen for prompt in selected):
+        raise RuntimeError("full-vocabulary profile exceeds sealed prompt length")
+    flattened = [token for prompt in selected for token in prompt]
+    tensor = struct.pack(f"<{len(flattened)}q", *flattened)
+    return selected, {
+        "schema": "gridbook.dsv4-full-vocab-prefix-profile.v1",
+        "selection": "first_n_tokens_of_every_sealed_full_kl_window",
+        "n_samples": len(selected),
+        "seqlen": seqlen,
+        "positions_per_repeat": len(selected) * (seqlen - 1),
+        "token_ids_tensor_sha256": hashlib.sha256(tensor).hexdigest(),
+        "prompt_sha256": [
+            hashlib.sha256(
+                struct.pack(f"<{len(prompt)}q", *prompt)
+            ).hexdigest()
+            for prompt in selected
+        ],
+    }
+
+
+class PersistentBArmController:
+    """Controlled same-process switch over already-resolved layer handles."""
+
+    def __init__(
+        self,
+        *,
+        ops: Any,
+        moe: Any,
+        route_api: Any,
+        expected_fp4: int,
+        expected_fp8: int,
+        expected_cfg: int,
+    ) -> None:
+        self.route_api = route_api
+        self.expected_cfg = int(expected_cfg)
+        bindings: list[_LayerBinding] = []
+        for layer_id in sorted(ops._LAYER_REGISTRY):
+            try:
+                method, layer = ops._lookup_cb_layer(layer_id)
+            except RuntimeError:
+                continue
+            if not isinstance(method, moe.PrismaQuantCBMoEMethod):
+                continue
+            is_fp4 = bool(method.is_fp4)
+            handle = getattr(layer, "_cb_moe_persistent_b", None)
+            cfg = (
+                int(getattr(layer, "_cb_moe_persistent_b_cfg", -1))
+                if handle is not None
+                else None
+            )
+            bindings.append(_LayerBinding(
+                layer_id=int(layer_id),
+                prefix=str(method.prefix),
+                method=method,
+                layer=layer,
+                persistent_handle=handle,
+                persistent_cfg=cfg,
+            ))
+        prefixes = [binding.prefix for binding in bindings]
+        if len(prefixes) != len(set(prefixes)):
+            raise RuntimeError("loaded CB MoE prefixes are not unique")
+        self.fp4 = tuple(binding for binding in bindings
+                         if bool(binding.method.is_fp4))
+        self.fp8 = tuple(binding for binding in bindings
+                         if not bool(binding.method.is_fp4))
+        self.inventory_gate = {
+            "expected_fp4_cb_moe_layers": int(expected_fp4),
+            "observed_fp4_cb_moe_layers": len(self.fp4),
+            "expected_fp8_cb_moe_layers": int(expected_fp8),
+            "observed_fp8_cb_moe_layers": len(self.fp8),
+            "fp4_prefixes": [binding.prefix for binding in self.fp4],
+            "fp8_prefixes": [binding.prefix for binding in self.fp8],
+            "all_fp4_resolved_persistent_b_at_load": all(
+                binding.persistent_handle is not None for binding in self.fp4
+            ),
+            "all_fp4_cfg_match": all(
+                binding.persistent_cfg == self.expected_cfg for binding in self.fp4
+            ),
+            "all_fp8_excluded_from_persistent_b": all(
+                binding.persistent_handle is None for binding in self.fp8
+            ),
+        }
+        self.inventory_gate["pass"] = bool(
+            len(self.fp4) == expected_fp4
+            and len(self.fp8) == expected_fp8
+            and self.inventory_gate[
+                "all_fp4_resolved_persistent_b_at_load"
+            ]
+            and self.inventory_gate["all_fp4_cfg_match"]
+            and self.inventory_gate["all_fp8_excluded_from_persistent_b"]
+        )
+        if not self.inventory_gate["pass"]:
+            raise RuntimeError(
+                "loaded DSV4 CB MoE inventory does not match the requested "
+                f"contract: {self.inventory_gate}"
+            )
+        for binding in self.fp4:
+            if getattr(binding.layer, "_cb_bf16_sm120", None) is not None:
+                raise RuntimeError(
+                    f"{binding.prefix}: sm120 bridge lane is active; baseline "
+                    "must be the default expand+grouped-BF16 bridge"
+                )
+            if getattr(binding.layer, "_cb_fused_fp4_moe_mode", None):
+                raise RuntimeError(
+                    f"{binding.prefix}: fused activation-contract lane is active"
+                )
+
+    def clear_routes(self) -> None:
+        for binding in (*self.fp4, *self.fp8):
+            setattr(binding.layer, "_cb_route_state", None)
+
+    @contextmanager
+    def arm(self, arm: str, *, label: str) -> Iterator[dict[str, Any]]:
+        if arm not in ARMS:
+            raise ValueError(f"unknown arm {arm!r}")
+        before = [
+            getattr(binding.layer, "_cb_moe_persistent_b", None)
+            for binding in self.fp4
+        ]
+        requested = arm == "fused"
+        for binding in self.fp4:
+            binding.layer._cb_moe_persistent_b = (
+                binding.persistent_handle if requested else None
+            )
+        observed = [
+            getattr(binding.layer, "_cb_moe_persistent_b", None)
+            is binding.persistent_handle
+            for binding in self.fp4
+        ]
+        selector = {
+            "label": label,
+            "arm": arm,
+            "arm_label": ARM_LABELS[arm],
+            "expected_handle_present": requested,
+            "observed_handle_present_count": (
+                sum(observed) if requested else len(observed) - sum(observed)
+            ),
+            "expected_layer_count": len(self.fp4),
+            "pass": all(observed) if requested else not any(observed),
+        }
+        if not selector["pass"]:
+            raise RuntimeError(f"persistent-B arm switch failed: {selector}")
+        self.clear_routes()
+        try:
+            yield selector
+        finally:
+            for binding, value in zip(self.fp4, before):
+                binding.layer._cb_moe_persistent_b = value
+
+    def attest_routes(self, arm: str, *, label: str) -> dict[str, Any]:
+        expected = (
+            {
+                "policy": "moe_persistent_b",
+                "symbol": "cb_moe_persistent_b_prefill",
+                "tile_m": self.expected_cfg,
+                "contract": "fp4_group16_rtn",
+                "state": "served",
+                "reason": None,
+            }
+            if arm == "fused"
+            else {
+                "policy": "bf16_grouped_bridge",
+                "symbol": "cb_bf16_grouped_mm_out",
+                "tile_m": 0,
+                "contract": "fp4_group16_rtn",
+                "state": "served",
+                "reason": None,
+            }
+        )
+        fp4_routes: dict[str, Any] = {}
+        fp8_routes: dict[str, Any] = {}
+        violations: list[str] = []
+        for binding in self.fp4:
+            route = self.route_api.read_route(binding.layer)
+            fp4_routes[binding.prefix] = route
+            if route is None:
+                violations.append(f"{binding.prefix}: no current-request route")
+                continue
+            for field, wanted in expected.items():
+                if route.get(field) != wanted:
+                    violations.append(
+                        f"{binding.prefix}: {field}={route.get(field)!r}, "
+                        f"expected {wanted!r}"
+                    )
+            handle_present = (
+                getattr(binding.layer, "_cb_moe_persistent_b", None)
+                is binding.persistent_handle
+            )
+            if handle_present != (arm == "fused"):
+                violations.append(
+                    f"{binding.prefix}: dispatch handle changed during request"
+                )
+        for binding in self.fp8:
+            route = self.route_api.read_route(binding.layer)
+            fp8_routes[binding.prefix] = route
+            if route is None:
+                violations.append(f"{binding.prefix}: no current-request FP8 route")
+            elif route.get("state") != "served" or route.get("reason") is not None:
+                violations.append(
+                    f"{binding.prefix}: FP8 route was not served cleanly: {route}"
+                )
+            if getattr(binding.layer, "_cb_moe_persistent_b", None) is not None:
+                violations.append(
+                    f"{binding.prefix}: FP8 layer acquired a persistent-B handle"
+                )
+        return {
+            "label": label,
+            "arm": arm,
+            "arm_label": ARM_LABELS[arm],
+            "expected_fp4_route": expected,
+            "fp4_routes": fp4_routes,
+            "fp8_routes": fp8_routes,
+            "violations": violations,
+            "pass": not violations,
+        }
+
+
+def _run_generate(
+    *,
+    llm: Any,
+    sampling: Any,
+    prompt_ids: list[int],
+    arm: str,
+    label: str,
+    controller: PersistentBArmController,
+    synchronize: Any,
+) -> tuple[Any, float, dict[str, Any], dict[str, Any]]:
+    with controller.arm(arm, label=label) as selector:
+        synchronize()
+        started = time.perf_counter()
+        output = llm.generate(
+            [{"prompt_token_ids": prompt_ids}], sampling, use_tqdm=False
+        )[0]
+        synchronize()
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        routes = controller.attest_routes(arm, label=label)
+    return output, elapsed_ms, selector, routes
+
+
+def _model_contract_gate(
+    config: Any, args: argparse.Namespace
+) -> dict[str, Any]:
+    raw = v5._config_dict(config)
+    observed_architectures = list(raw.get("architectures") or ())
+    checks = {
+        "architecture": (
+            observed_architectures == [args.expected_architecture]
+        ),
+        "model_type": raw.get("model_type") == args.expected_model_type,
+        "num_hidden_layers": (
+            raw.get("num_hidden_layers") == args.expected_hidden_layers
+        ),
+        "hidden_size": raw.get("hidden_size") == args.expected_hidden_size,
+        "moe_intermediate_size": (
+            raw.get("moe_intermediate_size") == args.expected_moe_intermediate_size
+        ),
+        "n_routed_experts": (
+            raw.get("n_routed_experts") == args.expected_routed_experts
+        ),
+        "vocab_size": raw.get("vocab_size") == args.expected_vocab_size,
+    }
+    return {
+        "expected": {
+            "architectures": [args.expected_architecture],
+            "model_type": args.expected_model_type,
+            "num_hidden_layers": args.expected_hidden_layers,
+            "hidden_size": args.expected_hidden_size,
+            "moe_intermediate_size": args.expected_moe_intermediate_size,
+            "n_routed_experts": args.expected_routed_experts,
+            "vocab_size": args.expected_vocab_size,
+        },
+        "observed": {
+            key: raw.get(key) for key in (
+                "architectures", "model_type", "num_hidden_layers",
+                "hidden_size", "moe_intermediate_size", "n_routed_experts",
+                "vocab_size",
+            )
+        },
+        "checks": checks,
+        "pass": all(checks.values()),
+    }
+
+
+def _pair_order_gate(pairs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    counts = {"baseline/fused": 0, "fused/baseline": 0}
+    unexpected: list[list[str]] = []
+    per_prompt: dict[int, dict[str, int]] = {}
+    missing_prompt_identity: list[int] = []
+    for pair_index, pair in enumerate(pairs):
+        key = "/".join(pair["pair_order"])
+        if key in counts:
+            counts[key] += 1
+        else:
+            unexpected.append(list(pair["pair_order"]))
+            continue
+        source_prompt = pair.get("source_prompt_index")
+        if isinstance(source_prompt, bool) or not isinstance(source_prompt, int):
+            missing_prompt_identity.append(pair_index)
+            continue
+        prompt_counts = per_prompt.setdefault(
+            source_prompt, {"baseline/fused": 0, "fused/baseline": 0}
+        )
+        prompt_counts[key] += 1
+    prompts_missing_crossover = [
+        prompt_index
+        for prompt_index, prompt_counts in sorted(per_prompt.items())
+        if not all(prompt_counts.values())
+    ]
+    return {
+        "counts": counts,
+        "unexpected": unexpected,
+        "per_source_prompt": {
+            str(prompt_index): prompt_counts
+            for prompt_index, prompt_counts in sorted(per_prompt.items())
+        },
+        "missing_source_prompt_identity_blocks": missing_prompt_identity,
+        "source_prompts_missing_both_orders": prompts_missing_crossover,
+        "pass": (
+            not unexpected
+            and not missing_prompt_identity
+            and bool(per_prompt)
+            and not prompts_missing_crossover
+            and counts["baseline/fused"] > 0
+            and counts["baseline/fused"] == counts["fused/baseline"]
+        ),
+    }
+
+
+def _repeat_determinism_gate(
+    pairs: Sequence[Mapping[str, Any]], *, n_prompts: int, repeats: int
+) -> dict[str, Any]:
+    mismatches: list[dict[str, Any]] = []
+    for prompt_index in range(n_prompts):
+        prompt_pairs = [
+            pair for pair in pairs if pair["source_prompt_index"] == prompt_index
+        ]
+        if len(prompt_pairs) != repeats:
+            mismatches.append({
+                "prompt_index": prompt_index,
+                "reason": f"observed {len(prompt_pairs)} repeats, expected {repeats}",
+            })
+            continue
+        for arm in ARMS:
+            reference = prompt_pairs[0]["scores"][arm]
+            for repeat_index, pair in enumerate(prompt_pairs[1:], start=1):
+                if pair["scores"][arm] != reference:
+                    mismatches.append({
+                        "prompt_index": prompt_index,
+                        "arm": arm,
+                        "repeat_index": repeat_index,
+                        "reason": "PromptScore differs from repeat zero",
+                    })
+    return {
+        "required_repeats": repeats,
+        "mismatches": mismatches,
+        "pass": not mismatches,
+    }
+
+
+def _full_vocab_repeat_determinism_gate(
+    pairs: Sequence[Mapping[str, Any]], *, n_prompts: int, repeats: int
+) -> dict[str, Any]:
+    """Compare compact bit digests, never cardinality-sized PromptScores."""
+
+    mismatches: list[dict[str, Any]] = []
+    for prompt_index in range(n_prompts):
+        prompt_pairs = sorted(
+            (
+                pair for pair in pairs
+                if pair["source_prompt_index"] == prompt_index
+            ),
+            key=lambda pair: pair["repeat_index"],
+        )
+        if len(prompt_pairs) != repeats:
+            mismatches.append({
+                "prompt_index": prompt_index,
+                "reason": f"observed {len(prompt_pairs)} repeats, expected {repeats}",
+            })
+            continue
+        for arm in ARMS:
+            reference = prompt_pairs[0]["score_digests"][arm]
+            for pair in prompt_pairs[1:]:
+                observed = pair["score_digests"][arm]
+                if (
+                    observed["score_sha256"] != reference["score_sha256"]
+                    or observed["row_sha256"] != reference["row_sha256"]
+                    or observed["prompt_token_ids_sha256"]
+                    != reference["prompt_token_ids_sha256"]
+                ):
+                    mismatches.append({
+                        "prompt_index": prompt_index,
+                        "arm": arm,
+                        "repeat_index": pair["repeat_index"],
+                        "expected_score_sha256": reference["score_sha256"],
+                        "observed_score_sha256": observed["score_sha256"],
+                        "reason": "full-vocabulary score/row digest differs",
+                    })
+    return {
+        "required_repeats": repeats,
+        "digest_schema": "gridbook.compact-full-vocab-score.v1",
+        "comparison": "exact prompt, target-float64, and row-float32 digests",
+        "mismatches": mismatches,
+        "pass": not mismatches,
+    }
+
+
+def _fp8_invariance_gate(
+    pairs: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    mismatches: list[dict[str, Any]] = []
+    for pair in pairs:
+        baseline = pair["routes"]["baseline"]["fp8_routes"]
+        fused = pair["routes"]["fused"]["fp8_routes"]
+        if baseline != fused:
+            mismatches.append({
+                "block_index": pair["block_index"],
+                "source_prompt_index": pair.get("source_prompt_index"),
+                "baseline": baseline,
+                "fused": fused,
+            })
+    return {
+        "paired_blocks": len(pairs),
+        "mismatches": mismatches,
+        "pass": not mismatches,
+    }
+
+
+def _route_gate(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    failed = [
+        {
+            "label": record["label"],
+            "arm": record["arm"],
+            "violations": record["violations"],
+        }
+        for record in records if not record["pass"]
+    ]
+    return {
+        "requests": len(records),
+        "failed_requests": failed,
+        "pass": bool(records) and not failed,
+    }
+
+
+def _selector_gate(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    failed = [dict(record) for record in records if not record["pass"]]
+    return {
+        "measurements": len(records),
+        "failed": failed,
+        "pass": bool(records) and not failed,
+    }
+
+
+def _first_repeat_scores(
+    pairs: Sequence[Mapping[str, Any]], *, n_prompts: int
+) -> dict[str, list[Any]]:
+    result = {arm: [] for arm in ARMS}
+    for prompt_index in range(n_prompts):
+        matches = [
+            pair for pair in pairs
+            if pair["source_prompt_index"] == prompt_index
+            and pair["repeat_index"] == 0
+        ]
+        if len(matches) != 1:
+            raise RuntimeError(
+                f"prompt {prompt_index} has {len(matches)} repeat-zero blocks"
+            )
+        for arm in ARMS:
+            result[arm].append(matches[0]["scores"][arm])
+    return result
+
+
+def _promotion_quality_summary(
+    coarse: Mapping[str, Any],
+    exact: Mapping[str, Any],
+    *,
+    full_vocab_profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bind full-workload NLL/PPL to streamed exact-profile KL.
+
+    Pairwise target logprobs do not depend on how many non-target logprobs are
+    returned.  We nevertheless source NLL/PPL and their regression gates from
+    the complete sealed 8x512 screen, while the KL fields come only from the
+    cardinality-attested exact stage.  Both component reports remain embedded
+    so the metric provenance cannot be mistaken.
+    """
+
+    result = {
+        "arms": dict(coarse["arms"]),
+        "delta": dict(coarse["delta"]),
+        "per_prompt": list(coarse["per_prompt"]),
+        "kl_mode": v5.KL_FULL_VOCAB,
+        "kl_convention": exact["kl_convention"],
+        "metric_sources": {
+            "target_nll_ppl_and_regression": (
+                "coarse_full_sealed_8x512_stage"
+            ),
+            "pairwise_kl": "streamed_exact_full_vocab_profile_stage",
+        },
+        "coarse_full_workload": dict(coarse),
+        "exact_full_vocab_profile": {
+            "profile": dict(full_vocab_profile),
+            "quality": dict(exact),
+        },
+    }
+    for key in (
+        "kl_baseline_to_fused",
+        "kl_fused_to_baseline",
+        "kl_baseline_to_fused_confident_positions",
+    ):
+        result["delta"][key] = exact["delta"][key]
+    return result
+
+
+def _augment_persistent_b_provenance(runtime: MutableMapping[str, Any]) -> None:
+    package_root = Path(runtime["gridbook"]["package_root"])
+    additions = {
+        "moe_persistent_b_lane.py": package_root / "moe_persistent_b_lane.py",
+        "cb_moe_persistent_b.cu": package_root / "csrc" / "cb_moe_persistent_b.cu",
+    }
+    for label, path in additions.items():
+        record = {"path": str(path.resolve()), **v5._required_file_record(path)}
+        runtime["source_files"][label] = record
+        runtime["source_sha256"][label] = record["sha256"]
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    if args.kv_cache_dtype != DSV4_KV_CACHE_DTYPE:
+        raise RuntimeError(
+            "persistent-B DSV4 validation requires "
+            f"kv_cache_dtype={DSV4_KV_CACHE_DTYPE!r}, got "
+            f"{args.kv_cache_dtype!r}"
+        )
+    if "vllm" in sys.modules:
+        raise RuntimeError(
+            "vLLM was imported before the harness could force same-process "
+            f"execution; launch {Path(__file__).name} in a fresh Python process"
+        )
+    inherited = {
+        name: os.environ.get(name) for name in (
+            PERSISTENT_B_ENV, PERSISTENT_B_CFG_ENV, BF16_SM120_ENV,
+            v5.FUSED_ENV, v5.FUSED_MOE_ENV, v5.PREFILL_ENV,
+        )
+    }
+    os.environ[v5.VLLM_MP_ENV] = "0"
+    os.environ[PERSISTENT_B_ENV] = "1"
+    os.environ[PERSISTENT_B_CFG_ENV] = str(args.persistent_b_cfg)
+    os.environ[BF16_SM120_ENV] = "0"
+    os.environ[v5.FUSED_ENV] = ""
+    os.environ[v5.FUSED_MOE_ENV] = ""
+    os.environ.pop(v5.PREFILL_ENV, None)
+    started = time.monotonic()
+    bootstrap = validation_common.prepare_validation(
+        args,
+        harness_path=Path(__file__),
+        helpers=v5,
+        extension_none_message=(
+            "persistent-B extension did not build/load; refusing a fallback A/B"
+        ),
+        extension_loader="get_moe_persistent_b_ext",
+        required_symbol="cb_moe_persistent_b_prefill",
+        validation_name="persistent-B",
+        prompt_loader=_fixed_prompt_loader,
+    )
+    torch = bootstrap.torch
+    moe = bootstrap.moe
+    runtime = bootstrap.runtime
+    _augment_persistent_b_provenance(runtime)
+    from gridbook import nvfp4_activation_contract, ops
+
+    model_gate = _model_contract_gate(bootstrap.candidate_config, args)
+    if not model_gate["pass"]:
+        raise RuntimeError(f"loaded model is not the requested DSV4: {model_gate}")
+
+    class _LoadProbe:
+        @staticmethod
+        def restore() -> None:
+            return None
+
+    engine = validation_common.load_candidate_engine(
+        bootstrap, args, probe=_LoadProbe(), attest_chunked_prefill=True
+    )
+    chunked_contract = engine.chunked_prefill_contract
+    if chunked_contract is None:
+        raise RuntimeError("chunked-prefill contract attestation did not run")
+    controller = PersistentBArmController(
+        ops=ops,
+        moe=moe,
+        route_api=nvfp4_activation_contract,
+        expected_fp4=args.expected_persistent_b_layers,
+        expected_fp8=args.expected_fp8_cb_moe_layers,
+        expected_cfg=args.persistent_b_cfg,
+    )
+
+    coarse_sampling = engine.quality_sampling
+    exact_sampling = None
+    exact_prompts: list[list[int]] = []
+    exact_profile: dict[str, Any] | None = None
+    exact_accumulator: MutableMapping[str, Any] | None = None
+    if args.full_vocab_kl:
+        exact_sampling = engine.quality_sampling
+        coarse_sampling = bootstrap.sampling_params_class(
+            max_tokens=1,
+            temperature=0.0,
+            prompt_logprobs=args.top_k,
+            flat_logprobs=False,
+            detokenize=False,
+        )
+        exact_prompts, exact_profile = _full_vocab_profile(
+            bootstrap.prompts, seqlen=args.full_vocab_seqlen
+        )
+        exact_accumulator = v5._new_quality_accumulator(
+            kl_mode=v5.KL_FULL_VOCAB
+        )
+
+    llm = engine.llm
+    synchronize = torch.cuda.synchronize
+    warmup_records: list[dict[str, Any]] = []
+    selector_records: list[dict[str, Any]] = []
+    route_records: list[dict[str, Any]] = []
+    quality_pairs: list[dict[str, Any]] = []
+    full_vocab_pairs: list[dict[str, Any]] = []
+    timing_pairs: list[dict[str, Any]] = []
+    timing_samples: dict[str, list[float]] = {arm: [] for arm in ARMS}
+
+    for repeat in range(args.warmup_pairs):
+        order = v5.paired_arm_order(repeat)
+        routes: dict[str, Any] = {}
+        for arm in order:
+            output, wall_ms, selector, route = _run_generate(
+                llm=llm,
+                sampling=engine.timing_sampling,
+                prompt_ids=bootstrap.prompts[repeat % len(bootstrap.prompts)],
+                arm=arm,
+                label=f"warmup:{repeat}:{arm}",
+                controller=controller,
+                synchronize=synchronize,
+            )
+            selector_records.append(selector)
+            route_records.append(route)
+            routes[arm] = route
+            warmup_records.append({
+                "repeat_index": repeat,
+                "arm": arm,
+                "wall_ms": wall_ms,
+                "selector": selector,
+                "routes": route,
+            })
+            del output
+
+    for phase in validation_common.measurement_phase_order(args.timing_repeats):
+        if phase == "timing":
+            validation_common.quiesce_before_timing(torch)
+            for repeat in range(args.timing_repeats):
+                for prompt_index, prompt_ids in enumerate(bootstrap.prompts):
+                    block_index = repeat * len(bootstrap.prompts) + prompt_index
+                    # Cross each source prompt over both arm orders across
+                    # repeats. Using block_index here aliases repeat parity when
+                    # n_prompts is even, permanently confounding prompt and
+                    # order despite an aggregate 50/50 count.
+                    order = v5.paired_arm_order(repeat + prompt_index)
+                    routes: dict[str, Any] = {}
+                    walls: dict[str, float] = {}
+                    for arm in order:
+                        output, wall_ms, selector, route = _run_generate(
+                            llm=llm,
+                            sampling=engine.timing_sampling,
+                            prompt_ids=prompt_ids,
+                            arm=arm,
+                            label=f"timing:{repeat}:{prompt_index}:{arm}",
+                            controller=controller,
+                            synchronize=synchronize,
+                        )
+                        selector_records.append(selector)
+                        route_records.append(route)
+                        routes[arm] = route
+                        walls[arm] = wall_ms
+                        timing_samples[arm].append(wall_ms)
+                        del output
+                    timing_pairs.append({
+                        "block_index": block_index,
+                        "repeat_index": repeat,
+                        "source_prompt_index": prompt_index,
+                        "pair_order": list(order),
+                        "wall_ms": walls,
+                        "routes": routes,
+                    })
+            continue
+        if phase != "quality":
+            raise RuntimeError(f"unknown measurement phase {phase!r}")
+        for repeat in range(args.quality_repeats):
+            for prompt_index, prompt_ids in enumerate(bootstrap.prompts):
+                block_index = repeat * len(bootstrap.prompts) + prompt_index
+                order = v5.paired_arm_order(repeat + prompt_index)
+                scores: dict[str, Any] = {}
+                routes: dict[str, Any] = {}
+                walls: dict[str, float] = {}
+                for arm in order:
+                    output, wall_ms, selector, route = _run_generate(
+                        llm=llm,
+                        sampling=coarse_sampling,
+                        prompt_ids=prompt_ids,
+                        arm=arm,
+                        label=f"quality:{repeat}:{prompt_index}:{arm}",
+                        controller=controller,
+                        synchronize=synchronize,
+                    )
+                    selector_records.append(selector)
+                    route_records.append(route)
+                    routes[arm] = route
+                    walls[arm] = wall_ms
+                    scores[arm] = v5.score_prompt_output(
+                        output,
+                        prompt_ids,
+                        args.top_k,
+                        full_vocab=False,
+                        expected_vocab_size=None,
+                    )
+                    del output
+                quality_pairs.append({
+                    "prompt_index": block_index,
+                    "block_index": block_index,
+                    "repeat_index": repeat,
+                    "source_prompt_index": prompt_index,
+                    "pair_order": list(order),
+                    "scores": scores,
+                    "wall_ms": walls,
+                    "routes": routes,
+                })
+
+        if args.full_vocab_kl:
+            assert exact_sampling is not None
+            assert exact_accumulator is not None
+            assert exact_profile is not None
+            for repeat in range(args.quality_repeats):
+                for prompt_index, prompt_ids in enumerate(exact_prompts):
+                    block_index = repeat * len(exact_prompts) + prompt_index
+                    order = v5.paired_arm_order(repeat + prompt_index)
+                    compact_scores: dict[str, _CompactFullVocabScore] = {}
+                    score_digests: dict[str, dict[str, Any]] = {}
+                    routes: dict[str, Any] = {}
+                    walls: dict[str, float] = {}
+                    for arm in order:
+                        output, wall_ms, selector, route = _run_generate(
+                            llm=llm,
+                            sampling=exact_sampling,
+                            prompt_ids=prompt_ids,
+                            arm=arm,
+                            label=(
+                                f"full_vocab:{repeat}:{prompt_index}:{arm}"
+                            ),
+                            controller=controller,
+                            synchronize=synchronize,
+                        )
+                        selector_records.append(selector)
+                        route_records.append(route)
+                        routes[arm] = route
+                        walls[arm] = wall_ms
+                        score = _compact_full_vocab_score(
+                            output,
+                            prompt_ids,
+                            expected_vocab_size=bootstrap.candidate_vocab_size,
+                        )
+                        compact_scores[arm] = score
+                        score_digests[arm] = score.digest_record()
+                        del output
+                    scoring_pair = {
+                        "prompt_index": block_index,
+                        "pair_order": list(order),
+                        "scores": compact_scores,
+                    }
+                    v5._accumulate_quality_pair(
+                        exact_accumulator, scoring_pair
+                    )
+                    full_vocab_pairs.append({
+                        "prompt_index": block_index,
+                        "block_index": block_index,
+                        "repeat_index": repeat,
+                        "source_prompt_index": prompt_index,
+                        "pair_order": list(order),
+                        "score_digests": score_digests,
+                        "wall_ms": walls,
+                        "routes": routes,
+                    })
+                    # The scalar accumulator and digest record now carry every
+                    # value needed by the shared scorer and determinism gate.
+                    # Drop both cardinality-sized float32 arrays before the
+                    # next pair begins.
+                    del scoring_pair, compact_scores, score
+
+    coarse_quality = v5._quality_summary(
+        quality_pairs, kl_mode=v5.KL_COARSE_TOPK
+    )
+    if args.full_vocab_kl:
+        assert exact_accumulator is not None
+        assert exact_profile is not None
+        exact_quality = v5._finish_quality_accumulator(exact_accumulator)
+        quality = _promotion_quality_summary(
+            coarse_quality,
+            exact_quality,
+            full_vocab_profile=exact_profile,
+        )
+    else:
+        exact_quality = None
+        quality = coarse_quality
+    quality["arm_labels"] = dict(ARM_LABELS)
+    teacher_arm_scores = _first_repeat_scores(
+        quality_pairs,
+        n_prompts=len(bootstrap.prompts),
+    )
+    teacher_quality, teacher_record = validation_common.score_teacher(
+        bootstrap,
+        args,
+        arm_scores=teacher_arm_scores,
+        arms=ARMS,
+        helpers=v5,
+    )
+    if teacher_quality is not None:
+        teacher_quality["arm_labels"] = dict(ARM_LABELS)
+        teacher_quality["delta"] = {
+            "teacher_to_persistent_b_mean_kl_minus_bridge": (
+                teacher_quality["fused"]["kl_reference_to_candidate"]["mean"]
+                - teacher_quality["baseline"][
+                    "kl_reference_to_candidate"
+                ]["mean"]
+            ),
+            "kl_mode": bootstrap.quality_kl_mode,
+        }
+
+    all_pairs = [*quality_pairs, *full_vocab_pairs, *timing_pairs]
+    core_gates = {
+        "model_contract": model_gate,
+        "loaded_layer_inventory": controller.inventory_gate,
+        "chunked_prefill_execution_contract": (
+            validation_common.chunked_prefill_integrity_gate(chunked_contract)
+        ),
+        "same_process_execution": {
+            "expected_pid": os.getpid(),
+            "runtime_pid": runtime["pid"],
+            "pass": runtime["pid"] == os.getpid(),
+        },
+        "selector_switch_attested": _selector_gate(selector_records),
+        "route_and_fallback_attested": _route_gate(route_records),
+        "quality_arm_order_counterbalanced": _pair_order_gate(quality_pairs),
+        "quality_repeat_determinism": _repeat_determinism_gate(
+            quality_pairs,
+            n_prompts=len(bootstrap.prompts),
+            repeats=args.quality_repeats,
+        ),
+        "fp8_routes_unchanged_between_arms": _fp8_invariance_gate(all_pairs),
+    }
+    if args.timing_repeats:
+        core_gates["timing_arm_order_counterbalanced"] = _pair_order_gate(
+            timing_pairs
+        )
+    if args.full_vocab_kl:
+        core_gates.update({
+            "full_vocab_arm_order_counterbalanced": _pair_order_gate(
+                full_vocab_pairs
+            ),
+            "full_vocab_repeat_digest_determinism": (
+                _full_vocab_repeat_determinism_gate(
+                    full_vocab_pairs,
+                    n_prompts=len(exact_prompts),
+                    repeats=args.quality_repeats,
+                )
+            ),
+        })
+
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "created_at": v5._utc_now(),
+        "scope": (
+            "DSV4 routed FP4-CB quality prefill; TP=1; one in-process vLLM "
+            "engine; persistent-B handle A/B"
+        ),
+        "arm_labels": dict(ARM_LABELS),
+        "activation_contract": {
+            "baseline": "exact native group-16 FP4 activation QDQ",
+            "fused": "exact native group-16 FP4 activation QDQ",
+            "weights": "identical packed FP4-CB v2 bytes and codebooks",
+            "same_contract": True,
+            "permitted_difference": "FP32 GEMM reduction order only",
+        },
+        "settings": validation_common.shared_report_settings(
+            bootstrap,
+            args,
+            arm_settings={
+                "persistent_b_cfg": args.persistent_b_cfg,
+                "concrete_arm_modes": dict(ARM_LABELS),
+                "expected_persistent_b_layers": (
+                    args.expected_persistent_b_layers
+                ),
+                "expected_fp8_cb_moe_layers": args.expected_fp8_cb_moe_layers,
+            },
+            inherited_prefill=inherited[v5.PREFILL_ENV],
+            prefill_threshold=moe.MOE_PREFILL_M_THRESHOLD,
+            measurement_settings={
+                "chunked_prefill": chunked_contract["resolved_enabled"],
+                "warmup_pairs": args.warmup_pairs,
+                "quality_repeats": args.quality_repeats,
+                "timing_repeats": args.timing_repeats,
+                "full_vocab_kl": args.full_vocab_kl,
+                "full_vocab_seqlen": (
+                    args.full_vocab_seqlen if args.full_vocab_kl else None
+                ),
+                "full_vocab_profile": exact_profile,
+                "full_vocab_storage_contract": (
+                    "vllm FlatLogprobs -> paired float32 rows -> shared "
+                    "incremental scorer -> scalar/digest evidence; raw rows "
+                    "released before next pair"
+                    if args.full_vocab_kl else None
+                ),
+                "chunked_prefill_contract": chunked_contract,
+            },
+        ),
+        "environment_contract": {
+            "inherited_before_sanitization": inherited,
+            "during_model_load": {
+                PERSISTENT_B_ENV: os.environ.get(PERSISTENT_B_ENV),
+                PERSISTENT_B_CFG_ENV: os.environ.get(PERSISTENT_B_CFG_ENV),
+                BF16_SM120_ENV: os.environ.get(BF16_SM120_ENV),
+                v5.FUSED_ENV: os.environ.get(v5.FUSED_ENV),
+                v5.FUSED_MOE_ENV: os.environ.get(v5.FUSED_MOE_ENV),
+                v5.PREFILL_ENV: os.environ.get(v5.PREFILL_ENV),
+            },
+            "production_selector_remained_enabled": True,
+            "measurement_exception": (
+                "only the already-attested layer._cb_moe_persistent_b handle "
+                "is scoped per arm; no extension is loaded or selector read "
+                "inside a measured request"
+            ),
+        },
+        "runtime": runtime,
+        "extension": bootstrap.extension,
+        "candidate_artifact_provenance": (
+            bootstrap.candidate_artifact_provenance
+        ),
+        "dataset": bootstrap.dataset,
+        "model_load_seconds": engine.model_load_seconds,
+        "warmup": warmup_records,
+        "quality": quality,
+        "full_vocab_streaming_evidence": (
+            {
+                "profile": exact_profile,
+                "pairs": full_vocab_pairs,
+            }
+            if args.full_vocab_kl else None
+        ),
+        "teacher": teacher_record,
+        "teacher_quality": teacher_quality,
+        "dispatch": {
+            "layer_inventory": controller.inventory_gate,
+            "selector_attestations": selector_records,
+            "route_attestations": route_records,
+        },
+        "core_integrity_gates": core_gates,
+        "limitations": [
+            (
+                "Exact full-vocabulary KL was cardinality-attested on every "
+                "position of the digest-bound prefix profile, while exact "
+                "target NLL/PPL and coarse rejection KL cover the complete "
+                "sealed 8x512 workload."
+                if args.full_vocab_kl
+                else "Top-K/tail KL is a rejection screen and cannot promote "
+                "persistent-B."
+            ),
+            "Offline one-token wall timing is not streaming TTFT or TPOT.",
+            "A passing quality run does not replace served NATIVE-PARITY gates.",
+        ],
+        "elapsed_seconds": time.monotonic() - started,
+    }
+    if args.timing_repeats:
+        report["timing"] = v5._timing_summary(timing_samples)
+
+    configured = v5._configured_gates(args, report)
+    report["configured_promotion_gates"] = configured
+    report["measurement_only"] = bool(args.measurement_only)
+    report["measurement_valid"] = all(
+        bool(gate.get("pass")) for gate in core_gates.values()
+    )
+    report["configured_gates_pass"] = (
+        None
+        if args.measurement_only
+        else all(bool(gate.get("pass")) for gate in configured.values())
+    )
+    present_pairwise = [
+        name for name in _PAIRWISE_QUALITY_GATES
+        if getattr(args, name) is not None
+    ]
+    missing_pairwise = [
+        name for name in _PAIRWISE_QUALITY_GATES
+        if name not in present_pairwise
+    ]
+    report["promotion_contract"] = {
+        "same_weight_and_activation_contract": True,
+        "exact_full_vocab_kl_required": True,
+        "exact_full_vocab_kl_observed": (
+            quality["kl_mode"] == v5.KL_FULL_VOCAB
+        ),
+        "complete_sealed_workload_screen_observed": bool(quality_pairs),
+        "streamed_full_vocab_profile_observed": (
+            bool(full_vocab_pairs) if args.full_vocab_kl else False
+        ),
+        "full_vocab_profile": exact_profile,
+        "required_pairwise_quality_thresholds": list(_PAIRWISE_QUALITY_GATES),
+        "present_pairwise_quality_thresholds": present_pairwise,
+        "missing_pairwise_quality_thresholds": missing_pairwise,
+        "served_native_parity_still_required": True,
+        "complete": (
+            quality["kl_mode"] == v5.KL_FULL_VOCAB
+            and bool(quality_pairs)
+            and bool(full_vocab_pairs)
+            and not missing_pairwise
+        ),
+    }
+    report["promotion_recommendation"] = (
+        "measurement_failed"
+        if not report["measurement_valid"]
+        else "measurement_only_no_promotion_thresholds_configured"
+        if args.measurement_only
+        else "configured_gates_failed"
+        if report["configured_gates_pass"] is False
+        else "screening_only_full_vocab_required"
+        if quality["kl_mode"] != v5.KL_FULL_VOCAB
+        else "screening_only_pairwise_quality_thresholds_required"
+        if missing_pairwise
+        else "candidate_only_requires_served_native_parity"
+    )
+    return report
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prompt-token-ids-json", type=Path, required=True)
+    parser.add_argument("--revision")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--allow-downloads", action="store_true")
+    parser.add_argument("--teacher-model")
+    parser.add_argument("--teacher-revision")
+    parser.add_argument("--teacher-dtype", choices=("bfloat16",), default="bfloat16")
+    parser.add_argument(
+        "--full-vocab-kl",
+        action="store_true",
+        help=(
+            "request every candidate vocabulary logprob (and teacher row when "
+            "--teacher-model is supplied); memory-heavy on DSV4"
+        ),
+    )
+    parser.add_argument(
+        "--full-vocab-seqlen",
+        type=v5._positive_int,
+        default=64,
+        help=(
+            "digest-attested prefix length per sealed window for streamed "
+            "exact-vocabulary KL; complete-window NLL/PPL and coarse KL "
+            "always remain 512 tokens"
+        ),
+    )
+    parser.add_argument("--n-samples", type=v5._positive_int, default=8)
+    parser.add_argument("--seqlen", type=v5._positive_int, default=512)
+    parser.add_argument("--top-k", type=v5._positive_int, default=256)
+    parser.add_argument("--dtype", default="bfloat16")
+    parser.add_argument("--quantization", default="gridbook")
+    parser.add_argument("--tokenizer-mode", default="deepseek_v4")
+    parser.add_argument(
+        "--kv-cache-memory-bytes", type=v5._positive_int, default=268435456
+    )
+    parser.add_argument(
+        "--kv-cache-dtype",
+        choices=(DSV4_KV_CACHE_DTYPE,),
+        default=DSV4_KV_CACHE_DTYPE,
+        help="fixed DSV4 sparse-MLA KV-cache dtype",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization", type=v5._unit_interval, default=0.90
+    )
+    parser.add_argument("--max-num-batched-tokens", type=v5._positive_int)
+    chunked = parser.add_mutually_exclusive_group()
+    chunked.add_argument(
+        "--enable-chunked-prefill",
+        dest="enable_chunked_prefill",
+        action="store_const",
+        const=True,
+        default=None,
+    )
+    chunked.add_argument(
+        "--disable-chunked-prefill",
+        dest="enable_chunked_prefill",
+        action="store_const",
+        const=False,
+    )
+    parser.add_argument("--warmup-pairs", type=v5._positive_int, default=1)
+    parser.add_argument("--quality-repeats", type=v5._positive_int, default=2)
+    parser.add_argument("--timing-repeats", type=v5._nonnegative_int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--persistent-b-cfg", type=v5._nonnegative_int, default=0)
+    parser.add_argument("--expected-persistent-b-layers", type=v5._positive_int,
+                        default=35)
+    parser.add_argument("--expected-fp8-cb-moe-layers", type=v5._positive_int,
+                        default=8)
+    parser.add_argument("--expected-architecture",
+                        default="DeepseekV4ForCausalLM")
+    parser.add_argument("--expected-model-type", default="deepseek_v4")
+    parser.add_argument("--expected-hidden-layers", type=v5._positive_int,
+                        default=43)
+    parser.add_argument("--expected-hidden-size", type=v5._positive_int,
+                        default=4096)
+    parser.add_argument("--expected-moe-intermediate-size", type=v5._positive_int,
+                        default=2048)
+    parser.add_argument("--expected-routed-experts", type=v5._positive_int,
+                        default=256)
+    parser.add_argument("--expected-vocab-size", type=v5._positive_int,
+                        default=129280)
+    parser.add_argument("--measurement-only", action="store_true")
+    parser.add_argument("--max-mean-kl", type=v5._nonnegative_float)
+    parser.add_argument("--max-mean-nll-regression", type=v5._nonnegative_float)
+    parser.add_argument("--max-ppl-relative-regression", type=v5._nonnegative_float)
+    parser.add_argument(
+        "--max-teacher-persistent-b-mean-kl",
+        dest="max_teacher_fused_mean_kl",
+        type=v5._nonnegative_float,
+    )
+    parser.add_argument(
+        "--max-teacher-persistent-b-kl-regression",
+        dest="max_teacher_fused_kl_regression",
+        type=v5._nonnegative_float,
+    )
+    parser.add_argument("--min-timing-speedup", type=v5._nonnegative_float)
+    args = parser.parse_args(argv)
+
+    # Fields consumed by the shared loader/report API.  They are explicit here
+    # rather than hidden in a second parser with unrelated fused-NVFP4 modes.
+    args.mode = "moe256"
+    args.teacher_full_vocab_kl = bool(args.full_vocab_kl)
+    args.dataset_cache_dir = None
+    args.dataset_split = "train"
+    args.wikitext_text = None
+
+    if args.seqlen <= 16:
+        parser.error("--seqlen must exceed the routed prefill threshold (16)")
+    if args.full_vocab_seqlen <= 16:
+        parser.error("--full-vocab-seqlen must exceed prefill threshold 16")
+    if args.full_vocab_seqlen > args.seqlen:
+        parser.error("--full-vocab-seqlen cannot exceed --seqlen")
+    if args.quality_repeats < 2:
+        parser.error("--quality-repeats must be at least 2")
+    if args.n_samples * args.quality_repeats % 2:
+        parser.error("n-samples * quality-repeats must be even for arm balance")
+    if args.timing_repeats and args.n_samples * args.timing_repeats % 2:
+        parser.error("n-samples * timing-repeats must be even for arm balance")
+    if args.timing_repeats == 1:
+        parser.error(
+            "--timing-repeats must be 0 or at least 2 so every source prompt "
+            "sees both arm orders"
+        )
+    if args.min_timing_speedup is not None and args.timing_repeats == 0:
+        parser.error("--min-timing-speedup requires --timing-repeats > 0")
+    candidate_is_local = Path(args.model).expanduser().is_dir()
+    if not candidate_is_local:
+        parser.error("persistent-B DSV4 validation requires a local --model")
+    teacher_is_local = bool(
+        args.teacher_model and Path(args.teacher_model).expanduser().is_dir()
+    )
+    if args.teacher_model and not teacher_is_local and not args.teacher_revision:
+        parser.error(
+            "a non-local --teacher-model requires an explicit --teacher-revision"
+        )
+    if args.full_vocab_kl and args.teacher_model:
+        parser.error(
+            "streamed pairwise --full-vocab-kl does not retain candidate rows "
+            "for a later teacher pass; run the identity-matched teacher as a "
+            "separate predeclared gate"
+        )
+    teacher_limits = (
+        args.max_teacher_fused_mean_kl,
+        args.max_teacher_fused_kl_regression,
+    )
+    if any(value is not None for value in teacher_limits) and not args.teacher_model:
+        parser.error("teacher-relative gates require --teacher-model")
+    limits = v5._configured_limit_values(args)
+    has_thresholds = any(value is not None for value in limits)
+    if not has_thresholds and not args.measurement_only:
+        parser.error(
+            "no thresholds configured; pass --measurement-only for "
+            "evidence-only use"
+        )
+    if has_thresholds and args.measurement_only:
+        parser.error("--measurement-only cannot be combined with thresholds")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run(args)
+    except Exception as exc:  # noqa: BLE001 - preserve machine-readable failure
+        failure = {
+            "schema": SCHEMA,
+            "created_at": v5._utc_now(),
+            "status": "error",
+            "error": {"type": type(exc).__name__, "message": str(exc)},
+            "traceback": traceback.format_exc(),
+        }
+        v5._atomic_json(args.output, failure)
+        print(json.dumps(failure, indent=2), file=sys.stderr, flush=True)
+        return 1
+    if not report["measurement_valid"] or report["configured_gates_pass"] is False:
+        report["status"] = "gate_failed"
+    elif report["measurement_only"]:
+        report["status"] = "measurement_only"
+    elif not report["promotion_contract"]["complete"]:
+        report["status"] = "screening_only"
+    else:
+        report["status"] = "ok"
+    v5._atomic_json(args.output, report)
+    print(json.dumps({
+        "status": report["status"],
+        "output": str(args.output),
+        "measurement_valid": report["measurement_valid"],
+        "configured_gates_pass": report["configured_gates_pass"],
+        "promotion_contract": report["promotion_contract"],
+        "promotion_recommendation": report["promotion_recommendation"],
+        "quality_delta": report["quality"]["delta"],
+        "timing": report.get("timing"),
+        "layer_inventory": report["dispatch"]["layer_inventory"],
+    }, indent=2), flush=True)
+    return 0 if report["status"] in ("ok", "measurement_only") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cb_fill_guard.py
+++ b/tests/test_cb_fill_guard.py
@@ -229,6 +229,7 @@ def test_registry_is_data_not_a_try_except_chain():
     # DeepSeek-V4 (D0.1) lives in vLLM 0.24's per-platform package tree, and
     # the contract names the submodule that DEFINES the entrypoint class.
     assert "vllm.models.deepseek_v4.nvidia.model" in paths
+    assert "vllm.models.deepseek_v4.nvidia.dspark" in paths
     # no arch-specific class imports left in the install path
     imported = {n.module for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)}
     assert not any((m or "").startswith("vllm.model_executor.models")

--- a/tests/test_cb_gemv_select.py
+++ b/tests/test_cb_gemv_select.py
@@ -4,8 +4,9 @@ GPU-free and vLLM-free by construction: ``gridbook.moe_gemv_select`` imports
 nothing but the standard library, which is the reason the policy lives there
 and not in ``moe.py`` (see that module's docstring). Everything asserted here
 is the part that decides WHICH kernel a served layer runs — a wrong answer is
-silent (both kernels produce correct output; only speed and reassociation
-differ), so it has to be pinned by test rather than by observation.
+silent (both kernels produce correct output; selection changes speed and,
+outside the exact DSV4 K=2048/4096 default-schedule specializations, may change
+reduction order), so it has to be pinned by test rather than by observation.
 """
 import importlib.util
 import pathlib

--- a/tests/test_cb_gemv_v2_cuda.py
+++ b/tests/test_cb_gemv_v2_cuda.py
@@ -80,7 +80,7 @@ def _run_v2(case, k, *, dict_mode=0):
         k, type_size, 0, dict_mode)
 
 
-def _run_inherited_rowpack(case, k):
+def _run_inherited(case, k):
     x, qw, cb, compose, pair_expert, pair_xrow, type_size = case
     return inherited.cb_moe_gemv_fp4_v2(
         x, qw, cb, compose, pair_expert, pair_xrow, k, 2, type_size)
@@ -89,17 +89,49 @@ def _run_inherited_rowpack(case, k):
 @pytest.mark.parametrize("k,K", [
     (13, 512),
     (16, 1536),
-    (20, 2048),
-    (24, 4096),
+    (20, 2304),
+    (24, 3840),
 ])
 @pytest.mark.parametrize("contract", [None, "v2"])
 def test_v2_is_bit_exact_to_inherited_rowpack(k, K, contract):
     case = _case(k, K, seed=k + K)
     with _env(PRISMAQUANT_CB_W2_SCHED="rowpack",
               PRISMAQUANT_CB_DECODE_CONTRACT=contract):
-        want = _run_inherited_rowpack(case, k)
+        want = _run_inherited(case, k)
         got = _run_v2(case, k)
     assert torch.equal(got.view(torch.int16), want.view(torch.int16))
+
+
+@pytest.mark.parametrize("k,K", [
+    (12, 2048),
+    (12, 4096),
+    (16, 2048),
+    (16, 4096),
+    (18, 2048),
+    (18, 4096),
+])
+def test_v2_release_shapes_are_bit_exact_to_inherited_default(k, K):
+    """Pin the actual DSV4 target/draft release baseline, not rowpack.
+
+    The inherited default selects eight warps for both production widths
+    (n_sb=8/16). Exercise both decode contracts and every relevant dictionary
+    residency: auto, forced-global, forced-half and forced-full must all
+    reproduce its exact BF16 output. This is the coverage the original
+    rowpack-only parity test did not provide.
+    """
+    case = _case(k, K, seed=10_000 + 100 * k + K)
+    for contract in (None, "v2"):
+        with _env(PRISMAQUANT_CB_W2_SCHED=None,
+                  PRISMAQUANT_CB_W2_ROWS=None,
+                  PRISMAQUANT_CB_W2_WARPS=None,
+                  PRISMAQUANT_CB_DECODE_CONTRACT=contract):
+            want = _run_inherited(case, k)
+            for dict_mode in (0, 1, 2, 3):  # auto, GLOBAL, HALF, FULL
+                got = _run_v2(case, k, dict_mode=dict_mode)
+                assert torch.equal(got.view(torch.int16),
+                                   want.view(torch.int16)), (
+                    f"k={k} K={K} contract={contract or 'v1'} "
+                    f"dict_mode={dict_mode}: v2 != inherited default")
 
 
 def test_compiled_dispatch_predicate_covers_measured_wall_and_invalid_inputs():
@@ -110,7 +142,7 @@ def test_compiled_dispatch_predicate_covers_measured_wall_and_invalid_inputs():
     assert v2ext.cb_gemv_v2_prefers_inherited(16, 73, 0) is True
 
 
-def test_cuda_graph_replay_matches_eager():
+def test_rowpack_cuda_graph_replay_matches_eager():
     k, K = 16, 512
     case = _case(k, K, seed=77)
     with _env(PRISMAQUANT_CB_DECODE_CONTRACT="v2"):
@@ -122,6 +154,37 @@ def test_cuda_graph_replay_matches_eager():
         graph.replay()
         torch.cuda.synchronize()
     assert torch.equal(captured.view(torch.int16), eager.view(torch.int16))
+
+
+@pytest.mark.parametrize("k,K", [
+    (12, 2048),
+    (12, 4096),
+    (16, 2048),
+    (16, 4096),
+    (18, 2048),
+    (18, 4096),
+])
+@pytest.mark.parametrize("contract", [None, "v2"])
+def test_release_shape_cuda_graph_replay_matches_inherited_default(
+        k, K, contract):
+    case = _case(k, K, seed=20_000 + 100 * k + K)
+    with _env(PRISMAQUANT_CB_W2_SCHED=None,
+              PRISMAQUANT_CB_W2_ROWS=None,
+              PRISMAQUANT_CB_W2_WARPS=None,
+              PRISMAQUANT_CB_DECODE_CONTRACT=contract):
+        want = _run_inherited(case, k)
+        for dict_mode in (0, 1, 2, 3):
+            eager = _run_v2(case, k, dict_mode=dict_mode)
+            torch.cuda.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured = _run_v2(case, k, dict_mode=dict_mode)
+            graph.replay()
+            torch.cuda.synchronize()
+            assert torch.equal(eager.view(torch.int16),
+                               want.view(torch.int16))
+            assert torch.equal(captured.view(torch.int16),
+                               want.view(torch.int16))
 
 
 def test_custom_op_torch_compile_contract():

--- a/tests/test_codebook_provenance_config.py
+++ b/tests/test_codebook_provenance_config.py
@@ -131,6 +131,48 @@ def _set_model(
     return model_config
 
 
+def _set_target_and_draft(monkeypatch, target_config, draft_config):
+    current = types.SimpleNamespace(
+        model_config=target_config,
+        speculative_config=types.SimpleNamespace(
+            draft_model_config=draft_config,
+        ),
+    )
+    monkeypatch.setattr(
+        vllm_config, "get_current_vllm_config", lambda: current
+    )
+    return current
+
+
+def _model_config(model: str, *, resolved_commit: str | None = None):
+    return types.SimpleNamespace(
+        model=model,
+        hf_config=types.SimpleNamespace(_commit_hash=resolved_commit),
+        revision=None,
+    )
+
+
+def _dspark_class(on_init):
+    class FakeDSpark:
+        def __init__(self):
+            on_init()
+
+        @staticmethod
+        def _remap_dspark_name(name):
+            return name
+
+        def named_parameters(self):
+            return ()
+
+        def load_weights(self, weights):
+            return {name for name, _ in weights}
+
+    # The production gate is deliberately exact: a remapper on an arbitrary
+    # model is not authority to reinterpret its sidecar source as DSpark.
+    FakeDSpark.__module__ = "vllm.models.deepseek_v4.nvidia.dspark"
+    return FakeDSpark
+
+
 def test_inline_config_verifies_then_memoizes(tmp_path, monkeypatch):
     sidecar = tmp_path / "cb_codebooks.pqcb"
     table = _write_sidecar(sidecar)
@@ -175,6 +217,232 @@ def test_pointer_config_resolves_hashes_and_sidecar_path(tmp_path, monkeypatch):
     assert cfg.codebook_file == relative_sidecar
     assert torch.equal(got[_NAME], table)
     assert cfg._sidecar_source == (str(tmp_path), None)
+
+
+def test_speculative_config_alone_keeps_target_sidecar_source(
+    tmp_path, monkeypatch
+):
+    """Loading the target body must not inherit the draft's sidecars."""
+
+    target = tmp_path / "target"
+    draft = tmp_path / "draft"
+    target_table = _write_sidecar(target / "cb_codebooks.pqcb", value=1.0)
+    draft_table = _write_sidecar(draft / "cb_codebooks.pqcb", value=2.0)
+    (target / "quant_config.json").write_text(
+        json.dumps(_full_config(codebook_tensor_sha256(target_table))),
+        encoding="utf-8",
+    )
+    (draft / "quant_config.json").write_text(
+        json.dumps(_full_config(codebook_tensor_sha256(draft_table))),
+        encoding="utf-8",
+    )
+    _set_target_and_draft(
+        monkeypatch,
+        _model_config(str(target)),
+        _model_config(str(draft)),
+    )
+
+    cfg = PrismaQuantConfig.from_config({"config_file": "quant_config.json"})
+    got = cfg.get_codebooks()[_NAME]
+    assert torch.equal(got, target_table)
+    assert cfg._sidecar_source == (str(target), None)
+
+
+def test_dspark_construction_loads_both_sidecars_from_explicit_draft(
+    tmp_path, monkeypatch
+):
+    """DSpark pointer config and its declared pqcb share draft authority."""
+
+    from gridbook.moe_toplevel_loader import (
+        active_dspark_draft_model_config,
+        install_toplevel_cb_expert_loader,
+    )
+
+    target = tmp_path / "target"
+    draft = tmp_path / "draft"
+    target_table = _write_sidecar(target / "cb_codebooks.pqcb", value=1.0)
+    draft_table = _write_sidecar(draft / "cb_codebooks.pqcb", value=2.0)
+    (target / "quant_config.json").write_text(
+        json.dumps(_full_config(codebook_tensor_sha256(target_table))),
+        encoding="utf-8",
+    )
+    (draft / "quant_config.json").write_text(
+        json.dumps(_full_config(codebook_tensor_sha256(draft_table))),
+        encoding="utf-8",
+    )
+    draft_config = _model_config(str(draft))
+    _set_target_and_draft(
+        monkeypatch, _model_config(str(target)), draft_config
+    )
+
+    cfg = PrismaQuantConfig.from_config({"config_file": "quant_config.json"})
+    observed = []
+
+    def on_init():
+        assert active_dspark_draft_model_config() is draft_config
+        observed.append(cfg.get_codebooks()[_NAME])
+
+    dspark = _dspark_class(on_init)
+    install_toplevel_cb_expert_loader(dspark)
+    dspark()
+
+    assert len(observed) == 1
+    assert torch.equal(observed[0], draft_table)
+    assert cfg._sidecar_source == (str(draft), None)
+    assert active_dspark_draft_model_config() is None
+
+    # A fresh ordinary config after the DSpark constructor proves context
+    # restoration and retains the target source.
+    target_cfg = PrismaQuantConfig.from_config(
+        {"config_file": "quant_config.json"}
+    )
+    assert torch.equal(target_cfg.get_codebooks()[_NAME], target_table)
+
+
+def test_dspark_inline_config_pins_draft_before_delayed_codebook_read(
+    tmp_path, monkeypatch
+):
+    """Inline config must retain draft authority after construction exits."""
+
+    from gridbook.moe_toplevel_loader import (
+        active_dspark_draft_model_config,
+        install_toplevel_cb_expert_loader,
+    )
+
+    target = tmp_path / "target"
+    draft = tmp_path / "draft"
+    target_table = _write_sidecar(target / "cb_codebooks.pqcb", value=1.0)
+    draft_table = _write_sidecar(draft / "cb_codebooks.pqcb", value=2.0)
+    current = _set_target_and_draft(
+        monkeypatch,
+        _model_config(str(target)),
+        _model_config(str(draft)),
+    )
+    cfg = PrismaQuantConfig.from_config(
+        _full_config(codebook_tensor_sha256(draft_table))
+    )
+    # Inline metadata can be parsed before model construction without needing
+    # either external sidecar.  The later call inside DSpark must therefore pin
+    # draft authority even though the ordinary resolution early-return applies.
+    cfg._ensure_resolved()
+    assert cfg._resolved is True
+    assert cfg._sidecar_source is None
+
+    def on_init():
+        assert active_dspark_draft_model_config() \
+            is current.speculative_config.draft_model_config
+        cfg._ensure_resolved()
+        assert cfg._resolved is True
+        assert cfg._codebooks is None
+        assert cfg._sidecar_source == (str(draft), None)
+
+    dspark = _dspark_class(on_init)
+    install_toplevel_cb_expert_loader(dspark)
+    dspark()
+    assert active_dspark_draft_model_config() is None
+
+    # The first codebook read is deliberately after __init__, when vLLM no
+    # longer publishes a current config.  It must use the source pinned above.
+    monkeypatch.setattr(
+        vllm_config,
+        "get_current_vllm_config",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("delayed draft lookup was not pinned")
+        ),
+    )
+    assert torch.equal(cfg.get_codebooks()[_NAME], draft_table)
+
+    # Restoring the ordinary vLLM context proves a fresh non-DSpark config is
+    # still target-owned rather than inheriting the draft's cached authority.
+    monkeypatch.setattr(
+        vllm_config, "get_current_vllm_config", lambda: current
+    )
+    target_cfg = PrismaQuantConfig.from_config(
+        _full_config(codebook_tensor_sha256(target_table))
+    )
+    assert torch.equal(target_cfg.get_codebooks()[_NAME], target_table)
+    assert target_cfg._sidecar_source == (str(target), None)
+
+
+@pytest.mark.parametrize("same_model_config_object", [False, True])
+def test_dspark_accepts_explicit_collocated_draft_source(
+    tmp_path, monkeypatch, same_model_config_object
+):
+    """Explicit role survives co-location and even intentional object reuse."""
+
+    from gridbook.moe_toplevel_loader import install_toplevel_cb_expert_loader
+
+    table = _write_sidecar(tmp_path / "cb_codebooks.pqcb", value=3.0)
+    (tmp_path / "quant_config.json").write_text(
+        json.dumps(_full_config(codebook_tensor_sha256(table))),
+        encoding="utf-8",
+    )
+    target_config = _model_config(str(tmp_path))
+    draft_config = (
+        target_config
+        if same_model_config_object
+        else _model_config(str(tmp_path))
+    )
+    _set_target_and_draft(monkeypatch, target_config, draft_config)
+    cfg = PrismaQuantConfig.from_config({"config_file": "quant_config.json"})
+    observed = []
+    dspark = _dspark_class(
+        lambda: observed.append(cfg.get_codebooks()[_NAME])
+    )
+    install_toplevel_cb_expert_loader(dspark)
+
+    dspark()
+    assert torch.equal(observed[0], table)
+
+
+@pytest.mark.parametrize(
+    "speculative_config,message",
+    [
+        (None, "requires vLLM speculative_config.draft_model_config"),
+        (types.SimpleNamespace(), "requires vLLM speculative_config"),
+        (
+            types.SimpleNamespace(draft_model_config=None),
+            "requires vLLM speculative_config",
+        ),
+        (
+            types.SimpleNamespace(
+                draft_model_config=types.SimpleNamespace()
+            ),
+            "draft_model_config.model is not",
+        ),
+        (
+            types.SimpleNamespace(
+                draft_model_config=types.SimpleNamespace(model=object())
+            ),
+            "draft_model_config.model is not",
+        ),
+        (
+            types.SimpleNamespace(
+                draft_model_config=types.SimpleNamespace(model="")
+            ),
+            "draft_model_config.model is not a nonempty string",
+        ),
+    ],
+)
+def test_dspark_missing_or_malformed_draft_source_fails_before_init(
+    monkeypatch, speculative_config, message
+):
+    from gridbook.moe_toplevel_loader import install_toplevel_cb_expert_loader
+
+    current = types.SimpleNamespace(
+        model_config=_model_config("/target"),
+        speculative_config=speculative_config,
+    )
+    monkeypatch.setattr(
+        vllm_config, "get_current_vllm_config", lambda: current
+    )
+    entered = []
+    dspark = _dspark_class(lambda: entered.append(True))
+    install_toplevel_cb_expert_loader(dspark)
+
+    with pytest.raises(RuntimeError, match=message):
+        dspark()
+    assert entered == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deepseek_v4_contract.py
+++ b/tests/test_deepseek_v4_contract.py
@@ -23,12 +23,12 @@ CPU-first with synthetic fixtures:
    published only through ``stacked_params_mapping``, so Gridbook's fused
    fallback tables are the only merge information it has.
 
-MTP/DSpark is deliberately NOT exercised as a load path: the body's
+This file deliberately exercises only the target body's MTP behavior: its
 ``load_weights`` is ``AutoWeightsLoader(self, skip_substrs=["mtp."])``, so all
-4,705 ``mtp.*`` tensors are dropped before any parameter lookup, and no
-``dspark_*`` config key is referenced anywhere in the vLLM package. The test
-that matters for them is that a stacked-CB MTP tensor still DEFERS rather than
-being mis-routed into a body layer.
+4,705 ``mtp.*`` tensors are dropped before any parameter lookup. A stacked-CB
+MTP tensor must still DEFER rather than being mis-routed into a body layer.
+The separate DSpark draft entrypoint and its physical/registered/construction
+namespaces are covered in ``test_dspark_cb_loader.py``.
 
 torch-only for the loader/resolver halves (they import no vLLM); the
 class-shaped resolution test is skip-guarded and runs in the container.
@@ -138,13 +138,15 @@ def _cb_params():
 # 1. Registration
 # --------------------------------------------------------------------------
 
-def test_contract_registers_deepseek_v4_profile_and_defining_module():
+def test_contract_registers_deepseek_v4_profile_and_defining_modules():
     profiles = load_runtime_contract()["producer_profiles"]
     assert "deepseek_v4" in profiles["supported_ids"]
     # plugin.py installs on the module that DEFINES the entrypoint class; for
     # DSV4 that is the platform submodule, not the package __init__ (which only
     # re-exports and would be skipped by the __module__ guard).
     assert ("vllm.models.deepseek_v4.nvidia.model"
+            in profiles["top_level_loader_modules"])
+    assert ("vllm.models.deepseek_v4.nvidia.dspark"
             in profiles["top_level_loader_modules"])
     assert ("vllm.models.deepseek_v4"
             not in profiles["top_level_loader_modules"])
@@ -531,7 +533,8 @@ def test_real_vllm_deepseek_v4_class_matches_the_contract():
     # The merges Gridbook's fallback table has to know about.
     assert '"attn.fused_wqa_wkv", "attn.wq_a"' in src.replace("(", "").replace(
         ")", "") or "fused_wqa_wkv" in src
-    # No DSpark support to wire to.
+    # The target-body module itself owns no DSpark implementation; the draft is
+    # defined in the separately registered nvidia.dspark module.
     assert "dspark" not in src.lower()
 
 

--- a/tests/test_dspark_cb_loader.py
+++ b/tests/test_dspark_cb_loader.py
@@ -1,0 +1,556 @@
+"""DSpark Gridbook loader contract: construction, registered, and wire names.
+
+The production DSpark class constructs decoder layers with quantization
+prefixes ``model.layers.43/44/45``, registers its three-element ``ModuleList``
+as ``model.layers.0/1/2``, and reads physical checkpoint names ``mtp.0/1/2``.
+These CPU fixtures preserve that split and the production
+``_remap_dspark_name`` behavior.
+"""
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from gridbook.cb_fill_guard import CB_FILLED_ATTR
+from gridbook.moe_toplevel_loader import (
+    _dspark_rename,
+    _registered_mixed_source,
+    _validate_dspark_target_bridge_model,
+    install_toplevel_cb_expert_loader,
+)
+from gridbook.runtime_contract import load_runtime_contract
+
+
+E, HID, INTER, BYTES = 2, 8, 4, 3
+
+
+def _sharded_param(rows: int) -> torch.Tensor:
+    param = torch.zeros(2 * rows, BYTES, dtype=torch.uint8)
+
+    def weight_loader(destination, incoming, shard_id):
+        start = int(shard_id) * rows
+        destination.data[start:start + rows].copy_(incoming)
+
+    param.weight_loader = weight_loader
+    return param
+
+
+def _mixed_carrier(*, source: str, group: str) -> torch.Tensor:
+    param = torch.zeros(HID, BYTES, dtype=torch.uint8)
+    param._gridbook_mixed_fused_source = source
+    param._gridbook_mixed_fused_group = group
+    param._gridbook_mixed_fused_plane = "cb_qweight"
+    return param
+
+
+def _params(*, include_mixed: bool = False) -> dict[str, torch.Tensor]:
+    params: dict[str, torch.Tensor] = {}
+    for stage in range(3):
+        routed = (
+            f"model.layers.{stage}.ffn.experts.routed_experts"
+        )
+        params[routed + ".w13_cb_qweight"] = torch.zeros(
+            E, 2 * INTER, BYTES, dtype=torch.uint8
+        )
+        params[routed + ".w2_cb_qweight"] = torch.zeros(
+            E, HID, BYTES, dtype=torch.uint8
+        )
+        params[routed + ".w13_weight_scale"] = torch.zeros(
+            E, 2 * INTER, dtype=torch.float32
+        )
+        params[routed + ".w2_weight_scale"] = torch.zeros(
+            E, HID, dtype=torch.float32
+        )
+        params[routed + ".w13_input_global_scale"] = torch.full(
+            (1,), torch.nan, dtype=torch.float32
+        )
+        params[routed + ".w2_input_global_scale"] = torch.full(
+            (1,), torch.nan, dtype=torch.float32
+        )
+
+    # Stock DSpark owns ordinary direct and fused CB Linears. These are stage
+    # zero only because that is enough to prove raw-name delegation.
+    params["model.layers.0.attn.wq_b.cb_qweight"] = torch.zeros(
+        HID, BYTES, dtype=torch.uint8
+    )
+    params["model.layers.0.attn.fused_wqa_wkv.cb_qweight"] = \
+        _sharded_param(HID)
+    params[
+        "model.layers.0.ffn.shared_experts.gate_up_proj.cb_qweight"
+    ] = _sharded_param(INTER)
+    params[
+        "model.layers.0.ffn.shared_experts.down_proj.cb_qweight"
+    ] = torch.zeros(HID, BYTES, dtype=torch.uint8)
+
+    # A heterogeneous fusion is owned by Gridbook's existing transaction
+    # router. DSpark construction metadata stays at layer 44 while the actual
+    # ModuleList parameter path is registered at layer 1.
+    if include_mixed:
+        registered_group = "model.layers.1.attn.fused_wqa_wkv"
+        construction_group = "model.layers.44.attn.fused_wqa_wkv"
+        for index, role in enumerate(("wq_a", "wkv")):
+            name = (registered_group
+                    + f"._gridbook_mixed_roles.{index}.cb_qweight")
+            params[name] = _mixed_carrier(
+                source=f"model.layers.44.attn.{role}",
+                group=construction_group,
+            )
+    return params
+
+
+def _make_dspark_cls(*, include_mixed: bool = False):
+    class _FakeDSpark:
+        def __init__(self):
+            self._params = _params(include_mixed=include_mixed)
+            self.delegated_raw: list[str] = []
+
+        def named_parameters(self):
+            return list(self._params.items())
+
+        def _remap_dspark_name(self, name: str) -> str | None:
+            """Faithful copy of production DSpark's namespace remapper."""
+            match = re.match(r"mtp\.(\d+)\.(.*)", name)
+            if match is None:
+                return None
+            stage = int(match.group(1))
+            rest = match.group(2)
+            if rest.startswith("confidence_head."):
+                return None
+            heads = (
+                "norm.",
+                "hc_head_fn",
+                "hc_head_base",
+                "hc_head_scale",
+                "markov_head.",
+            )
+            if rest.startswith(("main_proj.", "main_norm.")) \
+                    or rest.startswith(heads):
+                return f"model.{rest}"
+            return f"model.layers.{stage}.{rest}"
+
+        def load_weights(self, weights):
+            """Production-shaped stock handling for the exercised CB names."""
+            loaded = set()
+            stacked = (
+                ("gate_up_proj", "w1", 0),
+                ("gate_up_proj", "w3", 1),
+                ("attn.fused_wqa_wkv", "attn.wq_a", 0),
+                ("attn.fused_wqa_wkv", "attn.wkv", 1),
+            )
+            for raw_name, weight in weights:
+                self.delegated_raw.append(raw_name)
+                name = self._remap_dspark_name(raw_name)
+                if name is None:
+                    continue
+                # Production DSpark rewrites source-checkpoint ``.scale`` to
+                # the scale parameter spelling selected by the quant method.
+                # Ordinary non-expert source FP8 uses ``weight_scale_inv``.
+                if name.endswith(".scale"):
+                    name = name.removesuffix(".scale") + \
+                        ".weight_scale_inv"
+                if ".shared_experts.w2" in name:
+                    name = name.replace(
+                        ".shared_experts.w2", ".shared_experts.down_proj"
+                    )
+                if ".experts." in name:
+                    # Production's per-expert mapping does not claim a stacked
+                    # Gridbook name. The wrapper must consume supported stacks;
+                    # an unmatched one defers and is dropped here.
+                    continue
+                is_layer = name.startswith("model.layers.")
+                for target, source, shard in stacked:
+                    if not is_layer or source not in name:
+                        continue
+                    mapped = name.replace(source, target)
+                    param = self._params[mapped]
+                    param.weight_loader(param, weight, shard)
+                    loaded.add(mapped)
+                    break
+                else:
+                    param = self._params[name]
+                    weight_loader = getattr(param, "weight_loader", None)
+                    if weight_loader is None:
+                        param.data.copy_(weight.to(param.dtype))
+                    else:
+                        weight_loader(param, weight)
+                    loaded.add(name)
+            return loaded
+
+    return _FakeDSpark
+
+
+def test_dspark_uses_its_own_physical_to_registered_mapping():
+    model = _make_dspark_cls()()
+    rename = _dspark_rename(model)
+    assert rename is not None
+    assert rename("mtp.0.attn.wq_b.cb_qweight") == \
+        "model.layers.0.attn.wq_b.cb_qweight"
+    assert rename("mtp.2.markov_head.weight") == \
+        "model.markov_head.weight"
+    # The model returns None for confidence/non-MTP tensors. The interception
+    # name stays physical so the original loader retains drop/ownership rules.
+    assert rename("mtp.1.confidence_head.weight") == \
+        "mtp.1.confidence_head.weight"
+    assert rename("model.layers.43.attn.wq_b.cb_qweight") == \
+        "model.layers.43.attn.wq_b.cb_qweight"
+    assert _dspark_rename(object()) is None
+
+
+def test_dspark_bridge_topology_matches_the_instantiated_model():
+    class _Model:
+        quant_config = SimpleNamespace(
+            _dspark_target_bridge_topology=(43, 3)
+        )
+        config = SimpleNamespace(num_hidden_layers=43)
+        model = SimpleNamespace(num_dspark_layers=3)
+
+        @staticmethod
+        def _remap_dspark_name(name):
+            return name
+
+    _validate_dspark_target_bridge_model(_Model())
+
+    _Model.quant_config._dspark_target_bridge_topology = (42, 3)
+    with pytest.raises(RuntimeError, match="does not match"):
+        _validate_dspark_target_bridge_model(_Model())
+
+    del _Model._remap_dspark_name
+    with pytest.raises(RuntimeError, match="without callable"):
+        _validate_dspark_target_bridge_model(_Model())
+
+
+def test_all_dspark_stacked_expert_planes_load_and_fill():
+    cls = _make_dspark_cls()
+    install_toplevel_cb_expert_loader(cls)
+    model = cls()
+    checkpoint = []
+    for stage in range(3):
+        base = f"mtp.{stage}.ffn.experts"
+        checkpoint.extend((
+            (base + ".gate_up_proj.cb_qweight", torch.full(
+                (E, 2 * INTER, BYTES), 10 + stage, dtype=torch.uint8
+            )),
+            (base + ".down_proj.cb_qweight", torch.full(
+                (E, HID, BYTES), 20 + stage, dtype=torch.uint8
+            )),
+            (base + ".gate_up_proj.weight_scale", torch.full(
+                (E, 2 * INTER), 30.0 + stage
+            )),
+            (base + ".down_proj.weight_scale", torch.full(
+                (E, HID), 40.0 + stage
+            )),
+            (base + ".gate_up_proj.input_global_scale", torch.tensor(
+                [50.0 + stage]
+            )),
+            (base + ".down_proj.input_global_scale", torch.tensor(
+                [60.0 + stage]
+            )),
+        ))
+
+    loaded = model.load_weights(iter(checkpoint))
+
+    assert model.delegated_raw == []
+    assert len(loaded) == 18
+    for stage in range(3):
+        routed = f"model.layers.{stage}.ffn.experts.routed_experts"
+        assert torch.all(model._params[routed + ".w13_cb_qweight"]
+                         == 10 + stage)
+        assert torch.all(model._params[routed + ".w2_cb_qweight"]
+                         == 20 + stage)
+        assert torch.all(model._params[routed + ".w13_weight_scale"]
+                         == 30 + stage)
+        assert torch.all(model._params[routed + ".w2_weight_scale"]
+                         == 40 + stage)
+        assert torch.all(model._params[routed + ".w13_input_global_scale"]
+                         == 50 + stage)
+        assert torch.all(model._params[routed + ".w2_input_global_scale"]
+                         == 60 + stage)
+        for leaf in ("w13_cb_qweight", "w2_cb_qweight"):
+            assert getattr(model._params[routed + "." + leaf],
+                           CB_FILLED_ATTR, False) is True
+
+
+def test_dspark_dense_direct_and_fused_cb_stay_stock_owned():
+    cls = _make_dspark_cls()
+    install_toplevel_cb_expert_loader(cls)
+    model = cls()
+    checkpoint = [
+        ("mtp.0.attn.wq_b.cb_qweight",
+         torch.full((HID, BYTES), 1, dtype=torch.uint8)),
+        ("mtp.0.attn.wq_a.cb_qweight",
+         torch.full((HID, BYTES), 2, dtype=torch.uint8)),
+        ("mtp.0.attn.wkv.cb_qweight",
+         torch.full((HID, BYTES), 3, dtype=torch.uint8)),
+        ("mtp.0.ffn.shared_experts.w1.cb_qweight",
+         torch.full((INTER, BYTES), 4, dtype=torch.uint8)),
+        ("mtp.0.ffn.shared_experts.w3.cb_qweight",
+         torch.full((INTER, BYTES), 5, dtype=torch.uint8)),
+        ("mtp.0.ffn.shared_experts.w2.cb_qweight",
+         torch.full((HID, BYTES), 6, dtype=torch.uint8)),
+    ]
+
+    loaded = model.load_weights(iter(checkpoint))
+
+    # The wrapper resolves against registered names but delegates the original
+    # physical names. This is the critical ownership boundary.
+    assert model.delegated_raw == [name for name, _ in checkpoint]
+    assert "model.layers.0.attn.wq_b.cb_qweight" in loaded
+    assert torch.all(model._params[
+        "model.layers.0.attn.wq_b.cb_qweight"] == 1)
+    fused = model._params[
+        "model.layers.0.attn.fused_wqa_wkv.cb_qweight"]
+    assert torch.all(fused[:HID] == 2)
+    assert torch.all(fused[HID:] == 3)
+    shared = model._params[
+        "model.layers.0.ffn.shared_experts.gate_up_proj.cb_qweight"]
+    assert torch.all(shared[:INTER] == 4)
+    assert torch.all(shared[INTER:] == 5)
+    assert torch.all(model._params[
+        "model.layers.0.ffn.shared_experts.down_proj.cb_qweight"] == 6)
+
+
+@pytest.mark.parametrize(
+    ("physical_base", "registered_base"),
+    (
+        ("mtp.0.main_proj", "model.main_proj"),
+        ("mtp.2.attn.wo_a", "model.layers.2.attn.wo_a"),
+    ),
+)
+def test_dspark_source_physical_planes_load_gridbook_w8a16_params(
+        monkeypatch, physical_base, registered_base):
+    """The wrapper delegates raw names; DSpark remaps into W8A16 params."""
+
+    # Instantiate the real Gridbook method's parameter contract without
+    # importing a GPU-bound vLLM installation into this CPU loader test.
+    for name in (
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.layers",
+    ):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    linear = types.ModuleType("vllm.model_executor.layers.linear")
+    linear.LinearMethodBase = type("LinearMethodBase", (), {})
+    monkeypatch.setitem(
+        sys.modules, "vllm.model_executor.layers.linear", linear
+    )
+    parameter = types.ModuleType("vllm.model_executor.parameter")
+
+    class _StubParameter(torch.nn.Parameter):
+        def __new__(cls, data, **_kwargs):
+            return super().__new__(cls, data, requires_grad=False)
+
+        def __init__(self, data, **kwargs):
+            del data
+            for name, value in kwargs.items():
+                setattr(self, name, value)
+
+    parameter.ModelWeightParameter = _StubParameter
+    parameter.BlockQuantScaleParameter = _StubParameter
+    monkeypatch.setitem(
+        sys.modules, "vllm.model_executor.parameter", parameter
+    )
+
+    from gridbook.fp8_source_w8a16 import (
+        WIRE_FP8_BLOCK128,
+        build_fp8_source_w8a16_method,
+    )
+
+    def copy_loader(destination, incoming, *_args, **_kwargs):
+        destination.data.copy_(incoming)
+
+    owner = torch.nn.Module()
+    method = build_fp8_source_w8a16_method(WIRE_FP8_BLOCK128)
+    method.create_weights(
+        owner,
+        input_size_per_partition=4,
+        output_partition_sizes=[4],
+        input_size=4,
+        output_size=4,
+        params_dtype=torch.bfloat16,
+        weight_loader=copy_loader,
+    )
+    assert owner.weight.dtype == torch.float8_e4m3fn
+    assert owner.weight_scale_inv.dtype == torch.float8_e8m0fnu
+
+    cls = _make_dspark_cls()
+    install_toplevel_cb_expert_loader(cls)
+    model = cls()
+    model._params[registered_base + ".weight"] = owner.weight
+    model._params[
+        registered_base + ".weight_scale_inv"
+    ] = owner.weight_scale_inv
+
+    source_weight = torch.empty_like(owner.weight)
+    source_weight.view(torch.uint8).copy_(
+        torch.arange(source_weight.numel(), dtype=torch.uint8).reshape(
+            source_weight.shape
+        )
+    )
+    source_scale = torch.empty_like(owner.weight_scale_inv)
+    source_scale.view(torch.uint8).fill_(127)
+    checkpoint = [
+        (physical_base + ".weight", source_weight),
+        (physical_base + ".scale", source_scale),
+    ]
+
+    loaded = model.load_weights(iter(checkpoint))
+
+    assert model.delegated_raw == [name for name, _ in checkpoint]
+    assert loaded == {
+        registered_base + ".weight",
+        registered_base + ".weight_scale_inv",
+    }
+    assert torch.equal(
+        owner.weight.view(torch.uint8), source_weight.view(torch.uint8)
+    )
+    assert torch.equal(
+        owner.weight_scale_inv.view(torch.uint8),
+        source_scale.view(torch.uint8),
+    )
+
+
+def test_dspark_mixed_fusion_resolves_registered_names_without_delegation():
+    cls = _make_dspark_cls(include_mixed=True)
+    install_toplevel_cb_expert_loader(cls)
+    model = cls()
+    checkpoint = [
+        ("mtp.1.attn.wq_a.cb_qweight",
+         torch.full((HID, BYTES), 7, dtype=torch.uint8)),
+        ("mtp.1.attn.wkv.cb_qweight",
+         torch.full((HID, BYTES), 8, dtype=torch.uint8)),
+    ]
+
+    loaded = model.load_weights(iter(checkpoint))
+
+    assert model.delegated_raw == []
+    group = "model.layers.1.attn.fused_wqa_wkv"
+    assert torch.all(model._params[
+        group + "._gridbook_mixed_roles.0.cb_qweight"] == 7)
+    assert torch.all(model._params[
+        group + "._gridbook_mixed_roles.1.cb_qweight"] == 8)
+    assert loaded == {
+        group + "._gridbook_mixed_roles.0.cb_qweight",
+        group + "._gridbook_mixed_roles.1.cb_qweight",
+    }
+
+
+def test_dspark_mixed_alias_is_structurally_44_to_1_and_fails_on_mutation():
+    construction_group = "model.layers.44.attn.fused_wqa_wkv"
+    construction_source = "model.layers.44.attn.wq_a"
+    registered_param = (
+        "model.layers.1.attn.fused_wqa_wkv."
+        "_gridbook_mixed_roles.0.cb_qweight"
+    )
+    assert _registered_mixed_source(
+        registered_param, construction_group, construction_source
+    ) == "model.layers.1.attn.wq_a"
+
+    # Mutating the construction source to another stage cannot silently route
+    # through the layer-1 carrier: the group/source sibling proof rejects it.
+    with pytest.raises(ValueError, match="not a sibling"):
+        _registered_mixed_source(
+            registered_param,
+            construction_group,
+            "model.layers.45.attn.wq_a",
+        )
+    # Mutating the registered fused leaf likewise invalidates the structural
+    # join instead of inventing a layer-offset rule.
+    with pytest.raises(ValueError, match="incompatible"):
+        _registered_mixed_source(
+            registered_param.replace("fused_wqa_wkv", "other_fusion"),
+            construction_group,
+            construction_source,
+        )
+
+
+def test_dspark_unmatched_names_defer_to_stock_filter_or_failure():
+    cls = _make_dspark_cls()
+    install_toplevel_cb_expert_loader(cls)
+    model = cls()
+
+    # Non-MTP and confidence names are stock-filtered; an unmatched stacked
+    # expert is likewise deferred to DSpark's per-expert branch and dropped.
+    names = [
+        "model.layers.7.attn.wq_b.cb_qweight",
+        "mtp.1.confidence_head.weight",
+        "mtp.9.ffn.experts.gate_up_proj.cb_qweight",
+    ]
+    assert model.load_weights(iter((name, torch.zeros(1))
+                                   for name in names)) == set()
+    assert model.delegated_raw == names
+
+    # An unmatched ordinary dense tensor follows production's direct
+    # params_dict lookup and therefore fails closed in the stock loader.
+    with pytest.raises(KeyError, match="model.layers.9.attn.wq_b"):
+        model.load_weights(iter([
+            ("mtp.9.attn.wq_b.cb_qweight",
+             torch.zeros(HID, BYTES, dtype=torch.uint8)),
+        ]))
+
+
+def test_dspark_quant_config_resolves_construction_layers_not_registered_ones():
+    pytest.importorskip("vllm")
+    from gridbook.config import PrismaQuantConfig
+
+    scheme = {
+        "grid": "fp4",
+        "mode": "product",
+        "k": 15,
+        "n_sub": 2,
+        "type_size": 69,
+        "group_size": 16,
+        "vec_dim": 8,
+        "scale_coding": {"kind": "two_tier"},
+        "codebook_ref": ["cb0", "cb1"],
+    }
+    targets = []
+    for layer in range(43, 46):
+        targets.extend((
+            f"model.layers.{layer}.attn.wq_b",
+            f"model.layers.{layer}.ffn.experts.gate_up_proj",
+            f"model.layers.{layer}.ffn.experts.down_proj",
+        ))
+    config = PrismaQuantConfig.from_config({
+        "quant_method": "gridbook",
+        "format": "nvfp4_cb",
+        "config_groups": {
+            "dspark": {"scheme": scheme, "targets": targets},
+        },
+        "ignore": [],
+    })
+    config._ensure_resolved()
+
+    for layer in range(43, 46):
+        assert config._scheme_for_prefix(
+            f"model.layers.{layer}.attn.wq_b"
+        ) is not None
+        assert config._moe_scheme_for_prefix(
+            f"model.layers.{layer}.ffn.experts"
+        ) is not None
+    assert config._scheme_for_prefix("model.layers.0.attn.wq_b") is None
+    assert config._moe_scheme_for_prefix(
+        "model.layers.0.ffn.experts"
+    ) is None
+
+
+def test_real_vllm_dspark_entrypoint_is_registered_and_structural():
+    pytest.importorskip("vllm")
+    from gridbook.plugin import _install_on_module_classes
+
+    module_path = "vllm.models.deepseek_v4.nvidia.dspark"
+    assert module_path in load_runtime_contract()[
+        "producer_profiles"
+    ]["top_level_loader_modules"]
+    cls = importlib.import_module(module_path).DSparkDeepseekV4ForCausalLM
+    assert cls.__module__ == module_path
+    assert callable(getattr(cls, "_remap_dspark_name", None))
+
+    _install_on_module_classes(module_path)
+    assert cls.__dict__.get("_pq_cb_wrapped") is True
+    assert getattr(cls.load_weights, "_pq_cb_wrapper", False) is True

--- a/tests/test_layer_registry.py
+++ b/tests/test_layer_registry.py
@@ -109,6 +109,134 @@ def test_live_moe_dispatch_keeps_output_contract():
     assert torch.equal(out, torch.full_like(x, 2))
 
 
+def test_moe_dispatch_neutralizes_only_vllm_padding_sentinel():
+    """A padded route is inert before any owned MoE implementation sees it.
+
+    vLLM's static dummy/profile batches use expert id ``-1`` for all routed
+    slots of padding tokens.  The normalization belongs at the one opaque
+    dispatch boundary so uniform-CB, mixed-CB, decode and prefill cannot drift.
+    Other ids remain unchanged, and the caller-owned tensors are not mutated.
+    """
+    seen = {}
+
+    class _RecordingMethod:
+        def _apply_inline(self, layer, x, topk_weights, topk_ids):
+            del layer
+            seen["x"] = x.clone()
+            seen["weights"] = topk_weights.clone()
+            seen["ids"] = topk_ids.clone()
+            return torch.zeros_like(x)
+
+    method = _RecordingMethod()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+    x = torch.arange(12, dtype=torch.float32).view(3, 4)
+    weights = torch.tensor([
+        [float("nan"), 0.25],
+        [0.50, 0.75],
+        [1.00, float("nan")],
+    ])
+    ids = torch.tensor([
+        [-1, 2],
+        [-2, 4],
+        [999, -1],
+    ], dtype=torch.int32)
+    original_weights = weights.clone()
+    original_ids = ids.clone()
+
+    out = ops.cb_moe_forward(x, weights, ids, layer_id)
+
+    assert torch.equal(out, torch.zeros_like(x))
+    assert torch.equal(seen["x"], x)
+    assert torch.equal(seen["ids"], torch.tensor([
+        [0, 2],
+        [-2, 4],
+        [999, 0],
+    ], dtype=torch.int32))
+    assert torch.equal(seen["weights"], torch.tensor([
+        [0.0, 0.25],
+        [0.50, 0.75],
+        [1.00, 0.0],
+    ]))
+    assert torch.equal(ids, original_ids)
+    torch.testing.assert_close(weights, original_weights, equal_nan=True)
+
+
+def test_moe_padding_normalization_has_no_host_read():
+    """Sentinel handling remains capture-safe and inside the opaque op."""
+    import inspect
+
+    source = inspect.getsource(ops._neutralize_moe_padding_sentinel)
+    for forbidden in (".item(", ".cpu(", ".tolist(", "bool("):
+        assert forbidden not in source
+    assert "== -1" in source
+    assert source.count("masked_fill") == 2
+
+
+def test_moe_custom_op_fake_and_schema_contract():
+    method = _MoEMethod()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+    x = torch.ones((3, 7))
+    weights = torch.ones((3, 2))
+    ids = torch.zeros((3, 2), dtype=torch.int64)
+
+    torch.library.opcheck(
+        ops.cb_moe_forward, (x, weights, ids, layer_id))
+
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode() as mode:
+        fake_out = ops.cb_moe_forward(
+            mode.from_tensor(x), mode.from_tensor(weights),
+            mode.from_tensor(ids), layer_id)
+    assert fake_out.shape == x.shape
+    assert fake_out.dtype == x.dtype
+
+
+def test_moe_custom_op_compiles_opaque_with_padding_normalization():
+    """Fullgraph records one op; normalization runs only in its backend."""
+    traced = []
+    seen = []
+
+    class _RecordingMethod:
+        def _apply_inline(self, layer, x, topk_weights, topk_ids):
+            del layer
+            seen.append((topk_weights.clone(), topk_ids.clone()))
+            return torch.zeros_like(x)
+
+    method = _RecordingMethod()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+
+    def backend(graph, example_inputs):
+        del example_inputs
+        traced.append(graph)
+        return graph.forward
+
+    def forward(x, weights, ids):
+        return ops.cb_moe_forward(x, weights, ids, layer_id)
+
+    compiled = torch.compile(forward, backend=backend, fullgraph=True)
+    x = torch.ones((2, 4))
+    weights = torch.tensor([[0.25, 0.75], [1.0, 1.0]])
+    ids = torch.tensor([[2, 3], [-1, -1]], dtype=torch.int32)
+    out = compiled(x, weights, ids)
+
+    assert torch.equal(out, torch.zeros_like(x))
+    assert len(traced) == 1
+    nodes = [node for node in traced[0].graph.nodes
+             if node.op == "call_function"
+             and "prismaquant" in str(node.target)]
+    assert len(nodes) == 1
+    assert len(seen) == 1
+    seen_weights, seen_ids = seen[0]
+    assert torch.equal(seen_weights, torch.tensor([
+        [0.25, 0.75], [0.0, 0.0]]))
+    assert torch.equal(seen_ids, torch.tensor([
+        [2, 3], [0, 0]], dtype=torch.int32))
+
+
 def test_linear_custom_op_fake_and_schema_contract():
     method = _Method()
     layer = _Layer()
@@ -234,8 +362,9 @@ def test_capture_size_gate_constants_match_the_dispatch_boundaries():
     from gridbook import moe
 
     assert ops._DENSE_DECODE_MAX == CUDA_GEMV_M_MAX
+    assert ops._MOE_DECODE_MAX == moe.MOE_PREFILL_M_THRESHOLD
     source = inspect.getsource(moe.PrismaQuantCBMoEMethod._apply_inline)
-    assert f"num_tokens <= {ops._MOE_DECODE_MAX}" in source
+    assert "num_tokens <= MOE_PREFILL_M_THRESHOLD" in source
 
 
 def test_capture_size_advisory_is_silent_without_a_vllm_config(capsys):

--- a/tests/test_no_triton_runtime.py
+++ b/tests/test_no_triton_runtime.py
@@ -397,6 +397,9 @@ _CONTRACT_MODEL_MODULES = {
     # plugin.py installs on the defining module (__module__ guard), so that is
     # the path the contract names and the path reviewed here.
     "vllm.models.deepseek_v4.nvidia.model",
+    # DSpark is defined separately and consumes the checkpoint's ``mtp.*``
+    # draft payload through its own top-level loader.
+    "vllm.models.deepseek_v4.nvidia.dspark",
 }
 
 

--- a/tests/test_nvfp4_static_runtime.py
+++ b/tests/test_nvfp4_static_runtime.py
@@ -133,6 +133,18 @@ def _config(scales, *, scheme=None, targets=None, contract=True):
     return result
 
 
+def _dspark_config(scales, construction_to_physical, *, hidden=43,
+                   n_mtp=3):
+    config = _config(scales, targets=list(construction_to_physical))
+    config["dspark_target_bridge"] = {
+        "schema": "gridbook.dspark-target-bridge.v1",
+        "num_hidden_layers": hidden,
+        "n_mtp_layers": n_mtp,
+        "construction_to_physical": dict(construction_to_physical),
+    }
+    return config
+
+
 def _resolved(tmp_path, scales, *, cfg=None):
     _write_f32_scalars(
         tmp_path / "model.safetensors",
@@ -182,6 +194,207 @@ def test_config_attests_complete_physical_payload(tmp_path):
 
     cfg.apply_vllm_mapper(Mapper())
     assert cfg.activation_scales_for_targets(["served." + target]) == [3.25]
+
+
+def test_dspark_bridge_attests_mtp_physical_scalars_for_construction_targets(
+        tmp_path):
+    construction = {
+        "model.layers.44.ffn.experts.gate_up_proj":
+            "mtp.1.ffn.experts.gate_up_proj",
+        "model.layers.44.ffn.experts.down_proj":
+            "mtp.1.ffn.experts.down_proj",
+        "model.layers.44.blocks.0.proj": "mtp.1.blocks.0.proj",
+    }
+    scales = {
+        "mtp.1.ffn.experts.gate_up_proj": 2.5,
+        "mtp.1.ffn.experts.down_proj": 1.25,
+        "mtp.1.blocks.0.proj": 0.5,
+    }
+    cfg = _resolved(
+        tmp_path,
+        scales,
+        cfg=_dspark_config(scales, construction),
+    )
+
+    assert cfg._target_physical_name == construction
+    assert cfg._dspark_target_bridge_topology == (43, 3)
+    prefix = "model.layers.44.ffn.experts"
+    stages = cfg.moe_activation_stage_targets(prefix)
+    assert stages == {
+        "w13": [prefix + ".gate_up_proj"],
+        "w2": [prefix + ".down_proj"],
+    }
+    assert cfg.activation_scales_for_targets(stages["w13"]) == [2.5]
+    assert cfg.activation_scales_for_targets(stages["w2"]) == [1.25]
+
+
+def test_dspark_bridge_keeps_delegated_stock_nvfp4_target_physical(
+        tmp_path, monkeypatch):
+    """A contracted stock target crosses the same explicit DSpark bridge.
+
+    The bridge covers the complete activation contract, not only Gridbook's
+    custom-CB subset.  Quantization construction must delegate the
+    ``model.layers.L+stage`` spelling to compressed-tensors, while payload
+    attestation must resolve that target to the physical ``mtp.stage`` scalar.
+    """
+
+    from gridbook import config as config_module
+
+    cb_target = "model.layers.44.ffn.experts.down_proj"
+    stock_target = "model.layers.44.attn.wq_b"
+    cb_physical = "mtp.1.ffn.experts.down_proj"
+    stock_physical = "mtp.1.attn.wq_b"
+    construction_to_physical = {
+        cb_target: cb_physical,
+        stock_target: stock_physical,
+    }
+    scales = {cb_physical: 1.25, stock_physical: 2.75}
+    config = _dspark_config(scales, construction_to_physical)
+    config["config_groups"]["cb"]["targets"] = [cb_target]
+    stock_group = {
+        "format": "nvfp4-pack-quantized",
+        "targets": [stock_target],
+        "weights": {
+            "num_bits": 4,
+            "type": "float",
+            "strategy": "tensor_group",
+            "group_size": 16,
+        },
+        "input_activations": {
+            "num_bits": 4,
+            "type": "float",
+            "strategy": "tensor_group",
+            "group_size": 16,
+            "dynamic": "local",
+        },
+    }
+    config["config_groups"]["stock_nvfp4"] = stock_group
+
+    delegated: dict[str, object] = {}
+    compressed_package_name = (
+        "vllm.model_executor.layers.quantization.compressed_tensors"
+    )
+    compressed_module_name = compressed_package_name + ".compressed_tensors"
+    utils_module_name = compressed_package_name + ".utils"
+    compressed_package = types.ModuleType(compressed_package_name)
+    compressed_package.__path__ = []
+    compressed_module = types.ModuleType(compressed_module_name)
+
+    class _FakeCompressedTensorsConfig:
+        def __init__(self, raw):
+            self.raw = raw
+            self.packed_modules_mapping = {}
+
+        @classmethod
+        def from_config(cls, raw):
+            delegated["config"] = raw
+            return cls(raw)
+
+        def get_quant_method(self, layer, prefix):
+            del layer
+            delegated["prefix"] = prefix
+            return "stock-nvfp4-method"
+
+    compressed_module.CompressedTensorsConfig = _FakeCompressedTensorsConfig
+    utils_module = types.ModuleType(utils_module_name)
+
+    def find_matched_target(prefix, layer, targets, fused):
+        del layer, fused
+        return prefix if prefix in targets else None
+
+    utils_module.find_matched_target = find_matched_target
+    utils_module.should_ignore_layer = lambda *args, **kwargs: False
+    monkeypatch.setitem(
+        sys.modules, compressed_package_name, compressed_package
+    )
+    monkeypatch.setitem(sys.modules, compressed_module_name, compressed_module)
+    monkeypatch.setitem(sys.modules, utils_module_name, utils_module)
+
+    def record_preflight(**kwargs):
+        delegated["preflight"] = kwargs
+
+    monkeypatch.setattr(
+        config_module, "require_native_delegated_backend", record_preflight
+    )
+    cfg = _resolved(tmp_path, scales, cfg=config)
+
+    assert cfg._target_physical_name == construction_to_physical
+    assert cfg.activation_scales_for_targets([stock_target]) == [2.75]
+    assert cfg._stock_group_by_target == {stock_target: "stock_nvfp4"}
+    delegated_config = delegated["config"]
+    assert isinstance(delegated_config, dict)
+    assert "dspark_target_bridge" not in delegated_config
+    assert delegated_config["config_groups"] == {
+        "stock_nvfp4": stock_group
+    }
+
+    layer = config_module.LinearBase()
+    assert cfg.get_quant_method(layer, stock_target) == "stock-nvfp4-method"
+    assert delegated["prefix"] == stock_target
+    preflight = delegated["preflight"]
+    assert isinstance(preflight, dict)
+    assert preflight["prefix"] == stock_target
+    assert preflight["group_name"] == "stock_nvfp4"
+    assert preflight["group"] == stock_group
+
+
+@pytest.mark.parametrize(
+    ("construction", "physical", "message"),
+    [
+        ("model.layers.45.attn.wq_b", "mtp.1.attn.wq_b",
+         "expected num_hidden_layers \\+ stage = 44"),
+        ("model.layers.44.attn.wq_b", "mtp.3.attn.wq_b",
+         "outside n_mtp_layers=3"),
+        ("model.layers.44.attn.wq_b", "mtp.1.attn.wo_b",
+         "changes the target tail"),
+        ("layers.44.attn.wq_b", "mtp.1.attn.wq_b",
+         "not in the canonical namespace"),
+        ("model.layers.044.attn.wq_b", "mtp.1.attn.wq_b",
+         "invalid DSpark target bridge"),
+        ("model.layers.44.attn.wq_b", "mtp.01.attn.wq_b",
+         "invalid DSpark target bridge"),
+        ("model.layers.44.attn..wq_b", "mtp.1.attn..wq_b",
+         "invalid DSpark target bridge"),
+    ],
+)
+def test_dspark_bridge_rejects_topology_or_tail_mutation(
+        construction, physical, message):
+    scales = {physical: 2.5}
+    cfg = PrismaQuantConfig.from_config(_dspark_config(
+        scales, {construction: physical}
+    ))
+    with pytest.raises(ValueError, match=message):
+        cfg._ensure_resolved()
+
+
+def test_dspark_bridge_requires_exact_contracted_target_set_and_contract():
+    construction = "model.layers.44.attn.wq_b"
+    extra_construction = "model.layers.44.attn.wo_b"
+    physical = "mtp.1.attn.wq_b"
+    extra_physical = "mtp.1.attn.wo_b"
+    scales = {physical: 2.5, extra_physical: 3.5}
+    bridge = {
+        construction: physical,
+        extra_construction: extra_physical,
+    }
+    cfg_dict = _dspark_config(scales, bridge)
+    cfg_dict["config_groups"]["cb"]["targets"] = [construction]
+    cfg = PrismaQuantConfig.from_config(cfg_dict)
+    with pytest.raises(ValueError, match="declared by config_groups"):
+        cfg._ensure_resolved()
+
+    missing_contract = _config(
+        {physical: 2.5}, targets=[construction], contract=False
+    )
+    missing_contract["dspark_target_bridge"] = {
+        "schema": "gridbook.dspark-target-bridge.v1",
+        "num_hidden_layers": 43,
+        "n_mtp_layers": 3,
+        "construction_to_physical": {construction: physical},
+    }
+    cfg = PrismaQuantConfig.from_config(missing_contract)
+    with pytest.raises(ValueError, match="requires the nvfp4_w4a4"):
+        cfg._ensure_resolved()
 
 
 def test_moe_stage_resolution_keeps_gate_up_and_down_scales_distinct(tmp_path):
@@ -258,6 +471,17 @@ def test_legacy_fp4_config_does_not_read_or_register_scale(monkeypatch):
     )
     assert not hasattr(layer, "input_global_scale")
     assert method._fused_fp4_ok(layer, 256) is False
+
+
+def test_dense_cb_grouped_bmm_fails_closed_at_load():
+    """A DSv4-style grouped projection must use the qualified W8A16 lane."""
+
+    method = PrismaQuantCBLinearMethod.__new__(PrismaQuantCBLinearMethod)
+    method.prefix = "model.layers.43.attn.wo_a"
+    layer = types.SimpleNamespace(is_bmm=True)
+
+    with pytest.raises(RuntimeError, match="source FP8 W8A16"):
+        method.process_weights_after_loading(layer)
 
 
 def test_dense_contracted_scale_load_is_fail_closed_and_merged_exact(tmp_path):

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -36,6 +36,17 @@ ROOT = Path(__file__).resolve().parents[1]
 SDIST_ONLY_GLOBS = ("gridbook/csrc/tools/*",
                     "gridbook/csrc/cutlass_fork/*_orig.hpp")
 
+# Source-only validation entry points. ``check_dist.py`` applies this exact
+# floor to the built sdist and rejects any wheel leak; this source-level mirror
+# prevents a new utility from being named in only one packaging declaration.
+SDIST_REQUIRED_UTILITIES = (
+    "scripts/prepare_lfm_fused_validation.py",
+    "scripts/validate_fused_nvfp4_ab.py",
+    "scripts/validate_fused_nvfp4_three_arm.py",
+    "scripts/validate_moe_persistent_b_ab.py",
+    "scripts/validate_moe_gemv_v2_ab.py",
+)
+
 # The wheel must carry every source cuda_ext.py JIT-compiles. Same floor as
 # check_dist.REQUIRED / check_installed.REQUIRED_SOURCES, expressed against the
 # installed package.
@@ -82,6 +93,52 @@ def test_citation_and_changelog_match_package_version():
     assert re.search(rf"^## {re.escape(version)}(?:\s|$)", changelog,
                      flags=re.MULTILINE), (
         f"CHANGELOG.md has no release heading for {version}")
+
+
+def test_release_pinned_image_default_matches_package_version():
+    """The convenience image must not silently reinstall the prior release."""
+
+    if not _source_checkout():
+        pytest.skip("container recipe is not shipped in the wheel")
+    expected = f"v{gridbook.__version__}"
+    dockerfile = (
+        ROOT / "docker" / "Dockerfile.gridbook-pinned"
+    ).read_text(encoding="utf-8")
+    match = re.search(
+        r"^ARG GRIDBOOK_REF=([^\s]+)\s*$", dockerfile, flags=re.MULTILINE
+    )
+    assert match is not None, "pinned-image Dockerfile has no GRIDBOOK_REF"
+    assert match.group(1) == expected
+
+    container_doc = (ROOT / "docs" / "CONTAINER.md").read_text(
+        encoding="utf-8"
+    )
+    assert f"--build-arg GRIDBOOK_REF={expected}" in container_doc
+    assert f"gridbook:{expected}-pinned" in container_doc
+
+
+def test_release_workflow_rejects_tags_off_master():
+    """A tag alone must not authorize an off-release-branch upload."""
+
+    if not _source_checkout():
+        pytest.skip("release workflow is not shipped in the wheel")
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "fetch-depth: 0" in workflow
+    assert "Tag commit must be reachable from master" in workflow
+    assert 'git rev-parse "${GITHUB_REF}^{commit}"' in workflow
+    assert "refs/remotes/origin/master" in workflow
+    assert "git merge-base --is-ancestor" in workflow
+    assert workflow.index("Tag commit must be reachable from master") < (
+        workflow.index("Install build tooling")
+    )
+    assert "wheel_sha256: ${{ steps.meta.outputs.wheel_sha256 }}" in workflow
+    assert 'hashlib.file_digest(handle, "sha256")' in workflow
+    assert workflow.count("needs.build.outputs.wheel_sha256") == 3
+    assert "Downloaded wheel must match the build receipt" in workflow
+    assert "Downloaded wheel must match the verified build" in workflow
+    assert "Release wheel must match the published build" in workflow
 
 
 def test_sdist_only_split_is_declared_in_all_three_places():
@@ -145,6 +202,26 @@ def test_native_serving_floor_mirrors_are_exactly_equal():
     installed_floor = set(installed["REQUIRED_SOURCES"])
     metadata_floor = {f"csrc/{path}" for path in WHEEL_REQUIRED}
     assert dist_floor == installed_floor == metadata_floor
+
+
+def test_sdist_validation_utility_floor_matches_manifest_and_checkout():
+    """Every source-only harness must be present in the built-sdist gate.
+
+    ``check_dist.py::check_validation_utilities`` performs the artifact-level
+    membership test after build. This declaration test prevents CI's checkout
+    locator from masking an omitted MANIFEST entry before that build occurs.
+    """
+
+    if not _source_checkout():
+        pytest.skip("release packaging declarations are not shipped in the wheel")
+    manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    dist = runpy.run_path(str(ROOT / ".github/scripts/check_dist.py"))
+    assert tuple(dist["SDIST_REQUIRED_UTILITIES"]) == SDIST_REQUIRED_UTILITIES
+    for utility in SDIST_REQUIRED_UTILITIES:
+        assert (ROOT / utility).is_file(), f"missing source utility {utility}"
+        assert f"include {utility}" in manifest, (
+            f"{utility} is gated for the built sdist but MANIFEST.in omits it"
+        )
 
 
 def test_cpu_gate_locates_source_utilities_without_ci_environment(tmp_path):

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -34,8 +34,9 @@ def test_packaged_contract_loads_and_validates():
     contract = load_runtime_contract()
     assert contract == raw
     assert contract["schema"] == RUNTIME_CONTRACT_SCHEMA
-    assert contract["contract_version"] == 3
+    assert contract["contract_version"] == 4
     assert contract["abi_features"] == {
+        "dspark_construction_physical_bridge": 1,
         "routed_moe_per_role_codebook_lut": 1,
         "source_fp8_block128_w8a16": 1,
     }
@@ -112,6 +113,9 @@ def test_contract_matches_runtime_registration_and_loader_table():
         # class is DEFINED in the platform submodule, which is what plugin.py
         # has to match on (ROADMAP D0.1).
         "vllm.models.deepseek_v4.nvidia.model",
+        # The DSpark draft is a separate entrypoint with its own top-level
+        # loader and physical ``mtp.*`` namespace.
+        "vllm.models.deepseek_v4.nvidia.dspark",
     ]
     assert set(profiles["supported_ids"]) == {
         "deepseek_v4", "hy_v3", "laguna", "qwen3", "qwen3_5", "qwen3_5_dense",
@@ -190,6 +194,14 @@ def _wrong_per_role_lut_capability(contract):
     contract["abi_features"]["routed_moe_per_role_codebook_lut"] = 2
 
 
+def _missing_dspark_bridge_capability(contract):
+    del contract["abi_features"]["dspark_construction_physical_bridge"]
+
+
+def _wrong_dspark_bridge_capability(contract):
+    contract["abi_features"]["dspark_construction_physical_bridge"] = 2
+
+
 def _missing_source_fp8_w8a16_capability(contract):
     del contract["abi_features"]["source_fp8_block128_w8a16"]
 
@@ -217,6 +229,9 @@ def _unsupported_format_mode(contract):
         (_missing_per_role_lut_capability,
          "routed_moe_per_role_codebook_lut"),
         (_wrong_per_role_lut_capability, "must be 1"),
+        (_missing_dspark_bridge_capability,
+         "dspark_construction_physical_bridge"),
+        (_wrong_dspark_bridge_capability, "must be 1"),
         (_missing_source_fp8_w8a16_capability,
          "source_fp8_block128_w8a16"),
         (_wrong_source_fp8_w8a16_capability, "must be 1"),

--- a/tests/test_validate_moe_gemv_v2_ab.py
+++ b/tests/test_validate_moe_gemv_v2_ab.py
@@ -1,0 +1,458 @@
+"""CPU contract tests for the exact-DSV4 CB-GEMV-v2 quality A/B."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import inspect
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _script_path() -> Path:
+    roots = [Path(__file__).resolve().parents[1]]
+    for variable in ("GRIDBOOK_SOURCE_ROOT", "GITHUB_WORKSPACE"):
+        value = os.environ.get(variable)
+        if value:
+            roots.append(Path(value).expanduser())
+    for root in roots:
+        candidate = root / "scripts" / "validate_moe_gemv_v2_ab.py"
+        if candidate.is_file():
+            return candidate.resolve()
+    raise FileNotFoundError("validate_moe_gemv_v2_ab.py")
+
+
+SCRIPT = _script_path()
+SPEC = importlib.util.spec_from_file_location("validate_moe_gemv_v2_ab", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+gemv = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = gemv
+SPEC.loader.exec_module(gemv)
+
+
+def test_release_profile_and_artifact_constants_are_value_closed():
+    assert gemv._PROFILE_SAMPLES == 8
+    assert gemv._PROFILE_SEQLEN == 16
+    assert gemv._QUALITY_REPEATS == 2
+    assert gemv._EXPECTED_PREFIX_TENSOR_SHA256 == (
+        "11c40cbfd3819f72f18507f359787f479ff06d30fd6e30f697c3bc4e0b4b99f7"
+    )
+    assert gemv._EXPECTED_PREFIX_JSON_SHA256 == (
+        "9ed265d2e7202f2282a225929e55faef2a0f87b4508fe8fca10378de500b8c85"
+    )
+    assert gemv._EXPECTED_ARTIFACT == {
+        "config_sha256": (
+            "cf07dd1184989ce21a3aa8a21815feb234bcec6385763ae2fcb2781bde015a89"
+        ),
+        "quant_config_sha256": (
+            "6ecb5ffaca90a9ca3f5095df0d788381f9d3451dcb2c0ec5426ec736b26844ef"
+        ),
+        "codebook_sha256": (
+            "ec893b2e56354d1ce8f8a5f613937a8b60b7cf7d2e08e590e114376cbabecc0c"
+        ),
+        "weight_sha256": (
+            "d347c32304e50aa2e8904593744f1e38f7fa1a4a54aece47ae9b3b3e6c8b5334"
+        ),
+        "weight_bytes": 112_349_037_959,
+        "codebook_relative_path": "cb_codebooks.pqcb",
+    }
+    assert len(gemv._EXPECTED_FP4_LAYER_IDS) == 35
+    assert len(gemv._EXPECTED_FP8_LAYER_IDS) == 8
+    assert gemv._EXPECTED_FP4_LAYER_IDS.isdisjoint(
+        gemv._EXPECTED_FP8_LAYER_IDS
+    )
+    assert gemv._EXPECTED_FP4_LAYER_IDS | gemv._EXPECTED_FP8_LAYER_IDS == set(
+        range(43)
+    )
+
+
+def test_decode_profile_is_exact_8x16_and_digest_guarded(monkeypatch):
+    windows = [
+        list(range(index * 512, (index + 1) * 512))
+        for index in range(8)
+    ]
+    prompts = [window[:16] for window in windows]
+    flattened = [token for prompt in prompts for token in prompt]
+    tensor_digest = hashlib.sha256(
+        struct.pack(f"<{len(flattened)}q", *flattened)
+    ).hexdigest()
+    json_digest = gemv.pb._canonical_sha256(prompts)
+    monkeypatch.setattr(gemv, "_EXPECTED_PREFIX_TENSOR_SHA256", tensor_digest)
+    monkeypatch.setattr(gemv, "_EXPECTED_PREFIX_JSON_SHA256", json_digest)
+    observed, record = gemv._decode_profile(windows)
+    assert observed == prompts
+    assert record["n_samples"] == 8
+    assert record["seqlen"] == 16
+    assert record["positions_per_repeat"] == 120
+    assert record["total_scored_positions"] == 240
+    windows[0][0] += 1
+    with pytest.raises(RuntimeError, match="not the canonical DSV4 decode"):
+        gemv._decode_profile(windows)
+
+
+def _provenance() -> dict:
+    expected = gemv._EXPECTED_ARTIFACT
+    return {
+        "config": {"sha256": expected["config_sha256"]},
+        "quant_config": {"sha256": expected["quant_config_sha256"]},
+        "codebook_file": {
+            "sha256": expected["codebook_sha256"],
+            "relative_path": expected["codebook_relative_path"],
+        },
+        "weight_files": {
+            "model.safetensors": {
+                "sha256": expected["weight_sha256"],
+                "bytes": expected["weight_bytes"],
+            }
+        },
+    }
+
+
+def test_artifact_gate_matches_every_exact_file_field():
+    assert gemv._artifact_gate(_provenance())["pass"] is True
+    changed = _provenance()
+    changed["weight_files"]["model.safetensors"]["sha256"] = "0" * 64
+    gate = gemv._artifact_gate(changed)
+    assert gate["pass"] is False
+    assert gate["checks"]["weight_sha256"] is False
+    assert gemv._artifact_gate(None)["pass"] is False
+
+
+def test_qualified_runtime_requires_exact_true_moe_skip_padding():
+    assert gemv._moe_skip_padding_gate(True)["pass"] is True
+    assert gemv._moe_skip_padding_gate(False)["pass"] is False
+    assert gemv._moe_skip_padding_gate(1)["pass"] is False
+    source = inspect.getsource(gemv.run)
+    assert "vllm_envs.VLLM_MOE_SKIP_PADDING" in source
+    assert "VLLM_MOE_SKIP_PADDING=True" in source
+
+
+def test_gemv_provenance_names_only_existing_hashed_sources(tmp_path):
+    package = tmp_path / "gridbook"
+    csrc = package / "csrc"
+    csrc.mkdir(parents=True)
+    sources = {
+        "moe_gemv_select.py": package / "moe_gemv_select.py",
+        "cb_gemv.cu": csrc / "cb_gemv.cu",
+        "cb_gemv_v2.cu": csrc / "cb_gemv_v2.cu",
+    }
+    for label, path in sources.items():
+        path.write_text(f"// {label}\n", encoding="utf-8")
+    helper = tmp_path / "validate_moe_persistent_b_ab.py"
+    helper.write_text("# helper\n", encoding="utf-8")
+    runtime = {
+        "gridbook": {"package_root": str(package)},
+        "source_files": {},
+        "source_sha256": {},
+        "harness": {"shared_helpers": {}},
+    }
+    original_helper_file = gemv.pb.__file__
+    try:
+        gemv.pb.__file__ = str(helper)
+        gemv._augment_provenance(runtime)
+    finally:
+        gemv.pb.__file__ = original_helper_file
+    assert set(runtime["source_files"]) == set(sources)
+    for label, record in runtime["source_files"].items():
+        path = Path(record["path"])
+        assert path.is_file(), label
+        assert record["sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+        assert runtime["source_sha256"][label] == record["sha256"]
+    helper_record = runtime["harness"]["shared_helpers"][
+        "persistent_b_validation_api"
+    ]
+    assert Path(helper_record["path"]).is_file()
+    assert helper_record["sha256"] == hashlib.sha256(helper.read_bytes()).hexdigest()
+
+
+class _Shape:
+    def __init__(self, *shape: int):
+        self.shape = shape
+
+
+class _Method:
+    def __init__(self, index: int, *, fp4: bool):
+        self.prefix = f"model.layers.{index}.ffn.experts"
+        self.is_fp4 = fp4
+        self.is_v2 = fp4
+        self.k = 16 if index in gemv._EXPECTED_K16_LAYER_IDS else (
+            18 if fp4 else 28
+        )
+        self.n_sub = 2 if fp4 else 4
+        self.type_size = 4 * self.k + 9 if fp4 else 112
+
+    def _apply_grouped_decode(self, layer, x, topk_weights, topk_ids, act):
+        if self.is_fp4:
+            op = (
+                layer._test_ops.cb_moe_gemv_v2
+                if layer._cb_use_v2_w13
+                else layer._test_ops.cb_moe_gemv_fp4_v2
+            )
+            _invoke_op(op, stage="w13")
+            op = (
+                layer._test_ops.cb_moe_gemv_v2
+                if layer._cb_use_v2_w2
+                else layer._test_ops.cb_moe_gemv_fp4_v2
+            )
+            _invoke_op(op, stage="w2")
+        else:
+            _invoke_op(layer._test_ops.cb_moe_gemv_fp8, stage="w13")
+            _invoke_op(layer._test_ops.cb_moe_gemv_fp8, stage="w13")
+            _invoke_op(layer._test_ops.cb_moe_gemv_fp8, stage="w2")
+        return (layer, x, topk_weights, topk_ids, act)
+
+
+class _Layer:
+    def __init__(self, *, fp4: bool):
+        self._cb_use_v2_w13 = fp4
+        self._cb_use_v2_w2 = fp4
+        self._cb_hidden = 4096
+        self._cb_inter = 2048
+        self._cb_role_split = not fp4
+
+
+def _fake_runtime():
+    entries = {}
+    registry = {}
+    for index in range(43):
+        fp4 = index in gemv._EXPECTED_FP4_LAYER_IDS
+        entries[index] = (_Method(index, fp4=fp4), _Layer(fp4=fp4))
+        registry[index] = object()
+
+    def _op(name):
+        def call(*args, **kwargs):
+            return (name, args, kwargs)
+        return call
+
+    ops = SimpleNamespace(
+        _LAYER_REGISTRY=registry,
+        _lookup_cb_layer=lambda layer_id: entries[layer_id],
+        cb_moe_gemv_fp4_v2=_op("inherited"),
+        cb_moe_gemv_v2=_op("v2"),
+        cb_moe_gemv_fp8=_op("fp8"),
+    )
+    for _method, layer in entries.values():
+        layer._test_ops = ops
+    moe = SimpleNamespace(PrismaQuantCBMoEMethod=_Method)
+    return ops, moe, entries
+
+
+def test_controller_attests_exact_inventory_and_restores_every_stack():
+    ops, moe, _entries = _fake_runtime()
+    controller = gemv.GemvV2ArmController(ops=ops, moe=moe)
+    assert controller.inventory_gate["pass"] is True
+    assert controller.inventory_gate["observed_fp4_stack_booleans"] == 70
+    assert controller.inventory_gate["observed_fp8_stack_booleans"] == 16
+    with controller.arm("baseline", label="test") as record:
+        assert all(
+            binding.layer._cb_use_v2_w13 is False
+            and binding.layer._cb_use_v2_w2 is False
+            for binding in controller.fp4
+        )
+    assert record["pass"] is True
+    assert controller.restoration_gate()["pass"] is True
+    assert all(
+        binding.layer._cb_use_v2_w13 is True
+        and binding.layer._cb_use_v2_w2 is True
+        for binding in controller.fp4
+    )
+
+
+def test_controller_rejects_one_selector_fallback_at_load():
+    ops, moe, entries = _fake_runtime()
+    entries[0][1]._cb_use_v2_w2 = False
+    with pytest.raises(RuntimeError, match="inventory is not exact"):
+        gemv.GemvV2ArmController(ops=ops, moe=moe)
+
+
+def _invoke_op(op, *, stage: str):
+    tokens = 16
+    pairs = tokens * gemv._EXPECTED_TOPK
+    xq = _Shape(tokens if stage == "w13" else pairs, 4096)
+    qw = _Shape(256, 4096, 1)
+    pair = _Shape(pairs)
+    return op(xq, qw, _Shape(1), _Shape(1), pair, pair)
+
+
+def _simulate_request(
+    *, arm: str, controller, probe, entries, ops
+) -> tuple[dict, dict]:
+    with controller.arm(arm, label=f"test:{arm}") as selector:
+        with probe.request(label=f"test:{arm}", arm=arm, expected_tokens=16) as rec:
+            for index in range(43):
+                method, layer = entries[index]
+                method._apply_grouped_decode(
+                    layer, _Shape(16, 4096), _Shape(16, 6), _Shape(16, 6), "silu"
+                )
+    return selector, rec
+
+
+@pytest.mark.parametrize("arm", gemv.ARMS)
+def test_dispatch_probe_proves_exact_per_layer_and_cuda_op_routes(arm):
+    ops, moe, entries = _fake_runtime()
+    controller = gemv.GemvV2ArmController(ops=ops, moe=moe)
+    originals = {
+        name: getattr(ops, attr)
+        for name, attr in gemv.GemvDispatchProbe._OP_ATTRS.items()
+    }
+    probe = gemv.GemvDispatchProbe(
+        ops=ops, moe=moe, controller=controller
+    )
+    probe.install()
+    selector, record = _simulate_request(
+        arm=arm, controller=controller, probe=probe, entries=entries, ops=ops
+    )
+    assert selector["pass"] is True
+    assert record["pass"] is True
+    assert record["observed_layer_count"] == 43
+    assert record["observed_op_counts"] == (
+        {"inherited": 70, "fp8": 24}
+        if arm == "baseline" else {"v2": 70, "fp8": 24}
+    )
+    assert len(record["fp8_signature"]) == 24
+    probe.restore()
+    assert probe.restoration_gate()["pass"] is True
+    assert all(
+        getattr(ops, attr) is originals[name]
+        for name, attr in gemv.GemvDispatchProbe._OP_ATTRS.items()
+    )
+
+
+def test_dispatch_probe_fails_closed_on_unscoped_or_incomplete_request():
+    ops, moe, _entries = _fake_runtime()
+    controller = gemv.GemvV2ArmController(ops=ops, moe=moe)
+    probe = gemv.GemvDispatchProbe(ops=ops, moe=moe, controller=controller)
+    probe.install()
+    with pytest.raises(RuntimeError, match="outside a request scope"):
+        _invoke_op(ops.cb_moe_gemv_v2, stage="w13")
+    with probe.request(label="empty", arm="fused", expected_tokens=16) as record:
+        pass
+    assert record["pass"] is False
+    assert record["violations"]
+    probe.restore()
+    assert probe.restoration_gate()["pass"] is False
+    assert probe.restoration_gate()["unscoped_calls"]
+
+
+def _digest_record(*, score="a" * 64):
+    return {
+        "positions": 15,
+        "vocab_size": 129_280,
+        "row_sha256": ["b" * 64] * 15,
+        "score_sha256": score,
+        "prompt_token_ids_sha256": "c" * 64,
+        "mean_nll": 1.0,
+        "ppl": 2.718281828,
+    }
+
+
+def _quality_pairs():
+    pairs = []
+    for repeat in range(2):
+        for prompt in range(8):
+            block = repeat * 8 + prompt
+            signature = [{"stage": "w13", "tokens": 16}]
+            pairs.append({
+                "prompt_index": block,
+                "block_index": block,
+                "repeat_index": repeat,
+                "source_prompt_index": prompt,
+                "pair_order": list(gemv.v5.paired_arm_order(repeat + prompt)),
+                "score_digests": {
+                    "baseline": _digest_record(),
+                    "fused": _digest_record(),
+                },
+                "dispatch": {
+                    "baseline": {"fp8_signature": signature},
+                    "fused": {"fp8_signature": list(signature)},
+                },
+            })
+    return pairs
+
+
+def test_quality_evidence_gates_are_per_source_full_vocab_and_fp8_invariant():
+    pairs = _quality_pairs()
+    assert gemv.pb._pair_order_gate(pairs)["pass"] is True
+    assert gemv.pb._full_vocab_repeat_determinism_gate(
+        pairs, n_prompts=8, repeats=2
+    )["pass"] is True
+    assert gemv._score_cardinality_gate(
+        pairs, vocab_size=129_280
+    )["pass"] is True
+    assert gemv._fp8_dispatch_invariance_gate(pairs)["pass"] is True
+    pairs[8]["score_digests"]["fused"]["score_sha256"] = "0" * 64
+    assert gemv.pb._full_vocab_repeat_determinism_gate(
+        pairs, n_prompts=8, repeats=2
+    )["pass"] is False
+    pairs[0]["dispatch"]["fused"]["fp8_signature"] = []
+    assert gemv._fp8_dispatch_invariance_gate(pairs)["pass"] is False
+
+
+def test_parser_fixes_workload_engine_and_requires_explicit_gate(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    base = [
+        "--model", str(model),
+        "--prompt-token-ids-json", str(tmp_path / "inputs.json"),
+        "--output", str(tmp_path / "out.json"),
+    ]
+    measured = gemv.parse_args([*base, "--measurement-only"])
+    assert measured.n_samples == 8
+    assert measured.seqlen == 16
+    assert measured.teacher_full_vocab_kl is True
+    assert measured.quantization == "gridbook"
+    assert measured.tokenizer_mode == "deepseek_v4"
+    assert measured.kv_cache_dtype == "fp8"
+    args = gemv.parse_args([
+        *base,
+        "--max-mean-kl", "0.0001",
+        "--max-mean-nll-regression", "0.00498754",
+        "--max-ppl-relative-regression", "0.005",
+    ])
+    assert args.measurement_only is False
+    with pytest.raises(SystemExit):
+        gemv.parse_args(base)
+    with pytest.raises(SystemExit):
+        gemv.parse_args([*base, "--measurement-only", "--max-mean-kl", "0.1"])
+    with pytest.raises(SystemExit):
+        gemv.parse_args([
+            *base, "--measurement-only", "--kv-cache-dtype", "auto"
+        ])
+    measured.kv_cache_dtype = "auto"
+    with pytest.raises(RuntimeError, match="requires kv_cache_dtype='fp8'"):
+        gemv.run(measured)
+
+
+def test_harness_reuses_shared_loader_streaming_scorer_and_thresholds():
+    source = inspect.getsource(gemv.run)
+    assert "validation_common.prepare_validation" in source
+    assert "validation_common.load_candidate_engine" in source
+    assert "pb._compact_full_vocab_score" in source
+    assert "v5._new_quality_accumulator" in source
+    assert "v5._accumulate_quality_pair" in source
+    assert "v5._finish_quality_accumulator" in source
+    assert "v5._configured_gates" in source
+    assert "PRISMAQUANT_CB_GEMV" not in inspect.getsource(
+        gemv.GemvV2ArmController.arm
+    )
+    assert gemv.ARM_LABELS == {
+        "baseline": "inherited_default_grouped_fp4_v2",
+        "fused": "smem_resident_dictionary_v2",
+    }
+
+
+def test_environment_guard_requires_unmodified_inherited_default(monkeypatch):
+    monkeypatch.setenv(gemv.GEMV_ENV, "v2")
+    monkeypatch.setenv(gemv.DECODE_CONTRACT_ENV, "v1")
+    for name in gemv.W2_SCHEDULE_ENVS:
+        monkeypatch.delenv(name, raising=False)
+    gemv._assert_measurement_environment()
+    monkeypatch.setenv("PRISMAQUANT_CB_W2_SCHED", "rowpack")
+    with pytest.raises(RuntimeError, match="changed mid-run"):
+        gemv._assert_measurement_environment()

--- a/tests/test_validate_moe_persistent_b_ab.py
+++ b/tests/test_validate_moe_persistent_b_ab.py
@@ -1,0 +1,1086 @@
+"""CPU contract tests for the persistent-B whole-model quality A/B."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _script_path() -> Path:
+    roots = [Path(__file__).resolve().parents[1]]
+    for variable in ("GRIDBOOK_SOURCE_ROOT", "GITHUB_WORKSPACE"):
+        value = os.environ.get(variable)
+        if value:
+            roots.append(Path(value).expanduser())
+    for root in roots:
+        candidate = root / "scripts" / "validate_moe_persistent_b_ab.py"
+        if candidate.is_file():
+            return candidate.resolve()
+    raise FileNotFoundError("validate_moe_persistent_b_ab.py")
+
+
+SCRIPT = _script_path()
+SPEC = importlib.util.spec_from_file_location(
+    "validate_moe_persistent_b_ab", SCRIPT
+)
+assert SPEC is not None and SPEC.loader is not None
+pb = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = pb
+SPEC.loader.exec_module(pb)
+
+
+def _file_descriptor(path: Path) -> dict:
+    return pb.v5._required_file_record(path)
+
+
+def _write_gold_payload(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    windows: list[list[int]] | None = None,
+) -> tuple[Path, Path]:
+    model = root / "model"
+    model.mkdir()
+    (model / "tokenizer.json").write_text('{"test":true}\n', encoding="utf-8")
+    (model / "tokenizer_config.json").write_text("{}\n", encoding="utf-8")
+    files = {
+        name: _file_descriptor(model / name)
+        for name in ("tokenizer.json", "tokenizer_config.json")
+    }
+    tokenizer = {
+        "schema": "prismaquant.tokenizer_identity/1",
+        "content_sha256": pb._canonical_sha256({"files": files}),
+        "files": files,
+    }
+    windows = windows or [[1, 2, 3], [4, 5, 6]]
+    flattened = [token for window in windows for token in window]
+    tensor_digest = pb.hashlib.sha256(
+        struct.pack(f"<{len(flattened)}q", *flattened)
+    ).hexdigest()
+    full_selection = dict(pb._CANONICAL_FULL_KL_SELECTION)
+    full_selection.update({
+        "n_samples": len(windows),
+        "seqlen": len(windows[0]),
+        "starts": list(range(len(windows))),
+    })
+    ppl_ids = [1, 2]
+    ppl_selection = dict(pb._CANONICAL_PPL_SELECTION)
+    ppl_selection["n_tokens"] = len(ppl_ids)
+    payload = {
+        "schema": pb._FULL_KL_SCHEMA,
+        "datasets_distribution": dict(pb._CANONICAL_DATASETS_DISTRIBUTION),
+        "corpus_construction": dict(pb._CANONICAL_CORPUS_CONSTRUCTION),
+        "tokenizer": tokenizer,
+        "full_kl": {
+            "dataset": dict(pb._CANONICAL_FULL_KL_DATASET),
+            "selection": full_selection,
+            "token_ids": windows,
+            "token_ids_tensor_sha256": tensor_digest,
+        },
+        "ppl": {
+            "dataset": dict(pb._CANONICAL_PPL_DATASET),
+            "selection": ppl_selection,
+            "token_ids": ppl_ids,
+            "token_ids_sha256": pb._canonical_sha256(ppl_ids),
+        },
+    }
+    payload["semantic_sha256"] = pb._canonical_sha256(payload)
+    # Unit fixtures are deliberately tiny; patch only the immutable expected
+    # values that their content necessarily changes. Separate tests below pin
+    # every production constant and prove that re-sealing cannot evade them.
+    monkeypatch.setattr(
+        pb, "_CANONICAL_INPUT_SEMANTIC_SHA256", payload["semantic_sha256"]
+    )
+    monkeypatch.setattr(
+        pb, "_CANONICAL_TOKENIZER_CONTENT_SHA256", tokenizer["content_sha256"]
+    )
+    monkeypatch.setattr(pb, "_CANONICAL_TOKENIZER_VOCAB_SIZE", 32)
+    monkeypatch.setattr(pb, "_CANONICAL_FULL_KL_SELECTION", full_selection)
+    monkeypatch.setattr(
+        pb, "_CANONICAL_FULL_KL_TOKEN_IDS_TENSOR_SHA256", tensor_digest
+    )
+    monkeypatch.setattr(pb, "_CANONICAL_PPL_SELECTION", ppl_selection)
+    monkeypatch.setattr(
+        pb, "_CANONICAL_PPL_TOKEN_IDS_SHA256", payload["ppl"]["token_ids_sha256"]
+    )
+    path = root / "gold.json"
+    path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    return model, path
+
+
+class _Tokenizer:
+    def __len__(self):
+        return 32
+
+
+def _prompt_args(model: Path, path: Path, *, n=2, seqlen=3):
+    return SimpleNamespace(
+        model=str(model),
+        prompt_token_ids_json=path,
+        n_samples=n,
+        seqlen=seqlen,
+    )
+
+
+def test_canonical_release_workload_constants_are_value_closed():
+    assert pb._CANONICAL_INPUT_SEMANTIC_SHA256 == (
+        "3eedb1a879e8e9cf13a2a0f16d3fd01a0817d18de60a2dd743c9c4fc44a34680"
+    )
+    assert pb._CANONICAL_DATASETS_DISTRIBUTION == {
+        "name": "datasets", "version": "4.6.0"
+    }
+    assert pb._CANONICAL_TOKENIZER_CONTENT_SHA256 == (
+        "9f7ee7cb93b58bf30f278965547e7584b89c848e76c3adfeb92c070a88492de0"
+    )
+    assert pb._CANONICAL_FULL_KL_SELECTION["starts"] == [
+        466_956, 104_902, 1_153_556, 1_027_150,
+        936_213, 585_264, 429_895, 2_287_433,
+    ]
+    assert pb._CANONICAL_FULL_KL_TOKEN_IDS_TENSOR_SHA256 == (
+        "b3426e9bab87a1c444b04d0ce01fa9cba5ace313b91db2c3f77fc3525e732b22"
+    )
+
+
+def test_fixed_prompt_loader_attests_closed_payload_tokens_and_tokenizer(
+    tmp_path, monkeypatch
+):
+    model, path = _write_gold_payload(tmp_path, monkeypatch)
+    windows, record = pb._fixed_prompt_loader(
+        _prompt_args(model, path), _Tokenizer()
+    )
+    assert windows == [[1, 2, 3], [4, 5, 6]]
+    assert record["source"] == "producer_sealed_token_ids"
+    assert record["input_file"]["sha256"] == pb.hashlib.sha256(
+        path.read_bytes()
+    ).hexdigest()
+    assert record["prompt_token_ids_tensor_sha256"] == (
+        json.loads(path.read_text())["full_kl"]["token_ids_tensor_sha256"]
+    )
+    assert set(record["tokenizer"]["files"]) == {
+        "tokenizer.json", "tokenizer_config.json"
+    }
+
+
+def test_fixed_prompt_loader_rejects_subset_and_resigned_token_values(
+    tmp_path, monkeypatch
+):
+    model, path = _write_gold_payload(tmp_path, monkeypatch)
+    with pytest.raises(RuntimeError, match="complete sealed prompt selection"):
+        pb._fixed_prompt_loader(
+            _prompt_args(model, path, n=1), _Tokenizer()
+        )
+
+    payload = json.loads(path.read_text())
+    payload["full_kl"]["token_ids"][0][0] = 7
+    flattened = [
+        token for row in payload["full_kl"]["token_ids"] for token in row
+    ]
+    payload["full_kl"]["token_ids_tensor_sha256"] = pb.hashlib.sha256(
+        struct.pack(f"<{len(flattened)}q", *flattened)
+    ).hexdigest()
+    payload["semantic_sha256"] = pb._canonical_sha256({
+        key: value for key, value in payload.items()
+        if key != "semantic_sha256"
+    })
+    # Even if the outer self-digest were accepted, the independently pinned
+    # canonical token digest must reject the operator-created workload.
+    monkeypatch.setattr(
+        pb, "_CANONICAL_INPUT_SEMANTIC_SHA256", payload["semantic_sha256"]
+    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="token values are not canonical"):
+        pb._fixed_prompt_loader(_prompt_args(model, path), _Tokenizer())
+
+
+def test_fixed_prompt_loader_rejects_resigned_dataset_metadata(
+    tmp_path, monkeypatch
+):
+    model, path = _write_gold_payload(tmp_path, monkeypatch)
+    payload = json.loads(path.read_text())
+    payload["datasets_distribution"]["version"] = "999.0.0"
+    payload["semantic_sha256"] = pb._canonical_sha256({
+        key: value for key, value in payload.items()
+        if key != "semantic_sha256"
+    })
+    monkeypatch.setattr(
+        pb, "_CANONICAL_INPUT_SEMANTIC_SHA256", payload["semantic_sha256"]
+    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="datasets producer identity differs"):
+        pb._fixed_prompt_loader(_prompt_args(model, path), _Tokenizer())
+
+
+def test_fixed_prompt_loader_rejects_model_tokenizer_drift(tmp_path, monkeypatch):
+    model, path = _write_gold_payload(tmp_path, monkeypatch)
+    (model / "tokenizer.json").write_text('{"changed":true}\n')
+    with pytest.raises(RuntimeError, match="tokenizer file differs"):
+        pb._fixed_prompt_loader(_prompt_args(model, path), _Tokenizer())
+
+
+class _CBMethod:
+    def __init__(self, prefix: str, is_fp4: bool):
+        self.prefix = prefix
+        self.is_fp4 = is_fp4
+
+
+class _Layer:
+    pass
+
+
+class _RouteAPI:
+    @staticmethod
+    def read_route(layer):
+        return getattr(layer, "route", None)
+
+
+def _controller(*, fp4=2, fp8=1):
+    registry = {}
+    entries = {}
+    for index in range(fp4 + fp8):
+        is_fp4 = index < fp4
+        method = _CBMethod(f"layer.{index}", is_fp4)
+        layer = _Layer()
+        layer._cb_moe_persistent_b = object() if is_fp4 else None
+        if is_fp4:
+            layer._cb_moe_persistent_b_cfg = 0
+            layer._cb_bf16_sm120 = None
+            layer._cb_fused_fp4_moe_mode = ""
+        registry[index] = object()
+        entries[index] = (method, layer)
+    ops = SimpleNamespace(
+        _LAYER_REGISTRY=registry,
+        _lookup_cb_layer=lambda layer_id: entries[layer_id],
+    )
+    moe = SimpleNamespace(PrismaQuantCBMoEMethod=_CBMethod)
+    controller = pb.PersistentBArmController(
+        ops=ops,
+        moe=moe,
+        route_api=_RouteAPI,
+        expected_fp4=fp4,
+        expected_fp8=fp8,
+        expected_cfg=0,
+    )
+    return controller
+
+
+def _fp4_route(arm: str):
+    if arm == "fused":
+        return {
+            "policy": "moe_persistent_b",
+            "symbol": "cb_moe_persistent_b_prefill",
+            "tile_m": 0,
+            "contract": "fp4_group16_rtn",
+            "state": "served",
+            "reason": None,
+        }
+    return {
+        "policy": "bf16_grouped_bridge",
+        "symbol": "cb_bf16_grouped_mm_out",
+        "tile_m": 0,
+        "contract": "fp4_group16_rtn",
+        "state": "served",
+        "reason": None,
+    }
+
+
+def _fp8_route():
+    return {
+        "policy": "fp8_grouped",
+        "symbol": "cb_fused_moe_grouped",
+        "tile_m": 128,
+        "contract": "fp8_per_token_dynamic",
+        "state": "served",
+        "reason": None,
+    }
+
+
+@pytest.mark.parametrize("arm", pb.ARMS)
+def test_controller_switches_only_resolved_fp4_handles_and_proves_routes(arm):
+    controller = _controller()
+    initial = [binding.layer._cb_moe_persistent_b for binding in controller.fp4]
+    with controller.arm(arm, label=f"test:{arm}") as selector:
+        assert selector["pass"] is True
+        assert all(
+            (binding.layer._cb_moe_persistent_b is binding.persistent_handle)
+            == (arm == "fused")
+            for binding in controller.fp4
+        )
+        for binding in controller.fp4:
+            binding.layer.route = _fp4_route(arm)
+        for binding in controller.fp8:
+            binding.layer.route = _fp8_route()
+        routes = controller.attest_routes(arm, label=f"test:{arm}")
+        assert routes["pass"] is True
+        assert routes["violations"] == []
+    assert [
+        binding.layer._cb_moe_persistent_b for binding in controller.fp4
+    ] == initial
+
+
+def test_controller_route_attestation_fails_missing_or_fallback_route():
+    controller = _controller(fp4=1, fp8=1)
+    with controller.arm("fused", label="bad"):
+        controller.fp4[0].layer.route = {
+            **_fp4_route("fused"),
+            "state": "fallback",
+            "reason": "test miss",
+        }
+        # FP8 deliberately remains cleared/missing.
+        record = controller.attest_routes("fused", label="bad")
+    assert record["pass"] is False
+    assert any("state='fallback'" in item for item in record["violations"])
+    assert any("no current-request FP8 route" in item
+               for item in record["violations"])
+
+
+def test_controller_inventory_is_fail_closed():
+    controller = _controller(fp4=1, fp8=1)
+    assert controller.inventory_gate["pass"] is True
+    with pytest.raises(RuntimeError, match="inventory does not match"):
+        # Construct the same loaded registry while claiming a partial FP4 set.
+        entries = {
+            binding.layer_id: (binding.method, binding.layer)
+            for binding in (*controller.fp4, *controller.fp8)
+        }
+        pb.PersistentBArmController(
+            ops=SimpleNamespace(
+                _LAYER_REGISTRY={key: object() for key in entries},
+                _lookup_cb_layer=lambda key: entries[key],
+            ),
+            moe=SimpleNamespace(PrismaQuantCBMoEMethod=_CBMethod),
+            route_api=_RouteAPI,
+            expected_fp4=2,
+            expected_fp8=1,
+            expected_cfg=0,
+        )
+
+
+def _score(target=-1.0):
+    return pb.v5.PromptScore(
+        target_logprobs=(target,),
+        rows=(pb.v5.TopKRow(
+            token_ids=(0, 1),
+            logprobs=(pb.math.log(0.7), pb.math.log(0.3)),
+        ),),
+    )
+
+
+def _quality_pairs(*, mismatch=False):
+    pairs = []
+    for repeat in range(2):
+        for prompt in range(2):
+            block = repeat * 2 + prompt
+            scores = {"baseline": _score(), "fused": _score()}
+            if mismatch and repeat == 1 and prompt == 0:
+                scores["fused"] = _score(-1.1)
+            fp8 = {"fp8": _fp8_route()}
+            pairs.append({
+                "prompt_index": block,
+                "block_index": block,
+                "repeat_index": repeat,
+                "source_prompt_index": prompt,
+                "pair_order": list(pb.v5.paired_arm_order(repeat + prompt)),
+                "scores": scores,
+                "routes": {
+                    "baseline": {"fp8_routes": fp8},
+                    "fused": {"fp8_routes": dict(fp8)},
+                },
+            })
+    return pairs
+
+
+def test_interleaving_repeat_determinism_and_fp8_invariance_gates():
+    pairs = _quality_pairs()
+    order_gate = pb._pair_order_gate(pairs)
+    assert order_gate["pass"] is True
+    assert all(
+        counts == {"baseline/fused": 1, "fused/baseline": 1}
+        for counts in order_gate["per_source_prompt"].values()
+    )
+    assert pb._repeat_determinism_gate(
+        pairs, n_prompts=2, repeats=2
+    )["pass"] is True
+    assert pb._fp8_invariance_gate(pairs)["pass"] is True
+
+    nondeterministic = _quality_pairs(mismatch=True)
+    gate = pb._repeat_determinism_gate(
+        nondeterministic, n_prompts=2, repeats=2
+    )
+    assert gate["pass"] is False
+    assert gate["mismatches"][0]["arm"] == "fused"
+    nondeterministic[0]["routes"]["fused"]["fp8_routes"]["fp8"] = {
+        **_fp8_route(), "tile_m": 256
+    }
+    assert pb._fp8_invariance_gate(nondeterministic)["pass"] is False
+
+
+def test_aggregate_arm_balance_cannot_hide_missing_per_prompt_crossover():
+    pairs = _quality_pairs()
+    for pair in pairs:
+        # This is the retired block-index schedule. With an even prompt count,
+        # aggregate order remains 50/50 while each prompt always sees one order.
+        pair["pair_order"] = list(
+            pb.v5.paired_arm_order(pair["block_index"])
+        )
+    gate = pb._pair_order_gate(pairs)
+    assert gate["counts"] == {"baseline/fused": 2, "fused/baseline": 2}
+    assert gate["source_prompts_missing_both_orders"] == [0, 1]
+    assert gate["pass"] is False
+
+
+class _FlatLogprobs:
+    def __init__(self, rows):
+        self._rows = rows
+        self.start_indices = []
+        self.end_indices = []
+        self.token_ids = []
+        self.logprobs = []
+        self.ranks = []
+        self.decoded_tokens = []
+        for row in rows:
+            self.start_indices.append(len(self.token_ids))
+            for token, logprob in row.items():
+                self.token_ids.append(token)
+                self.logprobs.append(logprob)
+                self.ranks.append(1)
+                self.decoded_tokens.append(None)
+            self.end_indices.append(len(self.token_ids))
+
+    def __len__(self):
+        return len(self._rows)
+
+    def __getitem__(self, index):
+        return {
+            token: {"logprob": logprob}
+            for token, logprob in self._rows[index].items()
+        }
+
+
+class _PrimitiveFlatLogprobs:
+    """Exact pinned vLLM layout, including duplicate raw token ids."""
+
+    def __init__(self, rows, *, forbid_getitem=False):
+        self._rows = rows
+        self._forbid_getitem = forbid_getitem
+        self.getitem_calls = 0
+        self.start_indices = []
+        self.end_indices = []
+        self.token_ids = []
+        self.logprobs = []
+        self.ranks = []
+        self.decoded_tokens = []
+        for row in rows:
+            self.start_indices.append(len(self.token_ids))
+            for token, logprob in row:
+                self.token_ids.append(token)
+                self.logprobs.append(logprob)
+                self.ranks.append(1)
+                self.decoded_tokens.append(None)
+            self.end_indices.append(len(self.token_ids))
+
+    def __len__(self):
+        return len(self.start_indices)
+
+    def __getitem__(self, index):
+        self.getitem_calls += 1
+        if self._forbid_getitem:
+            raise AssertionError("direct scorer materialized a mapping row")
+        # This is vLLM FlatLogprobs.__getitem__ semantics: exact duplicate
+        # keys retain their original insertion slot but their last value.
+        return {
+            token: {"logprob": logprob}
+            for token, logprob in self._rows[index]
+        }
+
+
+def _primitive_output(rows, prompt_ids, *, forbid_getitem=False):
+    return SimpleNamespace(
+        prompt_token_ids=list(prompt_ids),
+        prompt_logprobs=_PrimitiveFlatLogprobs(
+            rows, forbid_getitem=forbid_getitem
+        ),
+    )
+
+
+def _legacy_compact_full_vocab_score(output, prompt_ids, vocab_size):
+    """The retired mapping-based implementation, retained only as an oracle."""
+
+    expected_ids = [int(token) for token in prompt_ids]
+    prompt_bytes = pb.struct.pack(f"<{len(expected_ids)}q", *expected_ids)
+    prompt_digest = pb.hashlib.sha256(prompt_bytes).hexdigest()
+    score_digest = pb.hashlib.sha256()
+    score_digest.update(b"gridbook.compact-full-vocab-score.v1\0")
+    score_digest.update(
+        pb.struct.pack("<II", len(expected_ids) - 1, vocab_size)
+    )
+    score_digest.update(bytes.fromhex(prompt_digest))
+    row_values = pb.array.array("f")
+    targets = []
+    row_digests = []
+    for position in range(1, len(expected_ids)):
+        entries = output.prompt_logprobs[position]
+        target = pb.v5.target_logprob(entries, expected_ids[position])
+        row = pb.v5.full_vocab_row(entries, vocab_size)
+        packed = pb.array.array("f", row.logprobs)
+        raw = packed.tobytes()
+        row_digest = pb.hashlib.sha256(raw).hexdigest()
+        row_values.extend(packed)
+        targets.append(target)
+        row_digests.append(row_digest)
+        score_digest.update(pb.struct.pack("<d", target))
+        score_digest.update(bytes.fromhex(row_digest))
+    return pb._CompactFullVocabScore(
+        target_logprobs=tuple(targets),
+        _row_values=row_values,
+        vocab_size=vocab_size,
+        prompt_token_ids_sha256=prompt_digest,
+        row_sha256=tuple(row_digests),
+        score_sha256=score_digest.hexdigest(),
+    )
+
+
+def _full_vocab_output(*, delta=0.0):
+    rows = [
+        {},
+        {0: pb.math.log(0.4), 1: pb.math.log(0.3),
+         2: pb.math.log(0.2), 3: pb.math.log(0.1)},
+        {0: pb.math.log(0.1), 1: pb.math.log(0.2),
+         2: pb.math.log(0.3) + delta, 3: pb.math.log(0.4)},
+    ]
+    return SimpleNamespace(
+        prompt_token_ids=[0, 1, 2],
+        prompt_logprobs=_FlatLogprobs(rows),
+    )
+
+
+def test_streamed_full_vocab_compaction_reuses_shared_incremental_scorer():
+    baseline = pb._compact_full_vocab_score(
+        _full_vocab_output(), [0, 1, 2], expected_vocab_size=4
+    )
+    fused = pb._compact_full_vocab_score(
+        _full_vocab_output(), [0, 1, 2], expected_vocab_size=4
+    )
+    assert len(baseline._row_values) == 8
+    assert baseline.digest_record()["row_storage_bytes"] == 32
+    assert baseline.score_sha256 == fused.score_sha256
+
+    accumulator = pb.v5._new_quality_accumulator(
+        kl_mode=pb.v5.KL_FULL_VOCAB
+    )
+    pb.v5._accumulate_quality_pair(accumulator, {
+        "prompt_index": 0,
+        "pair_order": ["baseline", "fused"],
+        "scores": {"baseline": baseline, "fused": fused},
+    })
+    quality = pb.v5._finish_quality_accumulator(accumulator)
+    assert quality["kl_mode"] == pb.v5.KL_FULL_VOCAB
+    assert quality["delta"]["kl_baseline_to_fused"]["mean"] == 0.0
+    assert quality["arms"]["baseline"]["tokens_scored"] == 2
+
+
+def test_direct_flat_compaction_is_legacy_digest_identical_without_getitem():
+    prompt_ids = [0, 1, 2]
+    rows = [
+        [],
+        [
+            (1, -8.0),
+            (3, pb.math.log(0.1)),
+            (0, pb.math.log(0.4)),
+            (1, pb.math.log(0.3)),
+            (2, pb.math.log(0.2)),
+        ],
+        [
+            (2, -9.0),
+            (1, pb.math.log(0.2)),
+            (3, pb.math.log(0.4)),
+            (2, pb.math.log(0.3)),
+            (0, pb.math.log(0.1)),
+        ],
+    ]
+    legacy_output = _primitive_output(rows, prompt_ids)
+    expected = _legacy_compact_full_vocab_score(
+        legacy_output, prompt_ids, 4
+    )
+    assert legacy_output.prompt_logprobs.getitem_calls == 2
+
+    direct_output = _primitive_output(
+        rows, prompt_ids, forbid_getitem=True
+    )
+    observed = pb._compact_full_vocab_score(
+        direct_output, prompt_ids, expected_vocab_size=4
+    )
+    assert direct_output.prompt_logprobs.getitem_calls == 0
+    assert observed.target_logprobs == expected.target_logprobs
+    assert observed._row_values.tobytes() == expected._row_values.tobytes()
+    assert observed.row_sha256 == expected.row_sha256
+    assert observed.prompt_token_ids_sha256 == expected.prompt_token_ids_sha256
+    assert observed.score_sha256 == expected.score_sha256
+    assert tuple(observed.rows) == tuple(expected.rows)
+
+
+def test_direct_flat_compaction_is_order_independent_and_last_value_wins():
+    prompt_ids = [0, 1]
+    canonical = [
+        [],
+        [
+            (1, -20.0),
+            (0, pb.math.log(0.6)),
+            (1, pb.math.log(0.3)),
+            (2, pb.math.log(0.1)),
+        ],
+    ]
+    shuffled = [
+        [],
+        [
+            (1, -20.0),
+            (2, pb.math.log(0.1)),
+            (1, pb.math.log(0.3)),
+            (0, pb.math.log(0.6)),
+        ],
+    ]
+    scores = [
+        pb._compact_full_vocab_score(
+            _primitive_output(rows, prompt_ids, forbid_getitem=True),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+        for rows in (canonical, shuffled)
+    ]
+    assert scores[0].target_logprobs == (pb.math.log(0.3),)
+    assert scores[0]._row_values.tobytes() == scores[1]._row_values.tobytes()
+    assert scores[0].row_sha256 == scores[1].row_sha256
+    assert scores[0].score_sha256 == scores[1].score_sha256
+
+
+def test_direct_flat_compaction_duplicate_nonfinite_uses_retained_value_only():
+    prompt_ids = [0, 1]
+    overwritten = [
+        [],
+        [
+            (1, pb.math.log(0.5)),
+            (0, float("nan")),
+            (0, pb.math.log(0.3)),
+            (1, pb.math.log(0.5)),
+            (2, pb.math.log(0.2)),
+        ],
+    ]
+    direct = pb._compact_full_vocab_score(
+        _primitive_output(overwritten, prompt_ids, forbid_getitem=True),
+        prompt_ids,
+        expected_vocab_size=3,
+    )
+    legacy = _legacy_compact_full_vocab_score(
+        _primitive_output(overwritten, prompt_ids), prompt_ids, 3
+    )
+    assert direct._row_values.tobytes() == legacy._row_values.tobytes()
+    assert direct.score_sha256 == legacy.score_sha256
+
+    retained_nonfinite = [
+        [],
+        [
+            (1, pb.math.log(0.5)),
+            (0, pb.math.log(0.3)),
+            (0, float("nan")),
+            (1, pb.math.log(0.5)),
+            (2, pb.math.log(0.2)),
+        ],
+    ]
+    with pytest.raises(ValueError, match="non-finite"):
+        pb._compact_full_vocab_score(
+            _primitive_output(
+                retained_nonfinite, prompt_ids, forbid_getitem=True
+            ),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+
+
+@pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), -float("inf")])
+def test_direct_flat_compaction_rejects_nonfinite_target_first(nonfinite):
+    prompt_ids = [0, 1]
+    rows = [
+        [],
+        [(1, nonfinite), (0, -1.0), (1, nonfinite), (99, -2.0)],
+    ]
+    with pytest.raises(ValueError, match="non-finite"):
+        pb._compact_full_vocab_score(
+            _primitive_output(rows, prompt_ids, forbid_getitem=True),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+
+
+def test_direct_flat_compaction_preserves_row_failure_order():
+    prompt_ids = [0, 1]
+    nonfinite_before_oor = [
+        [],
+        [(1, -0.5), (0, float("nan")), (99, -1.0), (2, -2.0)],
+    ]
+    with pytest.raises(ValueError, match="non-finite"):
+        pb._compact_full_vocab_score(
+            _primitive_output(
+                nonfinite_before_oor, prompt_ids, forbid_getitem=True
+            ),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+    oor_before_nonfinite = [
+        [],
+        [(1, -0.5), (99, -1.0), (0, float("nan")), (2, -2.0)],
+    ]
+    with pytest.raises(RuntimeError, match="out-of-range token id 99"):
+        pb._compact_full_vocab_score(
+            _primitive_output(
+                oor_before_nonfinite, prompt_ids, forbid_getitem=True
+            ),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+
+
+def test_direct_flat_compaction_target_missing_precedes_cardinality_error():
+    prompt_ids = [0, 2]
+    rows = [[], [(0, -0.5), (1, -1.0), (1, -2.0)]]
+    with pytest.raises(KeyError) as exc:
+        pb._compact_full_vocab_score(
+            _primitive_output(rows, prompt_ids, forbid_getitem=True),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+    assert exc.value.args == (2,)
+
+
+def test_direct_flat_compaction_cardinality_out_of_range_and_negative_rules():
+    prompt_ids = [0, 1]
+    missing = [[], [(1, -0.5), (0, -1.0), (1, -0.5)]]
+    with pytest.raises(RuntimeError, match="cardinality mismatch"):
+        pb._compact_full_vocab_score(
+            _primitive_output(missing, prompt_ids, forbid_getitem=True),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+
+    out_of_range = [
+        [], [(1, -0.5), (0, -1.0), (3, -2.0), (2, -3.0)]
+    ]
+    with pytest.raises(RuntimeError, match="out-of-range token id 3"):
+        pb._compact_full_vocab_score(
+            _primitive_output(
+                out_of_range, prompt_ids, forbid_getitem=True
+            ),
+            prompt_ids,
+            expected_vocab_size=3,
+        )
+
+    with_negative = [
+        [],
+        [(-7, float("nan")), (1, -0.5), (2, -2.0), (0, -1.0)],
+    ]
+    direct = pb._compact_full_vocab_score(
+        _primitive_output(with_negative, prompt_ids, forbid_getitem=True),
+        prompt_ids,
+        expected_vocab_size=3,
+    )
+    legacy = _legacy_compact_full_vocab_score(
+        _primitive_output(with_negative, prompt_ids), prompt_ids, 3
+    )
+    assert direct.score_sha256 == legacy.score_sha256
+
+
+def test_direct_flat_compaction_preserves_float32_row_bytes():
+    prompt_ids = [0, 1]
+    rows = [
+        [],
+        [
+            (1, 1.0000000596046448),
+            (3, -0.0),
+            (2, 1.0e-45),
+            (0, -87.3365447505531),
+            (1, 1.0000000596046448),
+        ],
+    ]
+    direct = pb._compact_full_vocab_score(
+        _primitive_output(rows, prompt_ids, forbid_getitem=True),
+        prompt_ids,
+        expected_vocab_size=4,
+    )
+    legacy = _legacy_compact_full_vocab_score(
+        _primitive_output(rows, prompt_ids), prompt_ids, 4
+    )
+    assert direct._row_values.tobytes() == legacy._row_values.tobytes()
+    assert direct.row_sha256 == legacy.row_sha256
+    assert direct.score_sha256 == legacy.score_sha256
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda flat: flat.logprobs.pop(), "different lengths"),
+        (lambda flat: flat.end_indices.pop(), "span count"),
+        (lambda flat: flat.start_indices.__setitem__(1, 1), "not contiguous"),
+        (lambda flat: flat.end_indices.__setitem__(1, 999), "out of bounds"),
+        (lambda flat: flat.end_indices.__setitem__(0, 1), "position zero"),
+    ],
+)
+def test_direct_flat_compaction_rejects_malformed_primitive_layout(
+    mutation, message
+):
+    prompt_ids = [0, 1]
+    output = _primitive_output(
+        [[], [(1, -0.5), (0, -1.0), (2, -2.0)]],
+        prompt_ids,
+        forbid_getitem=True,
+    )
+    mutation(output.prompt_logprobs)
+    with pytest.raises(RuntimeError, match=message):
+        pb._compact_full_vocab_score(
+            output, prompt_ids, expected_vocab_size=3
+        )
+
+
+def test_full_vocab_repeat_gate_uses_score_and_row_digests():
+    score = pb._compact_full_vocab_score(
+        _full_vocab_output(), [0, 1, 2], expected_vocab_size=4
+    ).digest_record()
+    pairs = []
+    for repeat in range(2):
+        pairs.append({
+            "source_prompt_index": 0,
+            "repeat_index": repeat,
+            "score_digests": {"baseline": score, "fused": score},
+        })
+    assert pb._full_vocab_repeat_determinism_gate(
+        pairs, n_prompts=1, repeats=2
+    )["pass"] is True
+    pairs[1]["score_digests"] = {
+        "baseline": score,
+        "fused": {**score, "score_sha256": "0" * 64},
+    }
+    assert pb._full_vocab_repeat_determinism_gate(
+        pairs, n_prompts=1, repeats=2
+    )["pass"] is False
+
+
+def test_promotion_summary_uses_full_workload_targets_and_exact_profile_kl():
+    coarse = pb.v5._quality_summary(
+        _quality_pairs(), kl_mode=pb.v5.KL_COARSE_TOPK
+    )
+    exact = pb.v5._quality_summary(
+        _quality_pairs(), kl_mode=pb.v5.KL_FULL_VOCAB
+    )
+    combined = pb._promotion_quality_summary(
+        coarse, exact, full_vocab_profile={"seqlen": 64}
+    )
+    assert combined["arms"] == coarse["arms"]
+    assert combined["delta"]["mean_nll_fused_minus_baseline"] == (
+        coarse["delta"]["mean_nll_fused_minus_baseline"]
+    )
+    assert combined["delta"]["kl_baseline_to_fused"] == (
+        exact["delta"]["kl_baseline_to_fused"]
+    )
+    assert combined["kl_mode"] == pb.v5.KL_FULL_VOCAB
+
+
+def test_model_contract_gate_is_exact_dsv4():
+    config = {
+        "architectures": ["DeepseekV4ForCausalLM"],
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 43,
+        "hidden_size": 4096,
+        "moe_intermediate_size": 2048,
+        "n_routed_experts": 256,
+        "vocab_size": 129280,
+    }
+    args = SimpleNamespace(
+        expected_architecture="DeepseekV4ForCausalLM",
+        expected_model_type="deepseek_v4",
+        expected_hidden_layers=43,
+        expected_hidden_size=4096,
+        expected_moe_intermediate_size=2048,
+        expected_routed_experts=256,
+        expected_vocab_size=129280,
+    )
+    assert pb._model_contract_gate(config, args)["pass"] is True
+    config["num_hidden_layers"] = 42
+    gate = pb._model_contract_gate(config, args)
+    assert gate["pass"] is False
+    assert gate["checks"]["num_hidden_layers"] is False
+
+
+def test_harness_reuses_v5_scoring_and_threshold_implementation():
+    source = inspect.getsource(pb.run)
+    assert "v5._quality_summary" in source
+    assert "v5._configured_gates" in source
+    assert "validation_common.score_teacher" in source
+    assert "prefill_threshold=moe.MOE_PREFILL_M_THRESHOLD" in source
+    assert pb.ARMS == ("baseline", "fused")
+    assert pb.ARM_LABELS["baseline"] == "expand_plus_grouped_bf16_bridge"
+    assert pb.ARM_LABELS["fused"] == "persistent_b_decode_in_mainloop"
+
+
+def test_report_and_runtime_share_exported_moe_prefill_threshold():
+    """The CPU gate catches a report-only name drift before a model run."""
+    moe_source = (
+        SCRIPT.parents[1] / "gridbook" / "moe.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(moe_source)
+    definitions = [
+        node for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name)
+            and target.id == "MOE_PREFILL_M_THRESHOLD"
+            for target in node.targets
+        )
+    ]
+    assert len(definitions) == 1
+    assert ast.literal_eval(definitions[0].value) == 16
+    assert any(
+        isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Name)
+        and node.left.id == "num_tokens"
+        and len(node.ops) == 1
+        and isinstance(node.ops[0], ast.LtE)
+        and len(node.comparators) == 1
+        and isinstance(node.comparators[0], ast.Name)
+        and node.comparators[0].id == "MOE_PREFILL_M_THRESHOLD"
+        for node in ast.walk(tree)
+    )
+    assert (
+        "prefill_threshold=moe.MOE_PREFILL_M_THRESHOLD"
+        in inspect.getsource(pb.run)
+    )
+
+
+def test_persistent_b_provenance_names_only_existing_hashed_sources(tmp_path):
+    package = tmp_path / "gridbook"
+    csrc = package / "csrc"
+    csrc.mkdir(parents=True)
+    lane = package / "moe_persistent_b_lane.py"
+    kernel = csrc / "cb_moe_persistent_b.cu"
+    lane.write_text("# lane\n", encoding="utf-8")
+    kernel.write_text("// kernel\n", encoding="utf-8")
+    runtime = {
+        "gridbook": {"package_root": str(package)},
+        "source_files": {},
+        "source_sha256": {},
+    }
+    pb._augment_persistent_b_provenance(runtime)
+    assert set(runtime["source_files"]) == {
+        "moe_persistent_b_lane.py", "cb_moe_persistent_b.cu"
+    }
+    assert set(runtime["source_sha256"]) == set(runtime["source_files"])
+    for label, record in runtime["source_files"].items():
+        path = Path(record["path"])
+        assert path.is_file(), label
+        assert record["sha256"] == pb.hashlib.sha256(path.read_bytes()).hexdigest()
+        assert runtime["source_sha256"][label] == record["sha256"]
+
+
+def test_shared_candidate_loader_forwards_explicit_kv_cache_dtype():
+    calls = []
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    class FakeSampling:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    bootstrap = SimpleNamespace(
+        candidate_load_revision=None,
+        quality_logprobs=32,
+        llm_class=FakeLLM,
+        sampling_params_class=FakeSampling,
+    )
+    args = SimpleNamespace(
+        model="candidate",
+        trust_remote_code=True,
+        dtype="bfloat16",
+        gpu_memory_utilization=0.9,
+        seqlen=64,
+        enable_chunked_prefill=None,
+        seed=0,
+        quantization="gridbook",
+        tokenizer_mode="deepseek_v4",
+        kv_cache_memory_bytes=268435456,
+        kv_cache_dtype="fp8",
+        max_num_batched_tokens=256,
+    )
+    pb.validation_common.load_candidate_engine(
+        bootstrap,
+        args,
+        probe=SimpleNamespace(restore=lambda: None),
+    )
+    assert calls[0]["kv_cache_dtype"] == "fp8"
+
+
+def test_parser_requires_repeats_balanced_arms_and_explicit_measurement(
+    tmp_path, monkeypatch
+):
+    model, inputs = _write_gold_payload(tmp_path, monkeypatch)
+    base = [
+        "--model", str(model),
+        "--prompt-token-ids-json", str(inputs),
+        "--output", str(tmp_path / "out.json"),
+    ]
+    args = pb.parse_args([*base, "--measurement-only"])
+    assert args.quality_repeats == 2
+    assert args.expected_persistent_b_layers == 35
+    assert args.expected_fp8_cb_moe_layers == 8
+    assert args.tokenizer_mode == "deepseek_v4"
+    assert args.kv_cache_memory_bytes == 268435456
+    assert args.kv_cache_dtype == "fp8"
+    assert args.full_vocab_seqlen == 64
+    assert args.teacher_full_vocab_kl is False
+    with pytest.raises(SystemExit):
+        pb.parse_args([*base, "--measurement-only", "--quality-repeats", "1"])
+    with pytest.raises(SystemExit):
+        pb.parse_args([*base, "--measurement-only", "--timing-repeats", "1"])
+    with pytest.raises(SystemExit):
+        pb.parse_args(base)
+    with pytest.raises(SystemExit):
+        pb.parse_args([*base, "--measurement-only", "--kv-cache-dtype", "auto"])
+    args.kv_cache_dtype = "auto"
+    with pytest.raises(RuntimeError, match="requires kv_cache_dtype='fp8'"):
+        pb.run(args)
+
+
+def test_parser_allows_pairwise_full_vocab_without_impossible_teacher(
+    tmp_path, monkeypatch
+):
+    model, inputs = _write_gold_payload(tmp_path, monkeypatch)
+    args = pb.parse_args([
+        "--model", str(model),
+        "--prompt-token-ids-json", str(inputs),
+        "--output", str(tmp_path / "out.json"),
+        "--full-vocab-kl",
+        "--max-mean-kl", "0.0001",
+        "--max-mean-nll-regression", "0.0001",
+        "--max-ppl-relative-regression", "0.0001",
+    ])
+    assert args.full_vocab_kl is True
+    assert args.teacher_full_vocab_kl is True
+    assert args.teacher_model is None
+
+
+def test_shared_bootstrap_extension_is_backward_compatible_and_selectable():
+    signature = inspect.signature(pb.validation_common.prepare_validation)
+    assert signature.parameters["extension_loader"].default == (
+        "get_fused_fp4_ext"
+    )
+    assert signature.parameters["required_symbol"].default is None
+    assert signature.parameters["prompt_loader"].default is None


### PR DESCRIPTION
## What changed

- adds GridBook runtime-contract v4 and the explicit DeepSeek-V4 DSpark construction-to-physical namespace bridge
- routes mixed native MXFP4/FP8 draft weights through the existing per-unit GridBook machinery without patching vLLM
- makes the FP4-CB GEMV v2 release-shape path bit-exact with the inherited default at K=2048/4096 while retaining its measured speedup
- adds fail-closed padding-sentinel handling, grouped-BMM refusal, DSpark loaders, full-vocabulary GEMV/persistent-B quality harnesses, and packaging tests
- hardens the tag release workflow with master-ancestry and end-to-end wheel-digest checks
- bumps GridBook to 0.8.6 and documents the exact qualified EUGR/vLLM/FlashInfer runtime

## Why

DSV4Flash needs a clean, unforked vLLM serving lane for its CB target plus K12 DSpark draft. The original v2 GEMV schedule reassociated the inherited reduction and failed the model quality gate. The new virtual-warp specialization preserves the inherited arithmetic order at the release shapes, closing that quality defect while keeping the bandwidth win.

## Validation

- GPU operator matrix: 30/30, k12/k16/k18 × K2048/K4096, both decode contracts, all dictionary residencies, CUDA graph replay
- direct-op benchmark: 1.8175–1.9977× over inherited, bit-exact
- same-process full-vocabulary model A/B: zero KL/NLL/PPL/logprob delta over 240 scored positions
- source CPU suite from clean commit: 1,135 passed, 143 skipped
- focused changed-area suite: 237 passed, 16 skipped
- clean sdist/wheel: check_dist PASS (0 warnings), twine strict PASS, non-editable installed-wheel check PASS

## Open hardware gates

The release documentation intentionally leaves final clean-wheel 256K serving, concurrency, long-prefill, soak, memory, and matched target-only/K12 throughput gates open. The tag will not be pushed until the exact CI wheel passes those gates.
